### PR TITLE
New hydro params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+syntax: glob
+vrx_gazebo/models/dock_2016_base/model.sdf
+vrx_gazebo/models/dock_2016/model.sdf
+vrx_gazebo/models/dock_2018_base/model.sdf
+vrx_gazebo/models/dock_2018/model.sdf
+vrx_gazebo/models/dock_2018_dynamic/model.sdf
+vrx_gazebo/models/robotx_2018_qualifying_avoid_obstacles_buoys/model.sdf
+wave_gazebo/world_models/ocean_waves/model.sdf
+vrx_gazebo/src/vrx_gazebo_python/generator_scripts/wamv_config/*.xacro
+build
+build_*
+.DS_Store
+*.swp
+*.orig
+*.*~
+vrx_gazebo/models/dock_permutations/*
+*.pyc

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 ## VRX 1
 
+1. New hydro params:
+    * [Pull request 214](https://github.com/osrf/vrx/pull/214)
+
 ### VRX 1.3.X
 
 1. Adding camera optical frame:
@@ -14,9 +17,9 @@
 
 1. Deterministic wind plugin:
     * [Pull request 157](https://bitbucket.org/osrf/vrx/pull-requests/157)
-    
+
 1. Waypoint marker visualization:
-    * [Pull request 162](https://bitbucket.org/osrf/vrx/pull-requests/162)    
+    * [Pull request 162](https://bitbucket.org/osrf/vrx/pull-requests/162)
 
 ### VRX 1.1
 

--- a/usv_gazebo_plugins/include/usv_gazebo_plugins/usv_gazebo_dynamics_plugin.hh
+++ b/usv_gazebo_plugins/include/usv_gazebo_plugins/usv_gazebo_dynamics_plugin.hh
@@ -44,14 +44,20 @@ namespace gazebo
   /// <waterLevel>: Water height [m]. Default value is 0.5.
   /// <xDotU>: Added mass coeff, surge.
   /// <yDotV>: Added mass coeff, sway.
-  /// <nDotR>: Added mass coeff, yaw
+  /// <zDotW>: Added mass coeff, heave.
+  /// <kDotP>: Added mass coeff, roll.
+  /// <mDotQ>: Added mass coeff, pitch.
+  /// <nDotR>: Added mass coeff, yaw.
   /// <xU>: Linear drag coeff surge.
   /// <xUU>: Quadratic drag coeff surge.
   /// <yV>: Linear drag coeff sway.
   /// <yVV>: Quadratic drag coeff sway
   /// <zW>: Linear drag coeff heave.
-  /// <kP>: Linear drag coeff pitch.
-  /// <mQ>: Linear drag coeff roll.
+  /// <zWW>: Quadratic drag coeff heave.
+  /// <kP>: Linear drag coeff roll.
+  /// <kPP>: Quadratic drag coeff roll.
+  /// <mQ>: Linear drag coeff pitch.
+  /// <mQQ>: Quadratic drag coeff pitch.
   /// <nR>: Linear drag coeff yaw.
   /// <nRR>: Quadratic drag coeff yaw.
   /// <wave_n>: Number of waves to generate wave field.

--- a/usv_gazebo_plugins/include/usv_gazebo_plugins/usv_gazebo_dynamics_plugin.hh
+++ b/usv_gazebo_plugins/include/usv_gazebo_plugins/usv_gazebo_dynamics_plugin.hh
@@ -142,11 +142,21 @@ namespace gazebo
     /// \brief Plugin Parameter: Linear drag in heave.
     private: double paramZw;
 
+
+    /// \brief Plugin Parameter: Quadratic drag in heave.
+    private: double paramZww;
+
     /// \brief Plugin Parameter: Linear drag in roll.
     private: double paramKp;
 
+    /// \brief Plugin Parameter: Quadratic drag in roll.
+    private: double paramKpp;
+
     /// \brief Plugin Parameter: Linear drag in pitch.
     private: double paramMq;
+
+    /// \brief Plugin Parameter: Quadratic drag in pitch.
+    private: double paramMqq;
 
     /// \brief Plugin Parameter: Linear drag in yaw.
     private: double paramNr;

--- a/usv_gazebo_plugins/include/usv_gazebo_plugins/usv_gazebo_dynamics_plugin.hh
+++ b/usv_gazebo_plugins/include/usv_gazebo_plugins/usv_gazebo_dynamics_plugin.hh
@@ -123,7 +123,7 @@ namespace gazebo
 
     /// \brief Plugin Parameter: Added mass in pitch, M_\dot{q}.
     private: double paramMdotQ;
-    
+
     /// \brief Plugin Parameter: Added mass in yaw, N_\dot{r}.
     private: double paramNdotR;
 

--- a/usv_gazebo_plugins/include/usv_gazebo_plugins/usv_gazebo_dynamics_plugin.hh
+++ b/usv_gazebo_plugins/include/usv_gazebo_plugins/usv_gazebo_dynamics_plugin.hh
@@ -115,6 +115,15 @@ namespace gazebo
     /// \brief Plugin Parameter: Added mass in sway, Y_\dot{v}.
     private: double paramYdotV;
 
+    /// \brief Plugin Parameter: Added mass in heave, Z_\dot{w}.
+    private: double paramZdotW;
+
+    /// \brief Plugin Parameter: Added mass in roll, K_\dot{p}.
+    private: double paramKdotP;
+
+    /// \brief Plugin Parameter: Added mass in pitch, M_\dot{q}.
+    private: double paramMdotQ;
+    
     /// \brief Plugin Parameter: Added mass in yaw, N_\dot{r}.
     private: double paramNdotR;
 

--- a/usv_gazebo_plugins/src/usv_gazebo_dynamics_plugin.cc
+++ b/usv_gazebo_plugins/src/usv_gazebo_dynamics_plugin.cc
@@ -91,6 +91,9 @@ void UsvDynamicsPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   this->waterDensity     = this->SdfParamDouble(_sdf, "waterDensity", 997.7735);
   this->paramXdotU       = this->SdfParamDouble(_sdf, "xDotU"       , 5);
   this->paramYdotV       = this->SdfParamDouble(_sdf, "yDotV"       , 5);
+  this->paramZdotW       = this->SdfParamDouble(_sdf, "zDotW"       , 0.1);
+  this->paramKdotP       = this->SdfParamDouble(_sdf, "kDotP"       , 0.1);
+  this->paramMdotQ       = this->SdfParamDouble(_sdf, "mDotQ"       , 0.1);
   this->paramNdotR       = this->SdfParamDouble(_sdf, "nDotR"       , 1);
   this->paramXu          = this->SdfParamDouble(_sdf, "xU"          , 20);
   this->paramXuu         = this->SdfParamDouble(_sdf, "xUU"         , 0);
@@ -158,9 +161,9 @@ void UsvDynamicsPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   this->Ma <<
     this->paramXdotU, 0,                0,   0,   0,   0,
     0,                this->paramYdotV, 0,   0,   0,   0,
-    0,                0,                0.1, 0,   0,   0,
-    0,                0,                0,   0.1, 0,   0,
-    0,                0,                0,   0,   0.1, 0,
+    0,                0,     this->paramZdotW, 0,   0,   0,
+    0,                0,                0,   this->paramKdotP, 0,   0,
+    0,                0,                0,   0,   this->paramMdotQ, 0,
     0,                0,                0,   0,   0,   this->paramNdotR;
 }
 

--- a/usv_gazebo_plugins/src/usv_gazebo_dynamics_plugin.cc
+++ b/usv_gazebo_plugins/src/usv_gazebo_dynamics_plugin.cc
@@ -100,8 +100,11 @@ void UsvDynamicsPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   this->paramYv          = this->SdfParamDouble(_sdf, "yV"          , 20);
   this->paramYvv         = this->SdfParamDouble(_sdf, "yVV"         , 0);
   this->paramZw          = this->SdfParamDouble(_sdf, "zW"          , 20);
+  this->paramZww         = this->SdfParamDouble(_sdf, "zWW"         , 0);
   this->paramKp          = this->SdfParamDouble(_sdf, "kP"          , 20);
+  this->paramKpp         = this->SdfParamDouble(_sdf, "kPP"         , 0);
   this->paramMq          = this->SdfParamDouble(_sdf, "mQ"          , 20);
+  this->paramMqq         = this->SdfParamDouble(_sdf, "mQQ"         , 0);
   this->paramNr          = this->SdfParamDouble(_sdf, "nR"          , 20);
   this->paramNrr         = this->SdfParamDouble(_sdf, "nRR"         , 0);
   this->paramHullRadius  = this->SdfParamDouble(_sdf, "hullRadius"  , 0.213);
@@ -257,9 +260,9 @@ void UsvDynamicsPlugin::Update()
   // Drag
   Dmat(0, 0) = this->paramXu + this->paramXuu * std::abs(kVelLinearBody.X());
   Dmat(1, 1) = this->paramYv + this->paramYvv * std::abs(kVelLinearBody.Y());
-  Dmat(2, 2) = this->paramZw;
-  Dmat(3, 3) = this->paramKp;
-  Dmat(4, 4) = this->paramMq;
+  Dmat(2, 2) = this->paramZw + this->paramZww * std::abs(kVelLinearBody.Z());
+  Dmat(3, 3) = this->paramKp + this->paramKpp * std::abs(kVelAngularBody.X());
+  Dmat(4, 4) = this->paramMq + this->paramMqq * std::abs(kVelAngularBody.Y());
   Dmat(5, 5) = this->paramNr + this->paramNrr * std::abs(kVelAngularBody.Z());
   ROS_DEBUG_STREAM_THROTTLE(1.0, "Dmat :\n" << Dmat);
   const Eigen::VectorXd kDvec = -1.0 * Dmat * state;


### PR DESCRIPTION
Exposes additional hydrodynamic parameters, specifically added mass and quadratic drag parameters.  These are used by the USV model in the Frontiers paper.  Also used for a non-VRX USV model.

To test, simply run the standard example...
```
roslaunch vrx_gazebo vrx.launch
```

Nothing should change since the current WAM-V model doesn't specify these parameters so the default, nominal values are used by they hydro model.