### PR TITLE
Teleop thruster articulation

### DIFF
--- a/vrx_gazebo/config/diffdrive.yaml
+++ b/vrx_gazebo/config/diffdrive.yaml
@@ -21,7 +21,7 @@ teleop:
   turn_left_thruster:
     type: topic
     message_type: std_msgs/Float32
-    topic_name: left_thrust_angle
+    topic_name: /wamv/thrusters/left_thrust_angle
     axis_mappings:
       - axis: 2
         target: data
@@ -30,7 +30,7 @@ teleop:
   turn_right_thruster:
     type: topic
     message_type: std_msgs/Float32
-    topic_name: right_thrust_angle
+    topic_name: /wamv/thrusters/right_thrust_angle
     axis_mappings:
       - axis: 2
         target: data


### PR DESCRIPTION
Addresses this issue: https://github.com/osrf/vrx/issues/262

Updated config file for joy teleop node, added more instructions to the wiki https://github.com/osrf/vrx/wiki/driving_teleop_tutorial and verified that both keyboard and gamepad teleop support thruster articulation examples.