### PR TITLE
Generate acoustic pinger YAML file for Gymkhana evaluation

### DIFF
--- a/vrx_gazebo/launch/generate_worlds.launch
+++ b/vrx_gazebo/launch/generate_worlds.launch
@@ -14,11 +14,16 @@
   <arg name="world_target"/>
   <param name="world_target" value="$(arg world_target)"/>
 
+  <!-- Only used for gymkhana task for pinger position configuration YAML -->
+  <arg name="config_target" default=""/>
+  <param name="config_target" value="$(arg config_target)"/>
+
   <arg name="competition_pkg" default="vrx_gazebo"/>
   <param name="competition_pkg" value="$(arg competition_pkg)"/>
 
   <arg name="world_name" default="robotx_example_course"/>
   <param name="world_name" value="$(arg world_name)"/>
 
-  <node name="world_gen" pkg="vrx_gazebo" type="generate_worlds" required="true" output="screen"/>
+  <node name="world_gen" pkg="vrx_gazebo" type="generate_worlds" required="true"
+    output="screen"/>
 </launch>

--- a/vrx_gazebo/src/vrx_gazebo/generate_worlds.py
+++ b/vrx_gazebo/src/vrx_gazebo/generate_worlds.py
@@ -99,7 +99,8 @@ def world_gen(coordinate={}, master={}, config_file=None):
                         world[macro_name].append({})
 
         # Only used for gymkhana task
-        if axis['yamls'] is not None and \
+        if 'yamls' in axis and \
+                axis['yamls'] is not None and \
                 coordinate[axis_name] in axis['yamls']:
             # Dump the subtree under this trial into a YAML file
             params = axis['yamls'][coordinate[axis_name]]


### PR DESCRIPTION
Probably not the most elegant solution, but as generic and quick as I could do.

I put the YAML generation where it is, because everything from `create_xacro_file()` downstream is creating a xacro file from a dictionary, pretty generic code, so the YAML stuff needed to go above that level.

Unfortunately, this means we need to duplicate the specification of the pinger position in the vrx-docker task_config YAML file, given the way the gymkhana scoring plugin is currently implemented.

The alternative is to specify the pinger position only once in the YAML file, but then here we would need to check for `pinger_[x | y | z]` inside `create_xacro_file()` and generated the YAML file from there. That would make the code too coupled and cluttered with specific checks.