### PR TITLE
Create new markers without passing Id

### DIFF
--- a/vrx_gazebo/include/vrx_gazebo/waypoint_markers.hh
+++ b/vrx_gazebo/include/vrx_gazebo/waypoint_markers.hh
@@ -91,7 +91,7 @@ class WaypointMarkers
   private: double height;
 
   /// \brief If an ID is not specified, the markers will start using this one.
-  private: int id;
+  private: int id = 0;
 
 #if GAZEBO_MAJOR_VERSION >= 8
   /// \brief gazebo transport node

--- a/vrx_gazebo/include/vrx_gazebo/waypoint_markers.hh
+++ b/vrx_gazebo/include/vrx_gazebo/waypoint_markers.hh
@@ -35,7 +35,9 @@
 ///           for marker. Default: Gazebo/Green
 /// scaling: Optional parameter (vector type) to specify marker scaling.
 ///          Default: 0.2 0.2 1.5
-/// height: Optional parameter (double type) height of marker above water
+/// height: Optional parameter (double type) height of marker above water.
+/// initial_id: Optional parameter (int type) to be used as initial ID when
+/// drawing markers without explicitly specifying ID.
 /// E.g.
 /// <markers>
 ///   <material>Gazebo/Green</material>
@@ -67,6 +69,15 @@ class WaypointMarkers
   public: bool DrawMarker(int _marker_id, double _x, double _y,
       double _yaw, std::string _text = "");
 
+  /// \brief Draw a new waypoint marker in Gazebo
+  /// \param[in] _x X coordinate of waypoint marker
+  /// \param[in] _y Y coordinate of waypoint marker
+  /// \param[in] _yaw orientation of waypoint marker in radians
+  /// \param[in] _text (optional) Text above waypoint marker
+  /// \return Returns true if marker is successfully sent to Gazebo
+  public: bool DrawMarker(double _x, double _y, double _yaw,
+    std::string _text = "");
+
   /// \brief Namespace for Gazebo markers
   private: std::string ns;
 
@@ -78,6 +89,9 @@ class WaypointMarkers
 
   /// \brief Height of marker above water
   private: double height;
+
+  /// \brief If an ID is not specified, the markers will start using this one.
+  private: int id;
 
 #if GAZEBO_MAJOR_VERSION >= 8
   /// \brief gazebo transport node

--- a/vrx_gazebo/models/crocodile_buoy/model.sdf
+++ b/vrx_gazebo/models/crocodile_buoy/model.sdf
@@ -58,6 +58,7 @@
         <material>Gazebo/Red</material>
         <scaling>0.2 0.2 2.0</scaling>
         <height>0.5</height>
+        <initial_id>20</initial_id>
       </markers> -->
     </plugin>
   </model>

--- a/vrx_gazebo/models/platypus_buoy/model.sdf
+++ b/vrx_gazebo/models/platypus_buoy/model.sdf
@@ -58,6 +58,7 @@
         <material>Gazebo/Blue</material>
         <scaling>0.2 0.2 2.0</scaling>
         <height>0.5</height>
+        <initial_id>10</initial_id>
       </markers> -->
     </plugin>
   </model>

--- a/vrx_gazebo/models/turtle_buoy/model.sdf
+++ b/vrx_gazebo/models/turtle_buoy/model.sdf
@@ -59,6 +59,7 @@
         <material>Gazebo/Green</material>
         <scaling>0.2 0.2 2.0</scaling>
         <height>0.5</height>
+        <initial_id>0</initial_id>
       </markers> -->
     </plugin>
   </model>

--- a/vrx_gazebo/src/follow_plugin.cc
+++ b/vrx_gazebo/src/follow_plugin.cc
@@ -94,7 +94,7 @@ void FollowPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
       int markerId = 0;
       for (const auto waypoint : this->localWaypoints)
       {
-        if (!this->waypointMarkers.DrawMarker(markerId, waypoint.X(),
+        if (!this->waypointMarkers.DrawMarker(waypoint.X(),
             waypoint.Y(), 0, std::to_string(markerId)))
         {
           gzerr << "Error creating visual marker" << std::endl;

--- a/vrx_gazebo/src/waypoint_markers.cc
+++ b/vrx_gazebo/src/waypoint_markers.cc
@@ -40,6 +40,11 @@ void WaypointMarkers::Load(sdf::ElementPtr _sdf)
   {
     this->height = _sdf->Get<double>("height");
   }
+
+  if (_sdf->HasElement("initial_id"))
+  {
+    this->id = _sdf->Get<int>("initial_id");
+  }
 }
 
 /////////////////////////////////////////////////
@@ -50,6 +55,13 @@ bool WaypointMarkers::IsAvailable()
 #else
   return false;
 #endif
+}
+
+/////////////////////////////////////////////////
+bool WaypointMarkers::DrawMarker(double _x, double _y, double _yaw,
+  std::string _text)
+{
+  return this->DrawMarker(this->id++, _x, _y, _yaw, _text);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
We had a minor issue with the way markers were designed. We always had to pass an ID to the `DrawMarker()` function. This was causing a problem when multiple plugins were using this function without knowing each other. All of the plugins started using the same IDs (starting with `0`), and then, sharing the same IDs creating an undesired effect.

This pull request allows to call `DrawMarker()` without explicitly passing an Id. If that's the case, the plugin will use an internal `id` member variable than can be optionally initialized with an `<initial_id>` SDF parameter. 

A second alternative would be to add this `<initial_id>` to each plugin using markers (passing different values to each of the plugins) and not having to modify the `WaypointMarkers` class. However that requires more code changes than the one proposed here.

You can see that the markers are now correctly displayed if we enable them in all of the animal buoys.

![marker_tweaks](https://user-images.githubusercontent.com/1440739/130992263-687559a4-0a5e-44d7-a36f-b669f6844022.png)
