### PR TITLE
Add per-plugin exit flag to scoring plugin

### DIFF
--- a/vrx_gazebo/include/vrx_gazebo/scoring_plugin.hh
+++ b/vrx_gazebo/include/vrx_gazebo/scoring_plugin.hh
@@ -71,6 +71,12 @@
 /// publish every instant a collision with the wamv is happening.
 /// Default is /vrx/debug/contact.
 ///
+/// <per_plugin_exit_on_completion>: Specifies whether to shut down after
+/// completion, for this specific plugin.
+/// Different from environment variable VRX_EXIT_ON_COMPLETION, which is for
+/// every plugin in the current shell. Environment variable overwrites this
+/// parameter.
+///
 /// <initial_state_duration>: Optional parameter (double type) specifying the
 /// amount of seconds that the plugin will be in the "initial" state.
 ///
@@ -313,6 +319,9 @@ class ScoringPlugin : public gazebo::WorldPlugin
 
   /// \brief Score in case of timeout - added for Navigation task
   private: double timeoutScore = -1.0;
+
+  /// \brief Whether to shut down after last gate is crossed.
+  private: bool perPluginExitOnCompletion = true;
 };
 
 #endif

--- a/vrx_gazebo/worlds/xacros/perception.xacro
+++ b/vrx_gazebo/worlds/xacros/perception.xacro
@@ -18,6 +18,8 @@
       <contact_debug_topic>/${competition}/debug/contact</contact_debug_topic>
       <landmark_topic>/${competition}/perception/landmark</landmark_topic>
 
+      <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
+
       <!-- Parameters for PopulationPlugin -->
       <loop_forever>false</loop_forever>
       <frame>${namespace}</frame>

--- a/vrx_gazebo/worlds/xacros/stationkeeping.xacro
+++ b/vrx_gazebo/worlds/xacros/stationkeeping.xacro
@@ -12,6 +12,8 @@
       <task_info_topic>/${competition}/task/info</task_info_topic>
       <contact_debug_topic>/${competition}/debug/contact</contact_debug_topic>
 
+      <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
+
       <!-- Goal as Latitude, Longitude, Yaw -->
       <goal_pose>${lat} ${lon} ${heading}</goal_pose>
       <initial_state_duration>10</initial_state_duration>

--- a/vrx_gazebo/worlds/xacros/wayfinding.xacro
+++ b/vrx_gazebo/worlds/xacros/wayfinding.xacro
@@ -15,6 +15,8 @@
       <task_info_topic>/${competition}/task/info</task_info_topic>
       <contact_debug_topic>/${competition}/debug/contact</contact_debug_topic>
 
+      <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
+
       <!-- Goal as Latitude, Longitude, Yaw -->
       <waypoints>
         <xacro:insert_block name="waypoints"/>


### PR DESCRIPTION
Adds optional SDF plugin parameter `<per_plugin_exit_on_completion>` to base class scoring plugin.
Defaults to true, which is original behavior.
If environment variable `VRX_EXIT_ON_COMPLETION` is specified, overwrites this parameter, as original behavior.

This allows each plugin to specify optionally to NOT shut down after the status changes to `"finished"`, which allows the combined use of plugins, one task after another, in the same run.
Example usage: VORC gymkhana task, where navigation task is followed by stationkeeping, and we don't want to shut down Gazebo when the navigation task has been completed.