### PR TITLE
Update GPS datum to more closely match nautical chart

### DIFF
--- a/vrx_gazebo/worlds/sandisland.xacro
+++ b/vrx_gazebo/worlds/sandisland.xacro
@@ -15,8 +15,8 @@
     <spherical_coordinates>
       <surface_model>EARTH_WGS84</surface_model>
       <world_frame_orientation>ENU</world_frame_orientation>
-      <latitude_deg>21.30996</latitude_deg>
-      <longitude_deg>-157.8901</longitude_deg>
+      <latitude_deg>21.31030</latitude_deg>
+      <longitude_deg>-157.8908</longitude_deg>
       <elevation>0.0</elevation>
       <!-- For legacy gazebo reasons, need to rotate -->
       <!--<heading_deg>180</heading_deg>-->

--- a/vrx_gazebo/worlds/stationkeeping_task.world.xacro
+++ b/vrx_gazebo/worlds/stationkeeping_task.world.xacro
@@ -25,7 +25,7 @@
       <vehicle>wamv</vehicle>
       <task_name>stationkeeping</task_name>
       <!-- Goal as Latitude, Longitude, Yaw -->
-      <goal_pose>21.31091 -157.88868 0.0 </goal_pose>
+      <goal_pose>21.31125 -157.88938 0.0 </goal_pose>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>

--- a/vrx_gazebo/worlds/wayfinding_task.world.xacro
+++ b/vrx_gazebo/worlds/wayfinding_task.world.xacro
@@ -27,15 +27,15 @@
       <waypoints>
         <!-- Approx. starting point of wamv -->
         <waypoint>
-          <pose>21.3109331464 -157.888576027 1.21756121843</pose>
+          <pose>21.3112720364 -157.889280727 1.21756121843</pose>
         </waypoint>
         <!-- A waypoint -->
         <waypoint>
-          <pose>21.30996 -157.8901 1.0</pose>
+          <pose>21.3103 -157.8908 1.0</pose>
         </waypoint>
         <!-- Another waypoint -->
         <waypoint>
-          <pose>21.31 -157.89 1.0</pose>
+          <pose>21.3103 -157.8907 1.0</pose>
         </waypoint>
       </waypoints>
       <initial_state_duration>10</initial_state_duration>

--- a/vrx_gazebo/worlds/xacros/sandisland_minus_scene.xacro
+++ b/vrx_gazebo/worlds/xacros/sandisland_minus_scene.xacro
@@ -6,8 +6,8 @@
     <spherical_coordinates>
       <surface_model>EARTH_WGS84</surface_model>
       <world_frame_orientation>ENU</world_frame_orientation>
-      <latitude_deg>21.30996</latitude_deg>
-      <longitude_deg>-157.8901</longitude_deg>
+      <latitude_deg>21.31030</latitude_deg>
+      <longitude_deg>-157.8908</longitude_deg>
       <elevation>0.0</elevation>
       <!-- For legacy gazebo reasons, need to rotate -->
       <!--<heading_deg>180</heading_deg>-->

--- a/vrx_gazebo/worlds/xacros/stationkeeping.xacro
+++ b/vrx_gazebo/worlds/xacros/stationkeeping.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <world xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="stationkeeping" params="**wp_markers lat:=21.31091 lon:=-157.88868 heading:=0.0 namespace:=wamv competition:=vrx">
+  <xacro:macro name="stationkeeping" params="**wp_markers lat:=21.31125 lon:=-157.88938 heading:=0.0 namespace:=wamv competition:=vrx">
     <plugin name="stationkeeping_scoring_plugin"
           filename="libstationkeeping_scoring_plugin.so">
       <vehicle>${namespace}</vehicle>

--- a/vrx_gazebo/worlds/yamls/wayfinding_deep.yaml
+++ b/vrx_gazebo/worlds/yamls/wayfinding_deep.yaml
@@ -15,13 +15,13 @@ tasks:
             wayfinding:
                 - /**waypoints: "
                 <waypoint>
-                  <pose>21.3109331464 -157.888576027 1.21756121843</pose>
+                  <pose>21.3112720364 -157.889280727 1.21756121843</pose>
                 </waypoint>
                 <waypoint>
-                  <pose>21.30996 -157.8901 1.0</pose>
+                  <pose>21.3103 -157.8908 1.0</pose>
                 </waypoint>
                 <waypoint>
-                  <pose>21.31 -157.89 1.0</pose>
+                  <pose>21.3103 -157.8907 1.0</pose>
                 </waypoint>"
 waves:
     steps: 2

--- a/vrx_gazebo/worlds/yamls/wayfinding_shallow.yaml
+++ b/vrx_gazebo/worlds/yamls/wayfinding_shallow.yaml
@@ -15,13 +15,13 @@ tasks:
             wayfinding:
                 - /**waypoints: "
                 <waypoint>
-                  <pose>21.3109331464 -157.888576027 1.21756121843</pose>
+                  <pose>21.3112720364 -157.889280727 1.21756121843</pose>
                 </waypoint>
                 <waypoint>
-                  <pose>21.30996 -157.8901 1.0</pose>
+                  <pose>21.3103 -157.8908 1.0</pose>
                 </waypoint>
                 <waypoint>
-                  <pose>21.31 -157.89 1.0</pose>
+                  <pose>21.3103 -157.8907 1.0</pose>
                 </waypoint>"
     macros:
         ocean_waves:

--- a/wamv_gazebo/launch/localization_example.launch
+++ b/wamv_gazebo/launch/localization_example.launch
@@ -53,7 +53,7 @@
     <param name="broadcast_utm_transform" value="true"/>
     <param name="wait_for_datum" value="true"/>
     <param name="use_odometry_yaw" value="true"/>
-    <rosparam param="datum">[21.30996, -157.8901]</rosparam>
+    <rosparam param="datum">[21.3103, -157.8908]</rosparam>
     <param name="yaw_offset" value="0"/>
     <param name="publish_filtered_gps" value="true"/>
     <remap to="/wamv/sensors/gps/gps/fix" from="/wamv/robot_localization/gps/fix" />

--- a/wamv_gazebo/urdf/sensors/wamv_gps.xacro
+++ b/wamv_gazebo/urdf/sensors/wamv_gps.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="wamv_gps" params="name:=gps x:=0.3 y:=0 z:=1.3 R:=0 P:=0 Y:=0 lat:=21.30996 lon:=-157.8901 elev:=0.0 update_rate:=15">
+  <xacro:macro name="wamv_gps" params="name:=gps x:=0.3 y:=0 z:=1.3 R:=0 P:=0 Y:=0 lat:=21.3103 lon:=-157.8907 elev:=0.0 update_rate:=15">
     <link name="${name}_link">
       <visual name="${name}_visual">
         <geometry>


### PR DESCRIPTION
Allows the use of nautical charts and other real-world geo-referenced maps for mission planning and monitoring.

On a related note, the hector gazebo gps plugin can now read the world's datum making models using the plugin more portable.
https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/commit/8e2a2a4664330387b68d31f42d0c4de290d33e80