### PR TITLE
Automatic release of Docker images

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -2,7 +2,7 @@ name: Release to DockerHub
 on:
   push:
     tags:
-      - v*  # Launch DockerHub push on v* tags (e.g.: v1.2.1)
+      - 'v*'  # Launch DockerHub push on v* tags (e.g.: v1.2.1)
   
 jobs:
   release-docker-image-nonvidia-bionic-melodic-gazebo9:

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Create a new VRX Docker image
         run: |
+          sudo apt update;
+          sudo apt-get install -y docker;
           cd docker;
           ls;
           bash +xe ./build.bash ${{env.build_docker_flags}} ..;

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -19,13 +19,24 @@ jobs:
         if: ${{ success() }}
         run: |
           sudo apt update;
-          sudo apt-get install -y docker
+          sudo apt-get install -y apt-transport-https \
+                                  ca-certificates \
+                                  curl \
+                                  gnupg-agent \
+                                  software-properties-common;
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+          sudo add-apt-repository \
+            "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+            $(lsb_release -cs) \
+            stable";
+          sudo apt-get update;
+          sudo apt-get install docker-ce docker-ce-cli containerd.io;
 
       - name: Run build script
         shell: bash
         if: ${{ success() }}
         run: |
-          ls;
+          ls -a;
           docker/build.bash .
 
       - name: Tag image

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -1,8 +1,9 @@
 name: Release to DockerHub
-on:
-  push:
-    tags:
-      - v*  # Launch DockerHub push on v* tags (e.g.: v1.2.1)
+# on:
+#   push:
+#     tags:
+#       - v*  # Launch DockerHub push on v* tags (e.g.: v1.2.1)
+on: [pull-request]
   
 jobs:
   release-docker-image-nonvidia-bionic-melodic-gazebo9:

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -37,8 +37,5 @@ jobs:
       - name: Push to docker
         if: ${{ success() }}
         uses: actions-hub/docker@master
-        env:
-          NAME: ${{ matrix.image_name }}:current
-          TAG: ${{ env.registry }}:current
         with:
-          args: push ${IMAGE_TAG}
+          args: push vrx:current

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -28,6 +28,10 @@ jobs:
           docker/build.bash .
           docker image list;
 
+      - name: Tag image
+        if: ${{ success() }}
+        run: docker tag ${{ matrix.image_name }}:latest ${{ env.registry }}:current
+
       - name: Login to docker hub
         if: ${{ success() }}
         uses: actions-hub/docker/login@master
@@ -40,6 +44,6 @@ jobs:
         uses: actions-hub/docker@master
         env:
           NAME: ${{ matrix.image_name }}
-          TAG: ${{ env.registry }}:${{ matrix.image_name }}:latest
+          TAG: ${{ env.registry }}:current
         with:
           args: push ${IMAGE_TAG}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -34,11 +34,4 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Push to docker
-        if: ${{ success() }}
-        uses: actions-hub/docker@master
-        env:
-          NAME: ${{ matrix.image_name }}
-          TAG: ${{ env.registry }}:current
-        with:
-          args: push ${IMAGE_TAG}
+      

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ success() }}
         uses: actions-hub/docker@master
         env:
-          NAME: ${{ matrix.image_name }}
-          TAG: current
+          NAME: ${{ matrix.image_name }}:current
+          TAG: ${{ env.registry }}:current
         with:
-          args: push vrx:current
+          args: push ${IMAGE_TAG}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -14,9 +14,9 @@ jobs:
       - name: Summary
         run: |
           echo "Pushing new image to DockerHub:";
-          echo "  " ${{ env.registry }}:${{env.dockerhub_tag_prefix}}v${{env.tag}};
+          echo "  " ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}};
           echo "Updating existing image in DockerHub:";
-          echo "  " ${{ env.registry }}:${{env.dockerhub_tag_prefix}}current;
+          echo "  " ${{env.registry}}:${{env.dockerhub_tag_prefix}}current;
 
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -26,12 +26,12 @@ jobs:
           sudo apt update;
           sudo apt-get install -y docker;
 
-      - name: Createa a new VRX Docker image
+      - name: Create a new VRX Docker image
         shell: bash
         run: docker/build.bash ${{env.build_docker_flags}} .;
 
       #- name: Tag versioned image
-      #  run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}v${{env.tag}};
+      #  run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}};
 
       - name: Tag current image
         run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}current;
@@ -42,12 +42,12 @@ jobs:
           DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
 
-      - name: Push versioned image to DockerHub
-        uses: actions-hub/docker@master
-        env:
-          TAG: ${{env.registry}}:${{env.dockerhub_tag_prefix}}v${{env.tag}}
-        with:
-          args: push ${IMAGE_TAG}
+      #- name: Push versioned image to DockerHub
+      #  uses: actions-hub/docker@master
+      #  env:
+      #    TAG: ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}}
+      #  with:
+      #    args: push ${IMAGE_TAG}
 
       - name: Push current image to DockerHub
         uses: actions-hub/docker@master
