### PR TITLE
Fix  #199 missing static transforms in localization example

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,6 +58,7 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) 
     ros-${DIST}-gazebo-ros \
     ros-${DIST}-gazebo-plugins \
     ros-${DIST}-hector-gazebo-plugins \
+    ros-${DIST}-joint-state-publisher \
     ros-${DIST}-joy \
     ros-${DIST}-joy-teleop \
     ros-${DIST}-key-teleop \

--- a/wamv_gazebo/launch/localization_example.launch
+++ b/wamv_gazebo/launch/localization_example.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!-- Example of ROS localization using the example wamv with sensors -->
 <launch>
-  <!-- Publishes static joint static transforms (lidar, cameras, etc) to /tf -->
+  <!-- Publishes static joint transforms (lidar, cameras, etc) to /tf -->
   <node ns="wamv" pkg="robot_state_publisher" type="robot_state_publisher" name="rob_st_pub">
     <param name="tf_prefix" value="wamv" />
   </node>

--- a/wamv_gazebo/launch/localization_example.launch
+++ b/wamv_gazebo/launch/localization_example.launch
@@ -1,9 +1,14 @@
 <?xml version="1.0"?>
 <!-- Example of ROS localization using the example wamv with sensors -->
 <launch>
-  <!-- Publishes static transforms (gps, imu, cameras, etc) to /tf -->
+  <!-- Publishes static joint static transforms (lidar, cameras, etc) to /tf -->
   <node ns="wamv" pkg="robot_state_publisher" type="robot_state_publisher" name="rob_st_pub">
     <param name="tf_prefix" value="wamv" />
+  </node>
+
+  <!-- Publishes revolute joint static transforms (gps and imu) to /tf -->
+  <node ns="wamv" pkg="joint_state_publisher" type="joint_state_publisher" name="joint_state_publisher">
+    <param name="gui" value="false" />
   </node>
 
   <!-- Kalman filter fusing imu and gps into combined odometry/tf -->


### PR DESCRIPTION
As seen in  3e44023d306776374 (or the old bitbucket [url](https://bitbucket.org/osrf/vrx/pull-requests/216/fix-issue-188/diff)), the GPS and IMU links were changed from "fixed joint" to "revolute joint" in the WAMV URDF. This leaves the robot localization example from wamv_gazebo (run via `roslaunch vrx_gazebo vrx.launch` and then `roslaunch wamv_gazebo localization_example.launch`) broken.

A simple fix is to add a joint state publisher to publish the transforms of the "revolute joints". `joint-state-publisher` can be installed via `sudo apt install ros-melodic-joint-state-publisher`.

You can verify this works by monitoring the

 `rostopic hz /wamv/robot_localization/odometry/filtered` 

before and after the fix. Before the fix, robot localization node will give warnings complaining of missing imu and gps link resulting in no filtered odometry messages being published. After applying this fix, those warnings go away and a roughly 60Hz update rate for the filtered odometry is achieved.
