### PR TITLE
Update Station Keeping Task

### DIFF
--- a/vrx_gazebo/launch/station_keeping.launch
+++ b/vrx_gazebo/launch/station_keeping.launch
@@ -13,12 +13,12 @@
   <arg name="namespace" default="wamv"/>
 
   <!-- Initial USV location and attitude-->
-  <arg name="x" default="158" />
-  <arg name="y" default="108" />
+  <arg name="x" default="532" />
+  <arg name="y" default="-162" />
   <arg name="z" default="0.1" />
   <arg name="P" default="0" />
   <arg name="R" default="0" />
-  <arg name="Y" default="-2.76" />
+  <arg name="Y" default="-2.15" />
 
   <!-- Allow user specified thruster configurations
        H = stern trusters on each hull

--- a/vrx_gazebo/worlds/stationkeeping_task.world.xacro
+++ b/vrx_gazebo/worlds/stationkeeping_task.world.xacro
@@ -2,8 +2,8 @@
 <!-- World containing sandisland model and some course challenges -->
 <sdf version="1.6" xmlns:xacro="http://ros.org/wiki/xacro">
   <world name="robotx_stationkeeping">
-    <xacro:include filename="$(find vrx_gazebo)/worlds/sandisland.xacro" />
-    <xacro:sandisland />
+    <xacro:include filename="$(find vrx_gazebo)/worlds/sydneyregatta.xacro" />
+    <xacro:sydneyregatta />
     <!--Waves-->
     <xacro:include filename="$(find wave_gazebo)/world_models/ocean_waves/model.xacro"/>
     <xacro:ocean_waves/>
@@ -25,7 +25,7 @@
       <vehicle>wamv</vehicle>
       <task_name>stationkeeping</task_name>
       <!-- Goal as Latitude, Longitude, Yaw -->
-      <goal_pose>21.31091 -157.88868 0.0 </goal_pose>
+      <goal_pose>-33.722702498 150.67402097002 0.0 </goal_pose>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>

--- a/vrx_gazebo/worlds/sydneyregatta.xacro
+++ b/vrx_gazebo/worlds/sydneyregatta.xacro
@@ -19,7 +19,7 @@
       <longitude_deg>150.679736</longitude_deg>
       <elevation>0.0</elevation>
       <!-- For legacy gazebo reasons, need to rotate -->
-      <!--<heading_deg>180</heading_deg>-->
+      <heading_deg>180</heading_deg>
     </spherical_coordinates>
 
     <!-- A global light source -->

--- a/wamv_gazebo/urdf/sensors/wamv_gps.xacro
+++ b/wamv_gazebo/urdf/sensors/wamv_gps.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="wamv_gps" params="name:=gps x:=0.3 y:=0 z:=1.3 R:=0 P:=0 Y:=0 lat:=21.30996 lon:=-157.8901 elev:=0.0 update_rate:=15">
+  <xacro:macro name="wamv_gps" params="name:=gps x:=0.3 y:=0 z:=1.3 R:=0 P:=0 Y:=0 lat:=-33.724223 lon:=150.679736 elev:=0.0 update_rate:=15">
     <link name="${namespace}/${name}_link">
       <visual name="${name}_visual">
         <geometry>
@@ -49,7 +49,7 @@
         <referenceLatitude>${lat}</referenceLatitude>
         <referenceLongitude>${lon}</referenceLongitude>
         <referenceAltitude>${elev}</referenceAltitude>
-        <referenceHeading>90</referenceHeading>
+        <referenceHeading>270</referenceHeading>
         <offset>0.0 0.0 0.0</offset>
         <drift>0.0 0.0 0.0</drift>
         <gaussianNoise>0 0 0</gaussianNoise>


### PR DESCRIPTION
##### Updates the station keeping task:
- Set in sydneyregatta world
- GPS headings updated
- Goal position updated

To run:
`roslaunch vrx_gazebo station_keeping.launch`

To move WAM-V via keyboard:
`roslaunch vrx_gazebo usv_keydrive.launch`

To monitor score:
`rostopic echo /vrx/station_keeping/pose_error`

##### Task Summary

Navigate to the goal pose and hold station. The best solutions will minimize the difference between the goal pose and the actual pose of the vehicle over the duration of the task.

Start the example: roslaunch vrx_gazebo station_keeping.launch
Subscribe to the task-specific topics provided by the stationkeeping scoring plugin:
The station-keeping goal (given as a geographic_msgs/GeoPoseStamped message):
rostopic echo /vrx/station_keeping/goal
The current position error values:
rostopic echo /vrx/station_keeping/pose_error
rostopic echo /vrx/station_keeping/rms_error
For implementation details, see "4.1.1. Task 1: Station-Keeping" in the Competition and Task Descriptions, or refer to the stationkeeping scoring plugin.