@@ -59,7 +59,7 @@ jobs:
   build-docker-image-nvidia-bionic-melodic-gazebo9:
     runs-on: ubuntu-latest
     env:
-      image_name: vrx
+      image_name: vrx_nvidia
       registry: osrf/vrx
       tag: ${GITHUB_REF#refs/tags/}
       dockerhub_tag_prefix: nvidia_
@@ -68,9 +68,9 @@ jobs:
       - name: Summary
         run: |
           echo "Pushing new image to DockerHub:";
-          echo "  " ${{ env.registry }}:${{env.dockerhub_tag_prefix}}v${{env.tag}};
+          echo "  " ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}};
           echo "Updating existing image in DockerHub:";
-          echo "  " ${{ env.registry }}:${{env.dockerhub_tag_prefix}}current;
+          echo "  " ${{env.registry}}:${{env.dockerhub_tag_prefix}}current;
 
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -80,12 +80,12 @@ jobs:
           sudo apt update;
           sudo apt-get install -y docker;
 
-      - name: Createa a new VRX Docker image
+      - name: Create a new VRX Docker image
         shell: bash
         run: docker/build.bash ${{env.build_docker_flags}} .;
 
       #- name: Tag versioned image
-      #  run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}v${{env.tag}};
+      #  run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}};
 
       - name: Tag current image
         run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}current;
@@ -96,12 +96,12 @@ jobs:
           DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
 
-      - name: Push versioned image to DockerHub
-        uses: actions-hub/docker@master
-        env:
-          TAG: ${{env.registry}}:${{env.dockerhub_tag_prefix}}v${{env.tag}}
-        with:
-          args: push ${IMAGE_TAG}
+      # - name: Push versioned image to DockerHub
+      #   uses: actions-hub/docker@master
+      #   env:
+      #     TAG: ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}}
+      #   with:
+      #     args: push ${IMAGE_TAG}
 
       - name: Push current image to DockerHub
         uses: actions-hub/docker@master

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install base dependencies
+      - name: Install Docker
         if: ${{ success() }}
         run: |
           sudo apt update;
@@ -37,11 +37,7 @@ jobs:
         if: ${{ success() }}
         run: |
           ls -a;
-          sudo docker/build.bash .
-
-      - name: Tag image
-        if: ${{ success() }}
-        run: sudo docker tag ${{ matrix.image_name }}:current ${{ env.registry }}:current
+          sudo docker/build.bash . -t ${{ matrix.image_name }}:current
 
       - name: Login to docker hub
         if: ${{ success() }}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -2,7 +2,7 @@ name: Release to DockerHub
 on: [push]
   
 jobs:
-  build_docker_image_nonvidia_bionic_melodic_gazebo9):
+  build-docker-image-nonvidia-bionic-melodic-gazebo9):
     runs-on: ubuntu-latest
     env:
       image_name: vrx
@@ -56,7 +56,7 @@ jobs:
         with:
           args: push ${IMAGE_TAG}
 
-  build_docker_image_nvidia_bionic_melodic_gazebo9):
+  build-docker-image-nvidia-bionic-melodic-gazebo9):
     runs-on: ubuntu-latest
     env:
       image_name: vrx

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       image_name: vrx
-      registry: osrf/${{image_name}}
+      registry: osrf/${{env.image_name}}
       tag: ${GITHUB_REF#refs/tags/}
     steps:
       - name: Summary
@@ -29,10 +29,10 @@ jobs:
         run: docker/build.bash .;
 
       - name: Tag versioned image
-        run: docker tag ${{image_name}}:latest ${{env.registry}}:${{env.tag}};
+        run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.tag}};
 
       - name: Tag current image
-        run: docker tag ${{image_name}}:latest ${{env.registry}}:current;
+        run: docker tag ${{env.image_name}}:latest ${{env.registry}}:current;
 
       - name: Login to docker hub
         uses: actions-hub/docker/login@master

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -5,6 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       registry: osrf/vrx
+      tag: ${GITHUB_REF#refs/tags/}
     strategy:
       matrix:
         image_name: ['vrx']
@@ -23,6 +24,7 @@ jobs:
         if: ${{ success() }}
         run: |
           ls -a;
+          echo ${{ env.tag }}
           docker/build.bash . -t ${{ matrix.image_name }}:current
 
       - name: Login to docker hub

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -2,19 +2,21 @@ name: Release to DockerHub
 on: [push]
   
 jobs:
-  build_docker_image:
+  build_docker_image without Nvidia support (Ubuntu Bionic / ROS Melodic / Gazebo 9):
     runs-on: ubuntu-latest
     env:
       image_name: vrx
       registry: osrf/vrx
       tag: ${GITHUB_REF#refs/tags/}
+      dockerhub_tag_prefix:
+      build_docker_flags:
     steps:
       - name: Summary
         run: |
           echo "Pushing new image to DockerHub:";
-          echo "  " ${{ env.registry }}:${{env.tag}};
+          echo "  " ${{ env.registry }}:${{dockerhub_tag_prefix}}v${{env.tag}};
           echo "Updating existing image in DockerHub:";
-          echo "  " ${{ env.registry }}:current;
+          echo "  " ${{ env.registry }}:${{dockerhub_tag_prefix}}current;
 
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -26,13 +28,13 @@ jobs:
 
       - name: Createa a new VRX Docker image
         shell: bash
-        run: docker/build.bash .;
+        run: docker/build.bash ${{build_docker_flags}} .;
 
-      - name: Tag versioned image
-        run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.tag}};
+      #- name: Tag versioned image
+      #  run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{dockerhub_tag_prefix}}v${{env.tag}};
 
       - name: Tag current image
