### PR TITLE
Set CMake 3.1+ policies explicitly to remove warnings

### DIFF
--- a/usv_gazebo_plugins/CMakeLists.txt
+++ b/usv_gazebo_plugins/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(usv_gazebo_plugins)
+
+# Set policy for CMake 3.1+, FindBoost.cmake dependency of gazebo uses quoted
+# variables in if()
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 OLD)
+endif()
+
 find_package(catkin REQUIRED COMPONENTS gazebo_dev roscpp message_generation xacro wave_gazebo_plugins usv_msgs)
 find_package(Eigen3 REQUIRED)
 

--- a/usv_gazebo_plugins/CMakeLists.txt
+++ b/usv_gazebo_plugins/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(usv_gazebo_plugins)
 
-# Set policy for CMake 3.1+, FindBoost.cmake dependency of gazebo uses quoted
-# variables in if()
+# Set policy for CMake 3.1+. Use OLD policy to let FindBoost.cmake, dependency
+# of gazebo, use quoted variables in if()
 if(POLICY CMP0054)
   cmake_policy(SET CMP0054 OLD)
 endif()

--- a/vrx_gazebo/CMakeLists.txt
+++ b/vrx_gazebo/CMakeLists.txt
@@ -7,13 +7,30 @@ if(NOT ERB_EXE_PATH)
   message(FATAL_ERROR "Could not find the `erb` tool.  Try `sudo apt-get install ruby`")
 endif()
 
-set (CMAKE_AUTOMOC ON)
-set (CMAKE_AUTOUIC ON)
+# For Qt
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
 
