### PR TITLE
Removing buoy generator b/c need to port to Python 3

### DIFF
--- a/vrx_gazebo/CMakeLists.txt
+++ b/vrx_gazebo/CMakeLists.txt
@@ -301,12 +301,13 @@ xacro_add_files(
   ${XACRO_INORDER} INSTALL DESTINATION worlds
 )
 # Generate obstacle course
-add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/models/robotx_2018_qualifying_avoid_obstacles_buoys/model.sdf
-  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_avoid_obstacles_buoys
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_avoid_obstacles_buoys --seed 1337 --a3 6 --a5 7 --a7 7 > ${CMAKE_CURRENT_SOURCE_DIR}/models/robotx_2018_qualifying_avoid_obstacles_buoys/model.sdf
-)
-add_custom_target(${PROJECT_NAME}_generate_obstacle_course_buoys ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/models/robotx_2018_qualifying_avoid_obstacles_buoys/model.sdf)
+# TODO Convert to Python3 for Noetic
+#add_custom_command(
+#  OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/models/robotx_2018_qualifying_avoid_obstacles_buoys/model.sdf
+#  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_avoid_obstacles_buoys
+#  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/generate_avoid_obstacles_buoys --seed 1337 --a3 6 --a5 7 --a7 7 > ${CMAKE_CURRENT_SOURCE_DIR}/models/robotx_2018_qualifying_avoid_obstacles_buoys/model.sdf
+#)
+#add_custom_target(${PROJECT_NAME}_generate_obstacle_course_buoys ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/models/robotx_2018_qualifying_avoid_obstacles_buoys/model.sdf)
 
 # Install all the config files
 install(DIRECTORY config/


### PR DESCRIPTION
Working with Noetic on Cloudsim.  The buoy generator program uses Python 2.  For now, commented this out of the the CMakelists.txt file and added https://github.com/osrf/vrx/issues/242 to remind us to do this later.