-        run: docker tag ${{env.image_name}}:latest ${{env.registry}}:current;
+        run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{dockerhub_tag_prefix}}current;
 
       - name: Login to docker hub
         uses: actions-hub/docker/login@master
@@ -43,13 +45,67 @@ jobs:
       - name: Push versioned image to DockerHub
         uses: actions-hub/docker@master
         env:
-          TAG: ${{ env.registry }}:${{env.tag}}
+          TAG: ${{env.registry}}:${{dockerhub_tag_prefix}}v${{env.tag}}
         with:
           args: push ${IMAGE_TAG}
 
       - name: Push current image to DockerHub
         uses: actions-hub/docker@master
         env:
-          TAG: ${{ env.registry }}:current
+          TAG: ${{env.registry}}:${{dockerhub_tag_prefix}}current
+        with:
+          args: push ${IMAGE_TAG}
+
+  build_docker_image with Nvidia support (Ubuntu Bionic / ROS Melodic / Gazebo 9):
+    runs-on: ubuntu-latest
+    env:
+      image_name: vrx
+      registry: osrf/vrx
+      tag: ${GITHUB_REF#refs/tags/}
+      dockerhub_tag_prefix: nvidia_
+      build_docker_flags: -n
+    steps:
+      - name: Summary
+        run: |
+          echo "Pushing new image to DockerHub:";
+          echo "  " ${{ env.registry }}:${{dockerhub_tag_prefix}}v${{env.tag}};
+          echo "Updating existing image in DockerHub:";
+          echo "  " ${{ env.registry }}:${{dockerhub_tag_prefix}}current;
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install Docker
+        run: |
+          sudo apt update;
+          sudo apt-get install -y docker;
+
+      - name: Createa a new VRX Docker image
+        shell: bash
+        run: docker/build.bash ${{build_docker_flags}} .;
+
+      #- name: Tag versioned image
+      #  run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{dockerhub_tag_prefix}}v${{env.tag}};
+
+      - name: Tag current image
+        run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{dockerhub_tag_prefix}}current;
+
+      - name: Login to docker hub
+        uses: actions-hub/docker/login@master
+        env:
+          DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
+          DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+
+      - name: Push versioned image to DockerHub
+        uses: actions-hub/docker@master
+        env:
+          TAG: ${{env.registry}}:${{dockerhub_tag_prefix}}v${{env.tag}}
+        with:
+          args: push ${IMAGE_TAG}
+
+      - name: Push current image to DockerHub
+        uses: actions-hub/docker@master
+        env:
+          TAG: ${{env.registry}}:${{dockerhub_tag_prefix}}current
         with:
           args: push ${IMAGE_TAG}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -39,6 +39,6 @@ jobs:
         uses: actions-hub/docker@master
         env:
           NAME: ${{ matrix.image_name }}
-          TAG: ${{ env.registry }}:current
+          TAG: current
         with:
           args: push vrx:current

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -1,8 +1,5 @@
-name: Relase to DockerHub
-on:
-  push:
-    tags:
-      - '**'  # Trigger Dockerhub push on all tags
+name: Release to DockerHub
+on: [pull_request]
 jobs:
   build_docker_image:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -1,9 +1,8 @@
 name: Release to DockerHub
-# on:
-#   push:
-#     tags:
-#       - v*  # Launch DockerHub push on v* tags (e.g.: v1.2.1)
-on: [push]
+on:
+  push:
+    tags:
+      - v*  # Launch DockerHub push on v* tags (e.g.: v1.2.1)
   
 jobs:
   release-docker-image-nonvidia-bionic-melodic-gazebo9:

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -41,4 +41,4 @@ jobs:
           NAME: ${{ matrix.image_name }}
           TAG: ${{ env.registry }}:current
         with:
-          args: push docker.pkg.github.com/osrf/vrx/vrx:current
+          args: push vrx:current

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -3,7 +3,7 @@ name: Release to DockerHub
 #   push:
 #     tags:
 #       - v*  # Launch DockerHub push on v* tags (e.g.: v1.2.1)
