### PR TITLE
Add parameters for customizing wave size

### DIFF
--- a/wamv_gazebo/urdf/dynamics/wamv_gazebo_dynamics_plugin.xacro
+++ b/wamv_gazebo/urdf/dynamics/wamv_gazebo_dynamics_plugin.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="usv_dynamics_gazebo" params="name">
+  <xacro:macro name="usv_dynamics_gazebo" params="name width:=2.4 length:=4.9">
     <!--Gazebo Plugin for simulating WAM-V dynamics-->
     <gazebo>
       <plugin name="usv_dynamics_${name}" filename="libusv_gazebo_dynamics_plugin.so">
@@ -25,8 +25,8 @@
         <!-- General dimensions -->
         <!--<boatArea>2.2</boatArea>-->
         <hullRadius>0.213</hullRadius>
-        <boatWidth>2.4</boatWidth>
-        <boatLength>4.9</boatLength>
+        <boatWidth>${width}</boatWidth>
+        <boatLength>${length}</boatLength>
         <!-- Length discretization, AKA, "N" -->
         <length_n>2</length_n>
         <!-- Wave model -->

--- a/wave_gazebo/world_models/ocean_waves/model.xacro
+++ b/wave_gazebo/world_models/ocean_waves/model.xacro
@@ -27,13 +27,13 @@
 <world xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="ocean_waves" params="gain:=0.1 period:=5
                      direction_x:=1.0 direction_y:=0.0
-                     angle:=0.4 size:=1000 scale:=1.5">
+                     angle:=0.4 scale:=1.5">
   <model name='ocean_waves'>
     <static>true</static>
     <plugin name="wavefield_plugin" filename="libWavefieldModelPlugin.so">
       <static>false</static>
       <update_rate>30</update_rate>
-      <size>${size} ${size}</size>
+      <size>1000 1000</size>
       <cell_count>50 50</cell_count>
       <wave>
 				<model>PMS</model>

--- a/wave_gazebo/world_models/ocean_waves/model.xacro
+++ b/wave_gazebo/world_models/ocean_waves/model.xacro
@@ -27,20 +27,20 @@
 <world xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="ocean_waves" params="gain:=0.1 period:=5
                      direction_x:=1.0 direction_y:=0.0
-                     angle:=0.4">
+                     angle:=0.4 size:=1000 scale:=1.5">
   <model name='ocean_waves'>
     <static>true</static>
     <plugin name="wavefield_plugin" filename="libWavefieldModelPlugin.so">
       <static>false</static>
       <update_rate>30</update_rate>
-      <size>1000 1000</size>
+      <size>${size} ${size}</size>
       <cell_count>50 50</cell_count>
       <wave>
 				<model>PMS</model>
         <period>${period}</period>
         <number>3</number>
-        <scale>1.5</scale>
-	<gain>${gain}</gain>
+        <scale>${scale}</scale>
+        <gain>${gain}</gain>
         <direction>${direction_x} ${direction_y}</direction>
         <angle>${angle}</angle>        
         <tau>2.0</tau>
@@ -60,8 +60,8 @@
             <model>PMS</model>
             <period>${period}</period>
             <number>3</number>
-            <scale>1.5</scale>
-	    <gain>${gain}</gain>
+            <scale>${scale}</scale>
+            <gain>${gain}</gain>
             <direction>${direction_x} ${direction_y}</direction>
             <angle>${angle}</angle>        
             <tau>2.0</tau>
@@ -71,6 +71,7 @@
         </plugin>
         <geometry>
           <mesh>
+            <scale>${scale} ${scale} 1</scale>
             <uri>model://ocean_waves/meshes/mesh.dae</uri>
           </mesh>
         </geometry>
@@ -86,6 +87,7 @@
         <pose>0 0 -0.05 0 0 0</pose>  <!-- Offset to prevent rendering conflict -->
         <geometry>
           <mesh>
+            <scale>${scale} ${scale} 1</scale>
             <uri>model://ocean_waves/meshes/mesh_below.dae</uri>
           </mesh>
         </geometry>

--- a/wave_gazebo/world_models/ocean_waves/model.xacro.erb
+++ b/wave_gazebo/world_models/ocean_waves/model.xacro.erb
@@ -28,7 +28,7 @@
   # period = ${period} # Peak wave period [s]
   # gain = ${gain}  # Deterined at load time by the world xacro file
   number = 3        # Number of component waves
-  scale = 1.5       # Spectrum sampling scale 
+  # scale = 1.5       # Spectrum sampling scale 
   # direction_x = 1.0 # Direction of peak wave component 
   # direction_y = 0.0
   # angle = 0.4       # Delta direction for components
@@ -44,7 +44,7 @@
 <world xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="ocean_waves" params="gain:=0.1 period:=5
                      direction_x:=1.0 direction_y:=0.0
-                     angle:=0.4">
+                     angle:=0.4 scale:=1.5">
   <model name='ocean_waves'>
     <static>true</static>
     <plugin name="wavefield_plugin" filename="libWavefieldModelPlugin.so">
@@ -56,8 +56,8 @@
 				<model><%= model %></model>
         <period>${period}</period>
         <number><%= number %></number>
-        <scale><%= scale %></scale>
-	<gain>${gain}</gain>
+        <scale>${scale}</scale>
+        <gain>${gain}</gain>
         <direction>${direction_x} ${direction_y}</direction>
         <angle>${angle}</angle>        
         <tau><%= tau %></tau>
@@ -77,8 +77,8 @@
             <model><%= model %></model>
             <period>${period}</period>
             <number><%= number %></number>
-            <scale><%= scale %></scale>
-	    <gain>${gain}</gain>
+            <scale>${scale}</scale>
+            <gain>${gain}</gain>
             <direction>${direction_x} ${direction_y}</direction>
             <angle>${angle}</angle>        
             <tau><%= tau %></tau>
@@ -88,6 +88,7 @@
         </plugin>
         <geometry>
           <mesh>
+            <scale>${scale} ${scale} 1</scale>
             <uri>model://ocean_waves/meshes/mesh.dae</uri>
           </mesh>
         </geometry>
@@ -103,6 +104,7 @@
         <pose>0 0 -0.05 0 0 0</pose>  <!-- Offset to prevent rendering conflict -->
         <geometry>
           <mesh>
+            <scale>${scale} ${scale} 1</scale>
             <uri>model://ocean_waves/meshes/mesh_below.dae</uri>
           </mesh>
         </geometry>


### PR DESCRIPTION
Added parameters for size and scale of waves.
Needed for https://github.com/osrf/vorc/pull/1

A larger wave plane is needed for VORC as the terrain covers a larger area.
I guessed this is how to get a bigger wave geometry? It gives me more blue stuff alright. If this isn't the proper way, please let me know how to do it right.