-find_package (Qt5Widgets REQUIRED)
-find_package (Qt5Core REQUIRED)
-find_package (Protobuf REQUIRED)
-find_package (gazebo REQUIRED)
+# To appease policy warnings in CMake 3.10+. See `cmake --help-policy CMP00##`
+if (POLICY CMP0071)
+  # Set to NEW to let AUTOMOC and AUTOUIC process generated files
+  cmake_policy(SET CMP0071 NEW)
+endif()
+# Set policy for CMake 3.1+, FindBoost.cmake dependency of gazebo uses quoted
+# variables in if()
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 OLD)
+endif()
+if(POLICY CMP0046)
+  # Use OLD policy to be able to use *_generate_services_cpp before they exist,
+  # without error.
+  cmake_policy(SET CMP0046 OLD)
+endif()
+
+find_package(Qt5Widgets REQUIRED)
+find_package(Qt5Core REQUIRED)
+find_package(Protobuf REQUIRED)
+find_package(gazebo REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS
   message_generation
@@ -184,7 +201,7 @@ install(TARGETS scan_dock_scoring_plugin
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-if("${GAZEBO_MAJOR_VERSION}" GREATER "7")
+if(${GAZEBO_MAJOR_VERSION} GREATER 7)
   # Plugin for Task Info GUI Overlay
   add_library(gui_task_widget SHARED ${headers_MOC}
          	src/gui_task_widget.cc
@@ -218,7 +235,7 @@ install(TARGETS perception_scoring_plugin
 )
 
 # Dock base files that need to be processed with erb
-set (dock_base_erb_files
+set(dock_base_erb_files
   models/dock_2016_base/model.sdf.erb
   models/dock_2018_base/model.sdf.erb
   models/dock_2016_base_dynamic/model.sdf.erb
@@ -226,7 +243,7 @@ set (dock_base_erb_files
 )
 
 # Dock files that need to be processed with erb
-set (dock_erb_files
+set(dock_erb_files
   models/dock_2016/model.sdf.erb
   models/dock_2018/model.sdf.erb
   models/dock_2016_dynamic/model.sdf.erb
@@ -319,7 +336,7 @@ catkin_install_python(PROGRAMS
     nodes/key2thrust_angle.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-if (CATKIN_ENABLE_TESTING)
+if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   add_rostest_gtest(sandisland_test
                     test/sandisland.test

--- a/vrx_gazebo/CMakeLists.txt
+++ b/vrx_gazebo/CMakeLists.txt
@@ -11,19 +11,14 @@ endif()
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
-# To appease policy warnings in CMake 3.10+. See `cmake --help-policy CMP00##`
-if (POLICY CMP0071)
-  # Set to NEW to let AUTOMOC and AUTOUIC process generated files
-  cmake_policy(SET CMP0071 NEW)
-endif()
-# Set policy for CMake 3.1+, FindBoost.cmake dependency of gazebo uses quoted
-# variables in if()
+# Set policy for CMake 3.1+. Use OLD policy to let FindBoost.cmake, dependency
+# of gazebo, use quoted variables in if()
 if(POLICY CMP0054)
   cmake_policy(SET CMP0054 OLD)
 endif()
+# Use OLD policy to be able to use *_generate_services_cpp before they exist,
+# without error.
 if(POLICY CMP0046)
-  # Use OLD policy to be able to use *_generate_services_cpp before they exist,
-  # without error.
   cmake_policy(SET CMP0046 OLD)
 endif()
 

--- a/vrx_gazebo/msgs/CMakeLists.txt
+++ b/vrx_gazebo/msgs/CMakeLists.txt
@@ -1,5 +1,11 @@
 find_package(Protobuf REQUIRED)
 
+# To remove policy warnings in CMake 3.10. See `cmake --help-policy CMP0071`
+if(POLICY CMP0071)
+  # Set to NEW to let AUTOMOC and AUTOUIC process generated files
+  cmake_policy(SET CMP0071 NEW)
+endif()
+
 set(PROTOBUF_IMPORT_DIRS)
 foreach(ITR ${GAZEBO_INCLUDE_DIRS})
   if(ITR MATCHES ".*gazebo-[0-11.]+$")
@@ -16,7 +22,7 @@ link_directories(
   ${GAZEBO_LIBRARY_DIRS}
 )
 
-set (msgs1
+set(msgs1
   light_buoy_colors.proto
 )
 PROTOBUF_GENERATE_CPP(PROTO_SRCS1 PROTO_HDRS ${msgs1})
@@ -28,7 +34,7 @@ target_link_libraries(light_buoy_colors_msgs
   ${GAZEBO_PROTO_LIBRARIES}
 )
 
-set (msgs2
+set(msgs2
   dock_placard.proto
 )
 PROTOBUF_GENERATE_CPP(PROTO_SRCS2 PROTO_HDRS ${msgs2})

--- a/wamv_gazebo/CMakeLists.txt
+++ b/wamv_gazebo/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(wamv_gazebo)
+
+# Set policy for CMake 3.1+, FindBoost.cmake dependency of gazebo uses quoted
+# variables in if()
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 OLD)
+endif()
+
 find_package(catkin REQUIRED COMPONENTS
   wamv_description
   usv_gazebo_plugins

--- a/wamv_gazebo/CMakeLists.txt
+++ b/wamv_gazebo/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(wamv_gazebo)
 
-# Set policy for CMake 3.1+, FindBoost.cmake dependency of gazebo uses quoted
-# variables in if()
+# Set policy for CMake 3.1+. Use OLD policy to let FindBoost.cmake, dependency
+# of gazebo, use quoted variables in if()
 if(POLICY CMP0054)
   cmake_policy(SET CMP0054 OLD)
 endif()

--- a/wave_gazebo_plugins/CMakeLists.txt
+++ b/wave_gazebo_plugins/CMakeLists.txt
@@ -19,6 +19,12 @@ else()
     message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++14 support. Please use a different C++ compiler.")
 endif()
 
+# Set policy for CMake 3.1+, FindBoost.cmake dependency of gazebo uses quoted
+# variables in if()
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 OLD)
+endif()
+
 ###############################################################################
 # Other dependencies...
 

--- a/wave_gazebo_plugins/CMakeLists.txt
+++ b/wave_gazebo_plugins/CMakeLists.txt
@@ -19,8 +19,8 @@ else()
     message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++14 support. Please use a different C++ compiler.")
 endif()
 
-# Set policy for CMake 3.1+, FindBoost.cmake dependency of gazebo uses quoted
-# variables in if()
+# Set policy for CMake 3.1+. Use OLD policy to let FindBoost.cmake, dependency
+# of gazebo, use quoted variables in if()
 if(POLICY CMP0054)
   cmake_policy(SET CMP0054 OLD)
 endif()


### PR DESCRIPTION
To support adding CI for VORC https://github.com/osrf/vorc/pull/21

CMake policies [CMP0046](https://cmake.org/cmake/help/v3.0/policy/CMP0046.html), [CMP0054](https://cmake.org/cmake/help/v3.1/policy/CMP0054.html), and [CMP0071](https://cmake.org/cmake/help/git-stage/policy/CMP0071.html) started introducing warnings in CMake 3.10.2, 3.1.3, and 3.10, respectively.

These produce warnings when using newer CMake versions.

To reproduce the warnings, on Ubuntu 18.04 (target platform for ROS Melodic, `apt` ships CMake 3.10.2), compile from scratch:
```
$ rm -rf build devel log install
$ catkin_make
```

This PR removes those warnings properly.

`OLD` and `NEW` flags are set explicitly to appease CMake warnings.
Specifically, CMP0054 is for using variables in quotes in `FindBoost.cmake`, which we cannot fix.
CMP0071 is for using `AUTOMOC` and `AUTOUIC` in `vrx_gazebo` with generated files in `vrx_gazebo/msgs` (from protobuf).
CMP0046 is for building messages and services in the same package as where they're used, by `add_dependencies(*generate_messages_cpp)` and `generate_services_cpp`, packages that do not exist yet until after everything is built.