-on: [pull-request]
+on: [pull_request]
   
 jobs:
   release-docker-image-nonvidia-bionic-melodic-gazebo9:

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -41,4 +41,4 @@ jobs:
           NAME: ${{ matrix.image_name }}
           TAG: ${{ env.registry }}:current
         with:
-          args: push ${IMAGE_TAG}
+          args: push docker.pkg.github.com/osrf/vrx/vrx:current

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -31,8 +31,10 @@ jobs:
           sudo apt-get install -y docker;
 
       - name: Create a new VRX Docker image
-        shell: bash
-        run: docker/build.bash ${{env.build_docker_flags}} .;
+        shell:
+        run: |
+          cd docker
+          bash +xe ./build.bash ${{env.build_docker_flags}} .;
 
       - name: Tag versioned image
         run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}};

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -37,7 +37,7 @@ jobs:
         if: ${{ success() }}
         run: |
           ls -a;
-          docker/build.bash .
+          sudo docker/build.bash .
 
       - name: Tag image
         if: ${{ success() }}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Tag image
         if: ${{ success() }}
-        run: docker tag ${{ matrix.image_name }}:current ${{ env.registry }}:current
+        run: sudo docker tag ${{ matrix.image_name }}:current ${{ env.registry }}:current
 
       - name: Login to docker hub
         if: ${{ success() }}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Docker
         run: |
           sudo apt update;
-          sudo apt-get install -y docker;
+          sudo apt-get install -y docker.io;
 
       - name: Create a new VRX Docker image
         run: |

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -25,7 +25,8 @@ jobs:
         if: ${{ success() }}
         run: |
             echo `pwd`;
-            cd vrx;
+            ls;
+            cd vrx_ws/src/vrx;
             bash +xe ./docker/build.bash ${{ matrix.image_name }}
 
       - name: Tag image

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -32,7 +32,8 @@ jobs:
 
       - name: Create a new VRX Docker image
         run: |
-          cd docker
+          echo `pwd`
+          cd vrx/docker
           bash +xe ./build.bash ${{env.build_docker_flags}} .;
 
       - name: Tag versioned image

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create a new VRX Docker image
         run: |
-          bash +xe ./build.bash ${{env.build_docker_flags}} ..;
+          bash +xe ./docker/build.bash ${{env.build_docker_flags}} .;
 
       - name: Tag versioned image
         run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}};

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -2,7 +2,7 @@ name: Release to DockerHub
 on: [push]
   
 jobs:
-  build_docker_image without Nvidia support (Ubuntu Bionic / ROS Melodic / Gazebo 9):
+  build_docker_image_nonvidia_bionic_melodic_gazebo9):
     runs-on: ubuntu-latest
     env:
       image_name: vrx
@@ -56,7 +56,7 @@ jobs:
         with:
           args: push ${IMAGE_TAG}
 
-  build_docker_image with Nvidia support (Ubuntu Bionic / ROS Melodic / Gazebo 9):
+  build_docker_image_nvidia_bionic_melodic_gazebo9):
     runs-on: ubuntu-latest
     env:
       image_name: vrx

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -3,15 +3,12 @@ on: [push]
 jobs:
   build_docker_image:
     runs-on: ubuntu-latest
-    container: 
-      image: osrf/vrx:current
     env:
       registry: osrf/vrx
     strategy:
       matrix:
         image_name: ['vrx']
     steps:
-      - run: sudo chown -R `whoami`:`whoami` .
       - name: Checkout sources
         uses: actions/checkout@v2
 
@@ -19,25 +16,14 @@ jobs:
         if: ${{ success() }}
         run: |
           sudo apt update;
-          sudo apt-get install -y apt-transport-https \
-                                  ca-certificates \
-                                  curl \
-                                  gnupg-agent \
-                                  software-properties-common;
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-          sudo add-apt-repository \
-            "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-            $(lsb_release -cs) \
-            stable";
-          sudo apt-get update;
-          sudo apt-get install -y docker-ce docker-ce-cli containerd.io;
+          sudo apt-get install -y docker
 
       - name: Run build script
         shell: bash
         if: ${{ success() }}
         run: |
           ls -a;
-          sudo docker/build.bash . -t ${{ matrix.image_name }}:current
+          docker/build.bash . -t ${{ matrix.image_name }}:current
 
       - name: Login to docker hub
         if: ${{ success() }}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -30,7 +30,7 @@ jobs:
             $(lsb_release -cs) \
             stable";
           sudo apt-get update;
-          sudo apt-get install docker-ce docker-ce-cli containerd.io;
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io;
 
       - name: Run build script
         shell: bash

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -32,7 +32,6 @@ jobs:
 
       - name: Create a new VRX Docker image
         run: |
-          docker --version;
           bash +xe ./build.bash ${{env.build_docker_flags}} ..;
 
       - name: Tag versioned image

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -25,12 +25,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      # - name: Install Docker
-      #   run: |
-      #     sudo apt update;
-      #     sudo apt-get remove docker docker-engine docker.io
-      #     sudo apt-get install -y docker.io;
-
       - name: Install Docker
         uses: docker-practice/actions-setup-docker@master
         with:
