### PR TITLE
Parse custom topics for station-keeping and wayfinding tasks

### DIFF
--- a/vrx_gazebo/src/stationkeeping_scoring_plugin.cc
+++ b/vrx_gazebo/src/stationkeeping_scoring_plugin.cc
@@ -82,11 +82,24 @@ void StationkeepingScoringPlugin::Load(gazebo::physics::WorldPtr _world,
 
   // Setup ROS node and publisher
   this->rosNode.reset(new ros::NodeHandle());
+  if (_sdf->HasElement("goal_topic"))
+  {
+    this->goalTopic = _sdf->Get<std::string>("goal_topic");
+  }
   this->goalPub = this->rosNode->advertise<geographic_msgs::GeoPoseStamped>(
     this->goalTopic, 10, true);
 
+  if (_sdf->HasElement("pose_error_topic"))
+  {
+    this->poseErrorTopic = _sdf->Get<std::string>("pose_error_topic");
+  }
   this->poseErrorPub = this->rosNode->advertise<std_msgs::Float64>(
     this->poseErrorTopic, 100);
+
+  if (_sdf->HasElement("rms_error_topic"))
+  {
+    this->meanErrorTopic = _sdf->Get<std::string>("rms_error_topic");
+  }
   this->meanErrorPub  = this->rosNode->advertise<std_msgs::Float64>(
     this->meanErrorTopic, 100);
 

--- a/vrx_gazebo/src/wayfinding_scoring_plugin.cc
+++ b/vrx_gazebo/src/wayfinding_scoring_plugin.cc
@@ -97,14 +97,26 @@ void WayfindingScoringPlugin::Load(gazebo::physics::WorldPtr _world,
 
   // Setup ROS node and publisher
   this->rosNode.reset(new ros::NodeHandle());
+  if (_sdf->HasElement("waypoints_topic"))
+  {
+    this->waypointsTopic = _sdf->Get<std::string>("waypoints_topic");
+  }
   this->waypointsPub =
     this->rosNode->advertise<geographic_msgs::GeoPath>(
       this->waypointsTopic, 10, true);
 
+  if (_sdf->HasElement("min_errors_topic"))
+  {
+    this->minErrorsTopic = _sdf->Get<std::string>("min_errors_topic");
+  }
   this->minErrorsPub =
     this->rosNode->advertise<std_msgs::Float64MultiArray>(
       this->minErrorsTopic, 100);
 
+  if (_sdf->HasElement("mean_error_topic"))
+  {
+    this->meanErrorTopic = _sdf->Get<std::string>("mean_error_topic");
+  }
   this->meanErrorPub =
     this->rosNode->advertise<std_msgs::Float64>(
       this->meanErrorTopic, 100);


### PR DESCRIPTION
Allow custom topics to be used for station-keeping and wayfinding tasks, to support VORC.

Test by editing existing world files for the tasks, e.g. add custom tags under the plugin in  `worlds/stationkeeping_task.world.xacro`:
```
  <plugin name="stationkeeping_scoring_plugin"
          filename="libstationkeeping_scoring_plugin.so">
      <goal_topic>/aaaaaaaaaaaaaaaaaaaaaaa</goal_topic>
      <rms_error_topic>/bbbbbbbbbbbbbbbbbbb</rms_error_topic>
      <pose_error_topic>/ccccccccccccccccccc</pose_error_topic>
```
```
$ roslaunch vrx_gazebo station_keeping.launch
$ rostopic list
/aaaaaaaaaaaaaaaaaaaaaaa
/bbbbbbbbbbbbbbbbbbb
/ccccccccccccccccccc
/clock
/gazebo/link_states
…
```

Similarly for wayfinding task in `worlds/wayfinding_task.world.xacro`:
```
    <plugin name="wayfinding_scoring_plugin"
            filename="libwayfinding_scoring_plugin.so">
      <waypoints_topic>/aaaaaaaaaaaaaaaaaaa</waypoints_topic>
      <min_errors_topic>/bbbbbbbbbbbbbbbbbbb</min_errors_topic>
      <mean_error_topic>/ccccccccccccccccccc</mean_error_topic>
```
```
$ roslaunch vrx_gazebo wayfinding.launch 
$ rostopic list
/aaaaaaaaaaaaaaaaaaa
/bbbbbbbbbbbbbbbbbbb
/ccccccccccccccccccc
/clock
/gazebo/link_states
...
```

At some point, if it’s in the plans, it’d be nice to have these custom parameters in actual test scripts.
