### PR TITLE
Changes to support Gazebo11 and Python3 on macOS 10.15.4

### DIFF
--- a/vrx_gazebo/docs/pm_sampling.py
+++ b/vrx_gazebo/docs/pm_sampling.py
@@ -31,9 +31,9 @@ for Tp in Tps:
     for o,d in zip(omegas,delos):
         s.append(pm(o,omega_p))
         a.append(sqrt(2*pm(o,omega_p)*d))
-    print 2*pi/omega_p
-    print 2*pi/array(omegas)
-    print a     
+    print (2*pi/omega_p)
+    print (2*pi/array(omegas))
+    print (a)     
     plot(omegas,s,'o',label='Samples for s = %.2f'%scale)
 
 legend()    

--- a/vrx_gazebo/msgs/CMakeLists.txt
+++ b/vrx_gazebo/msgs/CMakeLists.txt
@@ -1,23 +1,45 @@
 find_package(Protobuf REQUIRED)
+
 set(PROTOBUF_IMPORT_DIRS)
 foreach(ITR ${GAZEBO_INCLUDE_DIRS})
-  if(ITR MATCHES ".*gazebo-[0-9.]+$")
+  if(ITR MATCHES ".*gazebo-[0-11.]+$")
     set(PROTOBUF_IMPORT_DIRS "${ITR}/gazebo/msgs/proto")
   endif()
 endforeach()
-set (msgs
-  light_buoy_colors.proto
-  dock_placard.proto
-  ${PROTOBUF_IMPORT_DIRS}/header.proto
-  ${PROTOBUF_IMPORT_DIRS}/time.proto
+
+include_directories(
+  ${GAZEBO_INCLUDE_DIRS}
+  ${GAZEBO_PROTO_INCLUDE_DIRS}
 )
-PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${msgs})
 
-add_library(light_buoy_colors_msgs SHARED ${PROTO_SRCS})
-target_link_libraries(light_buoy_colors_msgs ${PROTOBUF_LIBRARY})
+link_directories(
+  ${GAZEBO_LIBRARY_DIRS}
+)
 
-add_library(dock_placard_msgs SHARED ${PROTO_SRCS})
-target_link_libraries(dock_placard_msgs ${PROTOBUF_LIBRARY})
+set (msgs1
+  light_buoy_colors.proto
+)
+PROTOBUF_GENERATE_CPP(PROTO_SRCS1 PROTO_HDRS ${msgs1})
+
+add_library(light_buoy_colors_msgs SHARED ${PROTO_SRCS1})
+target_link_libraries(light_buoy_colors_msgs 
+  ${PROTOBUF_LIBRARY}
+  ${GAZEBO_LIBRARIES}
+  ${GAZEBO_PROTO_LIBRARIES}
+)
+
+set (msgs2
+  dock_placard.proto
+)
+PROTOBUF_GENERATE_CPP(PROTO_SRCS2 PROTO_HDRS ${msgs2})
+
+add_library(dock_placard_msgs SHARED ${PROTO_SRCS2})
+
+target_link_libraries(dock_placard_msgs
+  ${PROTOBUF_LIBRARY} 
+  ${GAZEBO_LIBRARIES}
+  ${GAZEBO_PROTO_LIBRARIES}
+)
 
 install(TARGETS dock_placard_msgs
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/vrx_gazebo/scripts/generate_avoid_obstacles_buoys
+++ b/vrx_gazebo/scripts/generate_avoid_obstacles_buoys
@@ -121,5 +121,5 @@ if __name__ == '__main__':
             N_xml += get_models_xml(arrN,obj)
 
     # Assemble full sdf
-    print HEADER + a3_xml + a5_xml + a7_xml + surmark46104_xml + N_xml + FOOTER
+    print (HEADER + a3_xml + a5_xml + a7_xml + surmark46104_xml + N_xml + FOOTER)
 

--- a/vrx_gazebo/src/vrx_gazebo_python/generator_scripts/world_generator/generate_worlds.py
+++ b/vrx_gazebo/src/vrx_gazebo_python/generator_scripts/world_generator/generate_worlds.py
@@ -37,7 +37,7 @@ def main():
                   '.world ' +
                   rospy.get_param('world_xacro_target') + yaml_name +
                   str(num) + '.world.xacro')
-    print 'All ', len(coordinates), ' worlds generated'
+    print ('All ', len(coordinates), ' worlds generated')
 
 
 def world_gen(coordinate={}, master={}):

--- a/wave_gazebo_plugins/CMakeLists.txt
+++ b/wave_gazebo_plugins/CMakeLists.txt
@@ -130,11 +130,14 @@ add_library(wavegauge_plugin
 )
 
 target_link_libraries(wavegauge_plugin
+  WavefieldModelPlugin
   ${Boost_LIBRARIES}
   ${catkin_LIBRARIES}
   ${GAZEBO_LIBRARIES}
   ${WAVE_GAZEBO_LIBRARIES_LIST}
 )
+
+add_dependencies(wavegauge_plugin WavefieldModelPlugin)
 
 target_compile_options(wavegauge_plugin PRIVATE "-Wno-unknown-pragmas")
 