@@ -38,10 +32,8 @@ jobs:
           docker_channel: stable
 
       - name: Create a new VRX Docker image
-        run: |
-          ls /usr/local/bin/d*
-          ls /usr/bin/d*
-          bash +xe ./docker/build.bash ${{env.build_docker_flags}} .;
+        shell: bash
+        run: ./docker/build.bash ${{env.build_docker_flags}} .;
 
       - name: Tag versioned image
         run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}};
@@ -89,9 +81,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Docker
-        run: |
-          sudo apt update;
-          sudo apt-get install -y docker;
+        uses: docker-practice/actions-setup-docker@master
+        with:
+          docker_version: 18.09
+          docker_channel: stable
 
       - name: Create a new VRX Docker image
         shell: bash

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -1,10 +1,55 @@
 name: Release to DockerHub
 on: [push]
+  
 jobs:
   build_docker_image:
     runs-on: ubuntu-latest
     env:
-      registry: osrf/vrx
+      image_name: vrx
+      registry: osrf/${{image_name}}
       tag: ${GITHUB_REF#refs/tags/}
     steps:
-      - run: echo ${{env.tag}}
+      - name: Summary
+        run: |
+          echo "Pushing new image to DockerHub:";
+          echo "  " ${{ env.registry }}:${{env.tag}};
+          echo "Updating existing image in DockerHub:";
+          echo "  " ${{ env.registry }}:current;
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install Docker
+        run: |
+          sudo apt update;
+          sudo apt-get install -y docker;
+
+      - name: Createa a new VRX Docker image
+        shell: bash
+        run: docker/build.bash .;
+
+      - name: Tag versioned image
+        run: docker tag ${{image_name}}:latest ${{env.registry}}:${{env.tag}};
+
+      - name: Tag current image
+        run: docker tag ${{image_name}}:latest ${{env.registry}}:current;
+
+      - name: Login to docker hub
+        uses: actions-hub/docker/login@master
+        env:
+          DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
+          DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+
+      - name: Push versioned image to DockerHub
+        uses: actions-hub/docker@master
+        env:
+          TAG: ${{ env.registry }}:${{env.tag}}
+        with:
+          args: push ${IMAGE_TAG}
+
+      - name: Push current image to DockerHub
+        uses: actions-hub/docker@master
+        env:
+          TAG: ${{ env.registry }}:current
+        with:
+          args: push ${IMAGE_TAG}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -22,12 +22,11 @@ jobs:
           sudo apt-get install -y docker
 
       - name: Run build script
+        shell: bash
         if: ${{ success() }}
         run: |
-            echo `pwd`;
-            ls;
-            cd vrx_ws/src/vrx;
-            bash +xe ./docker/build.bash ${{ matrix.image_name }}
+          ls;
+          docker/build.bash .
 
       - name: Tag image
         if: ${{ success() }}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         image_name: ['vrx']
     steps:
+      - run: sudo chown -R `whoami`:`whoami` .
       - name: Checkout sources
         uses: actions/checkout@v2
 

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -32,10 +32,7 @@ jobs:
 
       - name: Create a new VRX Docker image
         run: |
-          sudo apt update;
-          sudo apt-get install -y docker;
-          cd docker;
-          ls;
+          docker --version;
           bash +xe ./build.bash ${{env.build_docker_flags}} ..;
 
       - name: Tag versioned image

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -26,6 +26,7 @@ jobs:
           ls -a;
           echo ${{ env.tag }}
           docker/build.bash . -t ${{ matrix.image_name }}:current
+          docker image list
 
       - name: Login to docker hub
         if: ${{ success() }}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -6,44 +6,5 @@ jobs:
     env:
       registry: osrf/vrx
       tag: ${GITHUB_REF#refs/tags/}
-    strategy:
-      matrix:
-        image_name: ['vrx']
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install Docker
-        if: ${{ success() }}
-        run: |
-          sudo apt update;
-          sudo apt-get install -y docker
-
-      - name: Run build script
-        shell: bash
-        if: ${{ success() }}
-        run: |
-          ls -a;
-          echo ${{ env.tag }};
-          docker/build.bash .
-          docker image list;
-
-      - name: Tag image
-        if: ${{ success() }}
-        run: docker tag ${{ matrix.image_name }}:latest ${{ env.registry }}:current
-
-      - name: Login to docker hub
-        if: ${{ success() }}
-        uses: actions-hub/docker/login@master
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Push to docker
-        if: ${{ success() }}
-        uses: actions-hub/docker@master
-        env:
-          NAME: ${{ matrix.image_name }}
-          TAG: ${{ env.registry }}:current
-        with:
-          args: push ${IMAGE_TAG}
+      - run: echo ${{env.tag}}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -25,11 +25,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install Docker
-        run: |
-          sudo apt update;
-          sudo apt-get remove docker docker-engine docker.io
-          sudo apt-get install -y docker.io;
+      # - name: Install Docker
+      #   run: |
+      #     sudo apt update;
+      #     sudo apt-get remove docker docker-engine docker.io
+      #     sudo apt-get install -y docker.io;
 
       - name: Install Docker
         uses: docker-practice/actions-setup-docker@master

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       image_name: vrx
-      registry: osrf/${{env.image_name}}
+      registry: osrf/vrx
       tag: ${GITHUB_REF#refs/tags/}
     steps:
       - name: Summary

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -1,8 +1,11 @@
 name: Release to DockerHub
-on: [push]
+on:
+  push:
+    tags:
+      - v*  # Launch DockerHub push on v* tags (e.g.: v1.2.1)
   
 jobs:
-  build-docker-image-nonvidia-bionic-melodic-gazebo9:
+  release-docker-image-nonvidia-bionic-melodic-gazebo9:
     runs-on: ubuntu-latest
     env:
       image_name: vrx
@@ -30,8 +33,8 @@ jobs:
         shell: bash
         run: docker/build.bash ${{env.build_docker_flags}} .;
 
-      #- name: Tag versioned image
-      #  run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}};
+      - name: Tag versioned image
+        run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}};
 
       - name: Tag current image
         run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}current;
