### PR TITLE
Thruster parameters for VORC

### DIFF
--- a/vrx_gazebo/CMakeLists.txt
+++ b/vrx_gazebo/CMakeLists.txt
@@ -308,7 +308,9 @@ install(PROGRAMS scripts/spawn_wamv.bash
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 # Install Python node file
-catkin_install_python(PROGRAMS nodes/twist2thrust.py
+catkin_install_python(PROGRAMS
+    nodes/twist2thrust.py
+    nodes/key2thrust_angle.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 if (CATKIN_ENABLE_TESTING)

--- a/vrx_gazebo/CMakeLists.txt
+++ b/vrx_gazebo/CMakeLists.txt
@@ -307,6 +307,10 @@ install(DIRECTORY launch/
 install(PROGRAMS scripts/spawn_wamv.bash
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
+# Install Python node file
+catkin_install_python(PROGRAMS nodes/twist2thrust.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
 if (CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   add_rostest_gtest(sandisland_test

--- a/vrx_gazebo/launch/usv_joydrive.launch
+++ b/vrx_gazebo/launch/usv_joydrive.launch
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="namespace" default="wamv"/>
+
   <!-- Joystick Driver -->
   <node pkg="joy" type="joy_node" name="joy">
     <param name="dev" value="/dev/input/js0"/>
@@ -16,7 +18,7 @@
 
   <!-- Convert Twist messages to Drive messages -->
   <node pkg="vrx_gazebo" type="twist2thrust.py" name="twist2thrust" output="screen">
-    <remap from="left_cmd" to="/wamv/thrusters/left_thrust_cmd"/>
-    <remap from="right_cmd" to="/wamv/thrusters/right_thrust_cmd"/>
+    <remap from="left_cmd" to="/$(arg namespace)/thrusters/left_thrust_cmd"/>
+    <remap from="right_cmd" to="/$(arg namespace)/thrusters/right_thrust_cmd"/>
   </node>
 </launch>

--- a/vrx_gazebo/launch/usv_keydrive.launch
+++ b/vrx_gazebo/launch/usv_keydrive.launch
@@ -2,6 +2,7 @@
 <launch>
   <arg name="max_angle" default="$(eval pi/2)"/>
   <arg name="thrust_config" default="H"/>
+  <arg name="namespace" default="wamv"/>
 
   <!-- Keyboard teleop -->
   <node pkg="teleop_twist_keyboard" type="teleop_twist_keyboard.py" name="teleop_twist_keyboard" output="screen">
@@ -13,13 +14,13 @@
     <!-- Set articulation angles -->
     <node pkg="vrx_gazebo" type="key2thrust_angle.py" name="key2thrust_angle" output="screen">
       <param name="max_angle" value="$(arg max_angle)"/>
-      <remap from="left_thrust_angle" to="/wamv/thrusters/left_thrust_angle"/>
-      <remap from="right_thrust_angle" to="/wamv/thrusters/right_thrust_angle"/>
+      <remap from="left_thrust_angle" to="/$(arg namespace)/thrusters/left_thrust_angle"/>
+      <remap from="right_thrust_angle" to="/$(arg namespace)/thrusters/right_thrust_angle"/>
     </node>
     <!-- Convert Twist messages (from keyboard teleop) to Drive messages -->
     <node pkg="vrx_gazebo" type="twist2thrust.py" name="twist2thrust" output="screen" args="--keyboard">
-      <remap from="left_cmd" to="/wamv/thrusters/left_thrust_cmd"/>
-      <remap from="right_cmd" to="/wamv/thrusters/right_thrust_cmd"/>
+      <remap from="left_cmd" to="/$(arg namespace)/thrusters/left_thrust_cmd"/>
+      <remap from="right_cmd" to="/$(arg namespace)/thrusters/right_thrust_cmd"/>
     </node>
   </group>
 
@@ -28,13 +29,13 @@
     <!-- Set articulation angles -->
     <node pkg="vrx_gazebo" type="key2thrust_angle.py" name="key2thrust_angle" output="screen">
       <param name="max_angle" value="$(arg max_angle)"/>
-      <remap from="left_thrust_angle" to="/wamv/thrusters/left_rear_thrust_angle"/>
-      <remap from="right_thrust_angle" to="/wamv/thrusters/right_rear_thrust_angle"/>
+      <remap from="left_thrust_angle" to="/$(arg namespace)/thrusters/left_rear_thrust_angle"/>
+      <remap from="right_thrust_angle" to="/$(arg namespace)/thrusters/right_rear_thrust_angle"/>
     </node>
     <!-- Convert Twist messages (from keyboard teleop) to Drive messages -->
     <node pkg="vrx_gazebo" type="twist2thrust.py" name="twist2thrust" output="screen" args="--keyboard">
-      <remap from="left_cmd" to="/wamv/thrusters/left_rear_thrust_cmd"/>
-      <remap from="right_cmd" to="/wamv/thrusters/right_rear_thrust_cmd"/>
+      <remap from="left_cmd" to="/$(arg namespace)/thrusters/left_rear_thrust_cmd"/>
+      <remap from="right_cmd" to="/$(arg namespace)/thrusters/right_rear_thrust_cmd"/>
     </node>
 
   </group>

--- a/wamv_gazebo/urdf/thruster_layouts/wamv_gazebo_thruster_config.xacro
+++ b/wamv_gazebo/urdf/thruster_layouts/wamv_gazebo_thruster_config.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <plugin xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro  name="wamv_gazebo_thruster_config" params="name">
+  <xacro:macro  name="wamv_gazebo_thruster_config" params="name enable_angle:=true">
     <thruster>
       <!-- Required Parameters -->
       <linkName>${name}_propeller_link</linkName>
@@ -8,7 +8,7 @@
       <engineJointName>${name}_chasis_engine_joint</engineJointName>
       <cmdTopic>${thruster_namespace}${name}_thrust_cmd</cmdTopic>
       <angleTopic>${thruster_namespace}${name}_thrust_angle</angleTopic>
-      <enableAngle>true</enableAngle>
+      <enableAngle>${enable_angle}</enableAngle>
 
       <!-- Optional Parameters -->
       <mappingType>1</mappingType>


### PR DESCRIPTION
Added a few thruster parameters for VORC.

Added an install command for `twist2thrust.py`, otherwise I got
```
ERROR: cannot launch node of type [vrx_gazebo/twist2thrust.py]: Cannot locate node of type [twist2thrust.py] in package [vrx_gazebo]. Make sure file exists in package path and permission is set to executable (chmod +x)
```