--- a/wave_gazebo_plugins/include/wave_gazebo_plugins/Utilities.hh
+++ b/wave_gazebo_plugins/include/wave_gazebo_plugins/Utilities.hh
@@ -21,26 +21,14 @@
 #ifndef _WAVE_GAZEBO_PLUGINS_UTILITIES_HH_
 #define _WAVE_GAZEBO_PLUGINS_UTILITIES_HH_
 
+#include <gazebo/gazebo.hh>
+#include <gazebo/common/common.hh>
+#include <gazebo/msgs/msgs.hh>
+
 #include <ignition/math/Vector2.hh>
 #include <ignition/math/Vector3.hh>
 
 #include <string>
-
-///////////////////////////////////////////////////////////////////////////////
-// Forward Declarations
-
-namespace gazebo
-{
-  namespace msgs
-  {
-    class Param_V;
-  }
-}
-
-namespace sdf
-{
-  class Element;
-}
 
 namespace asv
 {

--- a/wave_gazebo_plugins/include/wave_gazebo_plugins/Wavefield.hh
+++ b/wave_gazebo_plugins/include/wave_gazebo_plugins/Wavefield.hh
@@ -23,27 +23,15 @@
 #ifndef _ASV_WAVE_SIM_GAZEBO_PLUGINS_WAVEFIELD_HH_
 #define _ASV_WAVE_SIM_GAZEBO_PLUGINS_WAVEFIELD_HH_
 
+#include <gazebo/gazebo.hh>
+#include <gazebo/common/common.hh>
+#include <gazebo/msgs/msgs.hh>
+
 #include <ignition/math/Vector2.hh>
 #include <ignition/math/Vector3.hh>
 
 #include <memory>
 #include <vector>
-
-///////////////////////////////////////////////////////////////////////////////
-// Forward Declarations
-
-namespace gazebo
-{
-  namespace msgs
-  {
-    class Param_V;
-  }
-}
-
-namespace sdf
-{
-  class Element;
-}
 
 namespace asv
 {


### PR DESCRIPTION
Three minor changes to get the basic test case: 

```bash
$ roslaunch vrx_gazebo sandisland.launch
```

running on macOS Catalina 10.15.4 with Python3, ROS Melodic, Gazebo 11 (I appreciate this is not a supported configuration).

***Issue 1:*** The protobuf issue causes these runtime errors on macOS:

1. An error caused by importing `header.proto` and `time.proto` into the sources list:

```console
[libprotobuf ERROR google/protobuf/descriptor_database.cc:120] File already exists in database: time.proto
[libprotobuf FATAL google/protobuf/descriptor.cc:1356] CHECK failed: GeneratedDatabase()->Add(encoded_file_descriptor, size): 
libc++abi.dylib: terminating with uncaught exception of type google::protobuf::FatalException: CHECK failed: GeneratedDatabase()->Add(encoded_file_descriptor, size): 
/opt/ros/melodic/lib/gazebo_ros/gzclient: line 42: 50513 Abort trap: 6           GAZEBO_MASTER_URI="$desired_master_uri" GAZEBO_MODEL_DATABASE_URI="$desired_model_database_uri" gzclient $final
[gazebo_gui-2] process has died [pid 50443, exit code 134, cmd /opt/ros/melodic/lib/gazebo_ros/gzclient --verbose __name:=gazebo_gui __log:=/Users/rhys/.ros/log/13b8754e-bd58-11ea-9d16-94f6d6f3ade6/gazebo_gui-2.log].
```

2. An error caused by including the source for both `light_buoy_colors.proto` and `dock_placard.proto` into each of the libraries `light_buoy_colors_msgs` and `dock_placard_msgs`:

```console
[Msg] directions:  [Msg] 0.921061 -0.389418; [Msg] 1 0; [Msg] 0.921061 0.389418; [Msg] 
[libprotobuf ERROR google/protobuf/descriptor_database.cc:120] File already exists in database: light_buoy_colors.proto
[libprotobuf FATAL google/protobuf/descriptor.cc:1356] CHECK failed: GeneratedDatabase()->Add(encoded_file_descriptor, size): 
libc++abi.dylib: terminating with uncaught exception of type google::protobuf::FatalException: CHECK failed: GeneratedDatabase()->Add(encoded_file_descriptor, size): 
/opt/ros/melodic/lib/gazebo_ros/gzclient: line 42: 58337 Abort trap: 6           GAZEBO_MASTER_URI="$desired_master_uri" GAZEBO_MODEL_DATABASE_URI="$desired_model_database_uri" gzclient $final
[gazebo_gui-2] process has died [pid 58266, exit code 134, cmd /opt/ros/melodic/lib/gazebo_ros/gzclient --verbose __name:=gazebo_gui __log:=/Users/rhys/.ros/log/fb9e0c28-bd5a-11ea-86d4-94f6d6f3ade6/gazebo_gui-2.log].
```
***Issue 2:*** I see a namespace conflict between gazebo11 / ignition and sdf9 when using forward declarations
(there is an additional namespace sdf::v9:: in sdf9 which the forward declaration conflicts with). The simplest fix is to just remove them and add the necessary  #includes instead.

***Issue 3:*** Python 2 => Python 3 conversions. `catkin build` presents these as warnings. 

I've split the changes into 3 commits so you can pick and choose if that suits.