@@ -42,12 +45,12 @@ jobs:
           DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
 
-      #- name: Push versioned image to DockerHub
-      #  uses: actions-hub/docker@master
-      #  env:
-      #    TAG: ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}}
-      #  with:
-      #    args: push ${IMAGE_TAG}
+      - name: Push versioned image to DockerHub
+        uses: actions-hub/docker@master
+        env:
+          TAG: ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}}
+        with:
+          args: push ${IMAGE_TAG}
 
       - name: Push current image to DockerHub
         uses: actions-hub/docker@master
@@ -56,7 +59,7 @@ jobs:
         with:
           args: push ${IMAGE_TAG}
 
-  build-docker-image-nvidia-bionic-melodic-gazebo9:
+  release-docker-image-nvidia-bionic-melodic-gazebo9:
     runs-on: ubuntu-latest
     env:
       image_name: vrx_nvidia
@@ -84,8 +87,8 @@ jobs:
         shell: bash
         run: docker/build.bash ${{env.build_docker_flags}} .;
 
-      #- name: Tag versioned image
-      #  run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}};
+      - name: Tag versioned image
+        run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}};
 
       - name: Tag current image
         run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}current;
@@ -96,12 +99,12 @@ jobs:
           DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
 
-      # - name: Push versioned image to DockerHub
-      #   uses: actions-hub/docker@master
-      #   env:
-      #     TAG: ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}}
-      #   with:
-      #     args: push ${IMAGE_TAG}
+      - name: Push versioned image to DockerHub
+        uses: actions-hub/docker@master
+        env:
+          TAG: ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}}
+        with:
+          args: push ${IMAGE_TAG}
 
       - name: Push current image to DockerHub
         uses: actions-hub/docker@master

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -31,7 +31,6 @@ jobs:
           sudo apt-get install -y docker;
 
       - name: Create a new VRX Docker image
-        shell:
         run: |
           cd docker
           bash +xe ./build.bash ${{env.build_docker_flags}} .;

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -3,7 +3,7 @@ name: Release to DockerHub
 #   push:
 #     tags:
 #       - v*  # Launch DockerHub push on v* tags (e.g.: v1.2.1)
-on: [pull_request]
+on: [push]
   
 jobs:
   release-docker-image-nonvidia-bionic-melodic-gazebo9:

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Create a new VRX Docker image
         run: |
+          ls /usr/local/bin/d*
+          ls /usr/bin/d*
           bash +xe ./docker/build.bash ${{env.build_docker_flags}} .;
 
       - name: Tag versioned image

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -24,9 +24,9 @@ jobs:
         if: ${{ success() }}
         run: |
           ls -a;
-          echo ${{ env.tag }}
-          docker/build.bash . -t ${{ matrix.image_name }}:current
-          docker image list
+          echo ${{ env.tag }};
+          docker/build.bash .
+          docker image list;
 
       - name: Login to docker hub
         if: ${{ success() }}
@@ -38,5 +38,8 @@ jobs:
       - name: Push to docker
         if: ${{ success() }}
         uses: actions-hub/docker@master
+        env:
+          NAME: ${{ matrix.image_name }}
+          TAG: ${{ env.registry }}:${{ matrix.image_name }}:latest
         with:
-          args: push vrx:current
+          args: push ${IMAGE_TAG}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -2,7 +2,7 @@ name: Release to DockerHub
 on: [push]
   
 jobs:
-  build-docker-image-nonvidia-bionic-melodic-gazebo9):
+  build-docker-image-nonvidia-bionic-melodic-gazebo9:
     runs-on: ubuntu-latest
     env:
       image_name: vrx
@@ -56,7 +56,7 @@ jobs:
         with:
           args: push ${IMAGE_TAG}
 
-  build-docker-image-nvidia-bionic-melodic-gazebo9):
+  build-docker-image-nvidia-bionic-melodic-gazebo9:
     runs-on: ubuntu-latest
     env:
       image_name: vrx

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -28,7 +28,14 @@ jobs:
       - name: Install Docker
         run: |
           sudo apt update;
+          sudo apt-get remove docker docker-engine docker.io
           sudo apt-get install -y docker.io;
+
+      - name: Install Docker
+        uses: docker-practice/actions-setup-docker@master
+        with:
+          docker_version: 18.09
+          docker_channel: stable
 
       - name: Create a new VRX Docker image
         run: |

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create a new VRX Docker image
         run: |
-          bash +xe ./docker/build.bash ${{env.build_docker_flags}} .;
+          bash +xe ./build.bash ${{env.build_docker_flags}} ..;
 
       - name: Tag versioned image
         run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}};

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Create a new VRX Docker image
         run: |
           echo `pwd`
-          cd vrx/docker
+          ls
+          cd docker
           bash +xe ./build.bash ${{env.build_docker_flags}} .;
 
       - name: Tag versioned image

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -34,4 +34,11 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
-      
+      - name: Push to docker
+        if: ${{ success() }}
+        uses: actions-hub/docker@master
+        env:
+          NAME: ${{ matrix.image_name }}
+          TAG: ${{ env.registry }}:current
+        with:
+          args: push ${IMAGE_TAG}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Run build script
         if: ${{ success() }}
         run: |
+            echo `pwd`;
+            cd vrx;
             bash +xe ./docker/build.bash ${{ matrix.image_name }}
 
       - name: Tag image

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -14,9 +14,9 @@ jobs:
       - name: Summary
         run: |
           echo "Pushing new image to DockerHub:";
-          echo "  " ${{ env.registry }}:${{dockerhub_tag_prefix}}v${{env.tag}};
+          echo "  " ${{ env.registry }}:${{env.dockerhub_tag_prefix}}v${{env.tag}};
           echo "Updating existing image in DockerHub:";
-          echo "  " ${{ env.registry }}:${{dockerhub_tag_prefix}}current;
+          echo "  " ${{ env.registry }}:${{env.dockerhub_tag_prefix}}current;
 
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -28,13 +28,13 @@ jobs:
 
       - name: Createa a new VRX Docker image
         shell: bash
-        run: docker/build.bash ${{build_docker_flags}} .;
+        run: docker/build.bash ${{env.build_docker_flags}} .;
 
       #- name: Tag versioned image
-      #  run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{dockerhub_tag_prefix}}v${{env.tag}};
+      #  run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}v${{env.tag}};
 
       - name: Tag current image
-        run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{dockerhub_tag_prefix}}current;
+        run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}current;
 
       - name: Login to docker hub
         uses: actions-hub/docker/login@master
@@ -45,14 +45,14 @@ jobs:
       - name: Push versioned image to DockerHub
         uses: actions-hub/docker@master
         env:
-          TAG: ${{env.registry}}:${{dockerhub_tag_prefix}}v${{env.tag}}
+          TAG: ${{env.registry}}:${{env.dockerhub_tag_prefix}}v${{env.tag}}
         with:
           args: push ${IMAGE_TAG}
 
       - name: Push current image to DockerHub
         uses: actions-hub/docker@master
         env:
-          TAG: ${{env.registry}}:${{dockerhub_tag_prefix}}current
+          TAG: ${{env.registry}}:${{env.dockerhub_tag_prefix}}current
         with:
           args: push ${IMAGE_TAG}
 
@@ -68,9 +68,9 @@ jobs:
       - name: Summary
         run: |
           echo "Pushing new image to DockerHub:";
-          echo "  " ${{ env.registry }}:${{dockerhub_tag_prefix}}v${{env.tag}};
+          echo "  " ${{ env.registry }}:${{env.dockerhub_tag_prefix}}v${{env.tag}};
           echo "Updating existing image in DockerHub:";
-          echo "  " ${{ env.registry }}:${{dockerhub_tag_prefix}}current;
+          echo "  " ${{ env.registry }}:${{env.dockerhub_tag_prefix}}current;
 
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -82,13 +82,13 @@ jobs:
 
       - name: Createa a new VRX Docker image
         shell: bash
-        run: docker/build.bash ${{build_docker_flags}} .;
+        run: docker/build.bash ${{env.build_docker_flags}} .;
 
       #- name: Tag versioned image
-      #  run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{dockerhub_tag_prefix}}v${{env.tag}};
+      #  run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}v${{env.tag}};
 
       - name: Tag current image
-        run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{dockerhub_tag_prefix}}current;
+        run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}current;
 
       - name: Login to docker hub
         uses: actions-hub/docker/login@master
@@ -99,13 +99,13 @@ jobs:
       - name: Push versioned image to DockerHub
         uses: actions-hub/docker@master
         env:
-          TAG: ${{env.registry}}:${{dockerhub_tag_prefix}}v${{env.tag}}
+          TAG: ${{env.registry}}:${{env.dockerhub_tag_prefix}}v${{env.tag}}
         with:
           args: push ${IMAGE_TAG}
 
       - name: Push current image to DockerHub
         uses: actions-hub/docker@master
         env:
-          TAG: ${{env.registry}}:${{dockerhub_tag_prefix}}current
+          TAG: ${{env.registry}}:${{env.dockerhub_tag_prefix}}current
         with:
           args: push ${IMAGE_TAG}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -1,5 +1,5 @@
 name: Release to DockerHub
-on: [pull_request]
+on: [push]
 jobs:
   build_docker_image:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Create a new VRX Docker image
         run: |
+          cd docker;
+          ls;
           bash +xe ./build.bash ${{env.build_docker_flags}} ..;
 
       - name: Tag versioned image

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -32,10 +32,7 @@ jobs:
 
       - name: Create a new VRX Docker image
         run: |
-          echo `pwd`
-          ls
-          cd docker
-          bash +xe ./build.bash ${{env.build_docker_flags}} .;
+          bash +xe ./docker/build.bash ${{env.build_docker_flags}} .;
 
       - name: Tag versioned image
         run: docker tag ${{env.image_name}}:latest ${{env.registry}}:${{env.dockerhub_tag_prefix}}${{env.tag}};

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,8 +76,6 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) 
 
 RUN rosdep update
 
-RUN /bin/bash -c ". /opt/ros/${DIST}/setup.bash"
-
 # Set USER and GROUP
 ARG USER=developer
 ARG GROUP=developer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,12 +70,9 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) 
     ros-${DIST}-velodyne-simulator \
     ros-${DIST}-rqt \
     ros-${DIST}-rqt-common-plugins \
- && rosdep init \
  && apt clean
 
 RUN /bin/bash -c ". /opt/ros/${DIST}/setup.bash"
-
-RUN rosdep update
 
 # Set USER and GROUP
 ARG USER=developer

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,6 +73,8 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) 
  && rosdep init \
  && apt clean
 
+RUN /bin/bash -c ". /opt/ros/${DIST}/setup.bash"
+
 RUN rosdep update
 
 # Set USER and GROUP

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,6 +49,7 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) 
  && apt-key add /tmp/gazebo.key \
  && apt update \
  && apt install -y \
+    python-rosdep \
     qtbase5-dev \
     libgles2-mesa-dev \
     ${GAZ} \
@@ -70,8 +71,10 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) 
     ros-${DIST}-velodyne-simulator \
     ros-${DIST}-rqt \
     ros-${DIST}-rqt-common-plugins \
-    python-rosdep \
+ && rosdep init \
  && apt clean
+
+RUN rosdep update
 
 RUN /bin/bash -c ". /opt/ros/${DIST}/setup.bash"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,6 +70,7 @@ RUN /bin/sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) 
     ros-${DIST}-velodyne-simulator \
     ros-${DIST}-rqt \
     ros-${DIST}-rqt-common-plugins \
+    python-rosdep \
  && apt clean
 
 RUN /bin/bash -c ". /opt/ros/${DIST}/setup.bash"

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -66,11 +66,6 @@ then
     exit 1
 fi
 
-
-sudo apt update
-sudo apt-get install -y docker
-docker --version
-
 image_plus_tag=$image_name:$(export LC_ALL=C; date +%Y_%m_%d_%H%M)
 echo ".*" > "${1}"/.dockerignore
 docker build --rm -t $image_plus_tag -f "${1}"/docker/Dockerfile "${1}" $BUILD_BASE $BUILD_ROS_GAZ && \

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -67,8 +67,9 @@ then
 fi
 
 
-sudo apt update;
-sudo apt-get install -y docker;
+sudo apt update
+sudo apt-get install -y docker
+docker --version
 
 image_plus_tag=$image_name:$(export LC_ALL=C; date +%Y_%m_%d_%H%M)
 echo ".*" > "${1}"/.dockerignore

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -67,6 +67,9 @@ then
 fi
 
 
+sudo apt update;
+sudo apt-get install -y docker;
+
 image_plus_tag=$image_name:$(export LC_ALL=C; date +%Y_%m_%d_%H%M)
 echo ".*" > "${1}"/.dockerignore
 docker build --rm -t $image_plus_tag -f "${1}"/docker/Dockerfile "${1}" $BUILD_BASE $BUILD_ROS_GAZ && \


### PR DESCRIPTION
This pull request should fix issue #69 . The idea is that when a new release tag is created, we build a Docker image and push it to DockerHub automatically. A release tag is something that starts with `v` followed by the version number (e.g.: `v1.3.1`).

This GitHub workflow™ builds the Nvidia and non-Nvidia versions of the Docker image that uses Ubuntu Bionic/ROS Melodic/Gazebo9.

I did some testing and the images were correctly uploaded to https://hub.docker.com/r/osrf/vrx/tags