### PR TITLE
Wildlife scoring plugin - part 1

### DIFF
--- a/vrx_gazebo/CMakeLists.txt
+++ b/vrx_gazebo/CMakeLists.txt
@@ -183,6 +183,18 @@ install(TARGETS navigation_scoring_plugin
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
+# Plugin for scoring the wildlife challenge task.
+add_library(wildlife_scoring_plugin src/wildlife_scoring_plugin.cc)
+target_link_libraries(wildlife_scoring_plugin
+  ${catkin_LIBRARIES}
+  scoring_plugin)
+add_dependencies(wildlife_scoring_plugin ${catkin_EXPORTED_TARGETS})
+install(TARGETS wildlife_scoring_plugin
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
 # Plugin for scoring the station keeping challenge task.
 add_library(stationkeeping_scoring_plugin src/stationkeeping_scoring_plugin.cc)
 target_link_libraries(stationkeeping_scoring_plugin
@@ -335,19 +347,20 @@ endif()
 
 # Generate world files from xacro and install
 xacro_add_files(
+  worlds/dock.world.xacro
   worlds/example_course.world.xacro
   worlds/example_course_2019.world.xacro
   worlds/gymkhana.world.xacro
   worlds/navigation_task.world.xacro
-  worlds/perception_task.world.xacro
-  worlds/sandisland.world.xacro
-  worlds/sydneyregatta.world.xacro
-  worlds/dock.world.xacro
-  worlds/scan_and_dock.world.xacro
-  worlds/stationkeeping_task.world.xacro
-  worlds/wayfinding_task.world.xacro
-  worlds/wind_test.world.xacro
   worlds/ocean.world.xacro
+  worlds/perception_task.world.xacro
+  worlds/scan_and_dock.world.xacro
+  worlds/sandisland.world.xacro
+  worlds/stationkeeping_task.world.xacro
+  worlds/sydneyregatta.world.xacro
+  worlds/wayfinding_task.world.xacro
+  worlds/wildlife_task.world.xacro
+  worlds/wind_test.world.xacro
   ${XACRO_INORDER} INSTALL DESTINATION worlds
 )
 # Generate obstacle course

--- a/vrx_gazebo/include/vrx_gazebo/navigation_scoring_plugin.hh
+++ b/vrx_gazebo/include/vrx_gazebo/navigation_scoring_plugin.hh
@@ -189,4 +189,3 @@ class NavigationScoringPlugin : public ScoringPlugin
 };
 
 #endif
-

--- a/vrx_gazebo/include/vrx_gazebo/wildlife_scoring_plugin.hh
+++ b/vrx_gazebo/include/vrx_gazebo/wildlife_scoring_plugin.hh
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef VRX_GAZEBO_WILDLIFE_SCORING_PLUGIN_HH_
+#define VRX_GAZEBO_WILDLIFE_SCORING_PLUGIN_HH_
+
+#include <ros/ros.h>
+#include <string>
+#include <vector>
+#include <gazebo/common/Events.hh>
+#include <gazebo/physics/Link.hh>
+#include <gazebo/physics/Model.hh>
+#include <gazebo/physics/World.hh>
+#include <sdf/sdf.hh>
+#include "vrx_gazebo/scoring_plugin.hh"
+
+/// \brief A plugin for computing the score of the wildlife task.
+/// This plugin derives from the generic ScoringPlugin class. Check out that
+/// plugin for other required SDF elements.
+/// This plugin uses the following SDF parameters:
+///
+/// * Required parameters:
+/// <animals_model_name>: The top level model containing all the buoy animals.
+///
+/// * Optional parameters
+///
+/// <animals_topic>: The topic that publishes the animal poses.
+///                  Defaults to "/vrx/wildlife/animals/poses"
+/// <buoys>: Specifies the collection of buoys to circumnavigate, avoid, etc.
+///
+///   <buoy>: A buoy to circumnavigate, avoid.
+///      <link_name>: The name of the main link in the buoy.
+///      <goal> "avoid", "circumnavigate_clockwise" or
+///             "circumnavigate_counterclockwise"
+/// <engagement_distance>: At less or equal than this distance, the buoy is
+///                        considered engaged. Defaults to 10 meters.
+/// <obstacle_penalty>: Specifies how many seconds are added per collision.
+///                     Defaults to 10 seconds.
+/// <time_bonus>: Time bonus granted for each goal reached. Defaults to 30 secs.
+///
+/// Here's an example:
+/// <plugin name="wildlife_scoring_plugin"
+///         filename="libwildlife_scoring_plugin.so">
+///   <!-- Common parameters -->
+///   <vehicle>wamv</vehicle>
+///   <task_name>wildlife_course</task_name>
+///   <initial_state_duration>10</initial_state_duration>
+///   <ready_state_duration>10</ready_state_duration>
+///   <running_state_duration>300</running_state_duration>
+///   <collision_buffer>10</collision_buffer>
+///   <release_joints>
+///     <joint>
+///       <name>wamv_external_pivot_joint</name>
+///     </joint>
+///     <joint>
+///       <name>wamv_external_riser</name>
+///     </joint>
+///   </release_joints>
+///
+///   <!-- wildlife specific parameters -->
+///   <animals_model_name>animal_buoys</animals_model_name>
+///   <animals_topic>/vrx/wildlife/animals/poses</animals_topic>
+///   <buoys>
+///     <buoy>
+///       <link_name>crocodile_buoy::link</link_name>
+///       <goal>avoid</goal>
+///     </buoy>
+///     <buoy>
+///       <link_name>platypus_buoy::link</link_name>
+///       <goal>circumnavigate_clockwise</goal>
+///     </buoy>
+///     <buoy>
+///       <link_name>turtle_buoy::link</link_name>
+///       <goal>circumnavigate_counterclockwise</goal>
+///     </buoy>
+///   </buoys>
+///   <engagement_distance>10.0</engagement_distance>
+///   <obstacle_penalty>10.0</obstacle_penalty>
+///   <time_bonus>30.0</time_bonus>
+///
+/// </plugin>
+class WildlifeScoringPlugin : public ScoringPlugin
+{
+  /// \brief All buoy goals.
+  private: enum class BuoyGoal
+  {
+    /// \brief The goal is to stay out of the activation area.
+    AVOID,
+
+    /// \brief The goal is to circumnavigate the buoy clockwise.
+    CIRCUMNAVIGATE_CLOCKWISE,
+
+    /// \brief The goal is to circumnavigate the buoy counterclockwise
+    CIRCUMNAVIGATE_COUNTERCLOCKWISE,
+  };
+
+  /// \brief All buoy states.
+  private: enum class BuoyState
+  {
+    /// \brief Not "in" the gate and never engaged.
+    NEVER_ENGAGED,
+
+    /// \brief Not "in" the gate but was engaged at some point.
+    NOT_ENGAGED,
+
+    /// \brief Inside the area of activation of the gate.
+    ENGAGED,
+
+    /// \brief Succesfully circumnavigated.
+    CIRCUMNAVIGATED,
+  };
+
+  /// \brief A buoy that is part of the wildlife task.
+  private: class Buoy
+  {
+    /// \brief Constructor.
+    /// \param[in] _buoyLink The buoy's main link.
+    /// \param[in] _buoyGoal The buoy's goal.
+    /// \param[in] _engagementDistance The vehicle engages with the buoy when
+    ///            the distance between them is lower or equal than this value.
+    public: Buoy(const gazebo::physics::LinkPtr _buoyLink,
+                 const BuoyGoal _buoyGoal,
+                 double _engagementDistance);
+
+    /// \brief Update the status of this buoy.
+    public: void Update();
+
+    /// \brief Set the vehicle model.
+    /// \param[in] _vehicleModel The vehicle model pointer.
+    public: void SetVehicleModel(gazebo::physics::ModelPtr _vehicleModel);
+
+    /// \brief The buoy's main link.
+    public: gazebo::physics::LinkPtr link;
+
+    /// \brief The goal.
+    public: BuoyGoal goal;
+
+    /// \brief The state of this buoy.
+    public: BuoyState state = BuoyState::NEVER_ENGAGED;
+
+    /// \brief Pointer to the vehicle that interacts with the buoy.
+    public: gazebo::physics::ModelPtr vehicleModel;
+
+    /// \brief The vehicle engages with the buoy when the distance between them
+    /// is lower or equal than this value.
+    public: double engagementDistance;
+  };
+
+  // Constructor.
+  public: WildlifeScoringPlugin();
+
+  // Documentation inherited.
+  public: void Load(gazebo::physics::WorldPtr _world,
+                    sdf::ElementPtr _sdf);
+
+  /// \brief Parse the buoys from SDF.
+  /// \param[in] _sdf The current SDF element.
+  /// \return True when the buoys were successfully parsed or false otherwise.
+  private: bool ParseBuoys(sdf::ElementPtr _sdf);
+
+  /// \brief Register a new buoy.
+  /// \param[in] _linkName The name of the main buoy's link.
+  /// \param[in] _goal The goal associated to this buoy.
+  /// \return True when the buoy has been registered or false otherwise.
+  private: bool AddBuoy(const std::string &_linkName,
+                        const std::string &_goal);
+
+  /// \brief Callback executed at every world update.
+  private: void Update();
+
+  /// \brief Set the score to 0 and change the state to "finish".
+  private: void Fail();
+
+  /// \brief Publish a new ROS message with the animal locations.
+  private: void PublishAnimalLocations();
+
+  // Documentation inherited.
+  private: void OnCollision() override;
+
+  /// \brief All the buoys.
+  private: std::vector<Buoy> buoys;
+
+  /// \brief Pointer to the update event connection.
+  private: gazebo::event::ConnectionPtr updateConnection;
+
+  /// \brief The number of WAM-V collisions.
+  private: unsigned int numCollisions = 0u;
+
+  /// \brief Number of points deducted per collision.
+  private: double obstaclePenalty = 10.0;
+
+  /// \brief The name of the topic where the animal locations are published.
+  private: std::string animalsTopic = "/vrx/wildlife_animals";
+
+  /// \brief Time bonus granted for each succcesfuly goal achieved.
+  private: double timeBonus = 30.0;
+
+  /// \brief When the vehicle is between the buoy and this distance, the vehicle
+  /// engages with the buoy.
+  private: double engagementDistance = 10.0;
+
+  /// \brief The name of the model containing all the animals.
+  private: std::string animalsModelName;
+
+  /// \brief ROS node handle.
+  private: std::unique_ptr<ros::NodeHandle> rosNode;
+
+  /// \brief Publisher for the animal locations.
+  private: ros::Publisher animalsPub;
+};
+
+#endif

--- a/vrx_gazebo/launch/wildlife.launch
+++ b/vrx_gazebo/launch/wildlife.launch
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<launch>
+  <env name="ROSCONSOLE_CONFIG_FILE" value="$(find vrx_gazebo)/config/custom_rosconsole.conf"/>
+  <!-- Gazebo world to load -->
+  <arg name="world" default="$(find vrx_gazebo)/worlds/wildlife_task.world" />
+  <!-- If true, run gazebo GUI -->
+  <arg name="gui" default="true" />
+  <!-- If true, run gazebo in verbose mode -->
+  <arg name="verbose" default="false"/>
+  <!-- Set various other gazebo arguments-->
+  <arg name="extra_gazebo_args" default=""/>
+  <!-- Start in a default namespace -->
+  <arg name="namespace" default="wamv"/>
+
+  <!-- Initial USV location and attitude-->
+  <arg name="x" default="532" />
+  <arg name="y" default="-162" />
+  <arg name="z" default="0" />
+  <arg name="P" default="0" />
+  <arg name="R" default="0" />
+  <arg name="Y" default="-2.15" />
+
+  <!-- Allow user specified thruster configurations
+       H = stern trusters on each hull
+       T = H with a lateral thruster
+       X = "holonomic" configuration -->
+  <arg name="thrust_config" default="H" />
+
+  <!-- Do we lock the vessel to the world? -->
+  <arg name="wamv_locked" default="true" />
+
+  <!-- VRX sensors enabled -->
+  <arg name="vrx_sensors_enabled" default="true" />
+
+  <!-- Start Gazebo with the world file -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="world_name"   value="$(arg world)"/>
+    <arg name="verbose"      value="$(arg verbose)"/>
+    <arg name="paused"       value="false"/>
+    <arg name="use_sim_time" value="true"/>
+    <arg name="gui"          value="$(arg gui)" />
+    <arg name="extra_gazebo_args" value="$(arg extra_gazebo_args)"/>
+  </include>
+
+  <!-- Load robot model -->
+  <arg name="urdf" default="$(find wamv_gazebo)/urdf/wamv_gazebo.urdf.xacro"/>
+  <param name="$(arg namespace)/robot_description"
+         command="$(find xacro)/xacro &#x002D;&#x002D;inorder '$(arg urdf)'
+         locked:=$(arg wamv_locked)
+         thruster_config:=$(arg thrust_config)
+         vrx_sensors_enabled:=$(arg vrx_sensors_enabled)
+         namespace:=$(arg namespace) "/>
+
+  <!-- Spawn model in Gazebo -->
+  <node name="spawn_model" pkg="gazebo_ros" type="spawn_model"
+        args="-x $(arg x) -y $(arg y) -z $(arg z)
+              -R $(arg R) -P $(arg P) -Y $(arg Y)
+              -urdf -param $(arg namespace)/robot_description -model wamv"/>
+</launch>

--- a/vrx_gazebo/models/animal_buoys/model.config
+++ b/vrx_gazebo/models/animal_buoys/model.config
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<model>
+  <name>vrx_animal_buoys</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+  <author>
+    <name>Carlos Aguero</name>
+    <email>caguero@openrobotics.org</email>
+  </author>
+  <description>
+    A set of animal buoys.
+  </description>
+</model>

--- a/vrx_gazebo/models/animal_buoys/model.sdf
+++ b/vrx_gazebo/models/animal_buoys/model.sdf
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!-- A set of animal buoys -->
+<sdf version="1.6">
+  <model name="animal_buoys">
+
+    <include>
+      <name>crocodile_buoy</name>
+      <pose>20 0 0 0 0 0</pose>
+      <uri>model://crocodile_buoy</uri>
+    </include>
+
+    <include>
+      <name>platypus_buoy</name>
+      <pose>0 0 0 0 0 0</pose>
+      <uri>model://platypus_buoy</uri>
+    </include>
+
+    <include>
+      <name>turtle_buoy</name>
+      <pose>-20 0 0 0 0 0</pose>
+      <uri>model://turtle_buoy</uri>
+    </include>
+
+  </model>
+</sdf>

--- a/vrx_gazebo/models/crocodile_buoy/model.sdf
+++ b/vrx_gazebo/models/crocodile_buoy/model.sdf
@@ -17,7 +17,7 @@
           <izz>0.1</izz>
         </inertia>
       </inertial>
-      <collision name="collision">
+      <collision name="crocodile_collision">
         <pose>0 0 0.06 0 0 0</pose>
         <geometry>
           <box>
@@ -25,13 +25,13 @@
           </box>
         </geometry>
       </collision>
-      <visual name="visual">
+      <visual name="crocodile_visual">
         <geometry>
 	        <mesh><uri>model://crocodile_buoy/meshes/crocodile.dae</uri></mesh>
         </geometry>
       </visual>
     </link>
-    <plugin name="BuoyancyPlugin" filename="libbuoyancy_gazebo_plugin.so">
+    <plugin name="CrocodrileBuoyancyPlugin" filename="libbuoyancy_gazebo_plugin.so">
       <wave_model>ocean_waves</wave_model>
       <fluid_density>1000</fluid_density>
       <fluid_level>0.0</fluid_level>

--- a/vrx_gazebo/models/platypus_buoy/model.sdf
+++ b/vrx_gazebo/models/platypus_buoy/model.sdf
@@ -17,7 +17,7 @@
           <izz>0.1</izz>
         </inertia>
       </inertial>
-      <collision name="collision">
+      <collision name="platypus_collision">
         <pose>0.02 0 0.05 0 0 0</pose>
         <geometry>
           <box>
@@ -25,13 +25,13 @@
           </box>
         </geometry>
       </collision>
-      <visual name="visual">
+      <visual name="platypus_visual">
         <geometry>
 	        <mesh><uri>model://platypus_buoy/meshes/platypus.dae</uri></mesh>
         </geometry>
       </visual>
     </link>
-    <plugin name="BuoyancyPlugin" filename="libbuoyancy_gazebo_plugin.so">
+    <plugin name="PlatypusBuoyancyPlugin" filename="libbuoyancy_gazebo_plugin.so">
       <wave_model>ocean_waves</wave_model>
       <fluid_density>1000</fluid_density>
       <fluid_level>0.0</fluid_level>

--- a/vrx_gazebo/models/turtle_buoy/model.sdf
+++ b/vrx_gazebo/models/turtle_buoy/model.sdf
@@ -17,7 +17,7 @@
           <izz>0.1</izz>
         </inertia>
       </inertial>
-      <collision name="collision">
+      <collision name="turtle_collision">
         <pose>0.08 0 0.05 0 0 0</pose>
         <geometry>
           <cylinder>
@@ -26,13 +26,13 @@
           </cylinder>
         </geometry>
       </collision>
-      <visual name="visual">
+      <visual name="turtle_visual">
         <geometry>
 	        <mesh><uri>model://turtle_buoy/meshes/turtle.dae</uri></mesh>
         </geometry>
       </visual>
     </link>
-    <plugin name="BuoyancyPlugin" filename="libbuoyancy_gazebo_plugin.so">
+    <plugin name="TurtleBuoyancyPlugin" filename="libbuoyancy_gazebo_plugin.so">
       <wave_model>ocean_waves</wave_model>
       <fluid_density>1000</fluid_density>
       <fluid_level>0.0</fluid_level>

--- a/vrx_gazebo/src/wildlife_scoring_plugin.cc
+++ b/vrx_gazebo/src/wildlife_scoring_plugin.cc
@@ -40,8 +40,14 @@ void WildlifeScoringPlugin::Buoy::Update()
   if (this->state == BuoyState::CIRCUMNAVIGATED || !this->vehicleModel)
     return;
 
+#if GAZEBO_MAJOR_VERSION >= 8
   const ignition::math::Pose3d vehiclePose = this->vehicleModel->WorldPose();
   const ignition::math::Pose3d buoyPose = this->link->WorldPose();
+#else
+  const ignition::math::Pose3d vehiclePose =
+    this->vehicleModel->GetWorldPose().Ign();
+  const ignition::math::Pose3d buoyPose = this->link->GetWorldPose().Ign();
+#endif
   const double vehicleBuoyDistance = vehiclePose.Pos().Distance(buoyPose.Pos());
 
   if (this->state == BuoyState::NEVER_ENGAGED)
@@ -199,7 +205,11 @@ bool WildlifeScoringPlugin::AddBuoy(const std::string &_linkName,
     const std::string &_goal)
 {
   gazebo::physics::ModelPtr parentModel =
+#if GAZEBO_MAJOR_VERSION >= 8
     this->world->ModelByName(this->animalsModelName);
+#else
+    this->world->GetModel(this->animalsModelName);
+#endif
   // Sanity check: Make sure that the model exists.
   if (!parentModel)
   {
@@ -272,9 +282,15 @@ void WildlifeScoringPlugin::PublishAnimalLocations()
   for (auto const &buoy : this->buoys)
   {
     // Conversion from Gazebo Cartesian coordinates to spherical.
+#if GAZEBO_MAJOR_VERSION >= 8
     const ignition::math::Pose3d pose = buoy.link->WorldPose();
     const ignition::math::Vector3d latlon =
       this->world->SphericalCoords()->SphericalFromLocal(pose.Pos());
+#else
+    const ignition::math::Pose3d pose = buoy.link->GetWorldPose().Ign();
+    const ignition::math::Vector3d latlon =
+      this->world->GetSphericalCoords()->SphericalFromLocal(pose.Pos());
+#endif
     const ignition::math::Quaternion<double> orientation = pose.Rot();
 
     // Fill the GeoPoseStamped message.

--- a/vrx_gazebo/src/wildlife_scoring_plugin.cc
+++ b/vrx_gazebo/src/wildlife_scoring_plugin.cc
@@ -1,0 +1,315 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <geographic_msgs/GeoPoseStamped.h>
+#include <geographic_msgs/GeoPath.h>
+#include <gazebo/common/Assert.hh>
+#include <gazebo/common/Console.hh>
+#include <gazebo/physics/Link.hh>
+#include "vrx_gazebo/wildlife_scoring_plugin.hh"
+
+/////////////////////////////////////////////////
+WildlifeScoringPlugin::Buoy::Buoy(
+    const gazebo::physics::LinkPtr _buoyLink,
+    const BuoyGoal _buoyGoal,
+    double _engagementDistance)
+  : link(_buoyLink),
+    goal(_buoyGoal),
+    engagementDistance(_engagementDistance)
+{
+  this->Update();
+}
+
+/////////////////////////////////////////////////
+void WildlifeScoringPlugin::Buoy::Update()
+{
+  if (this->state == BuoyState::CIRCUMNAVIGATED || !this->vehicleModel)
+    return;
+
+  const ignition::math::Pose3d vehiclePose = this->vehicleModel->WorldPose();
+  const ignition::math::Pose3d buoyPose = this->link->WorldPose();
+  const double vehicleBuoyDistance = vehiclePose.Pos().Distance(buoyPose.Pos());
+
+  if (this->state == BuoyState::NEVER_ENGAGED)
+  {
+    if (vehicleBuoyDistance <= this->engagementDistance)
+    {
+      // Transition to ENGAGED.
+      this->state = BuoyState::ENGAGED;
+      gzdbg << "[WildlifeScoringPlugin::Buoy] " << this->link->GetName()
+            << " Transition from NEVER_ENGAGED" << " to ENGAGED" << std::endl;
+    }
+  }
+  else if (this->state == BuoyState::NOT_ENGAGED)
+  {
+    if (vehicleBuoyDistance <= this->engagementDistance)
+    {
+      // Transition to ENGAGED.
+      this->state = BuoyState::ENGAGED;
+      gzdbg << "[WildlifeScoringPlugin::Buoy] " << this->link->GetName()
+            << " Transition from NOT_ENGAGED" << " to ENGAGED" << std::endl;
+    }
+  }
+  else if (this->state == BuoyState::ENGAGED)
+  {
+    if (vehicleBuoyDistance > this->engagementDistance)
+    {
+      // Transition to NOT ENGAGED.
+      this->state = BuoyState::NOT_ENGAGED;
+      gzdbg << "[WildlifeScoringPlugin::Buoy] " << this->link->GetName()
+            << " Transition from ENGAGED" << " to NOT_ENGAGED" << std::endl;
+    }
+
+    // ToDo: Check if we transition to circumnavigate.
+    // ...
+  }
+}
+
+/////////////////////////////////////////////////
+void WildlifeScoringPlugin::Buoy::SetVehicleModel(
+  gazebo::physics::ModelPtr _vehicleModel)
+{
+  this->vehicleModel = _vehicleModel;
+}
+
+/////////////////////////////////////////////////
+WildlifeScoringPlugin::WildlifeScoringPlugin()
+{
+  gzmsg << "Wildlife scoring plugin loaded" << std::endl;
+}
+
+/////////////////////////////////////////////////
+void WildlifeScoringPlugin::Load(gazebo::physics::WorldPtr _world,
+    sdf::ElementPtr _sdf)
+{
+  ScoringPlugin::Load(_world, _sdf);
+
+  // Parse the required <animals_model_name> element.
+  if (!_sdf->HasElement("animals_model_name"))
+  {
+    gzerr << "Unable to find <animals_model_name>" << std::endl;
+    return;
+  }
+  this->animalsModelName = _sdf->Get<std::string>("animals_model_name");
+
+  // Parse the optional <animals_topic> element.
+  if (_sdf->HasElement("animals_topic"))
+    this->animalsTopic = _sdf->Get<std::string>("animals_topic");
+
+  // Parse the optional <engagement_distance> element.
+  if (_sdf->HasElement("engagement_distance"))
+    this->engagementDistance = _sdf->Get<double>("engagement_distance");
+
+  // Parse the optional <obstacle_penalty> element.
+  if (_sdf->HasElement("obstacle_penalty"))
+    this->obstaclePenalty = _sdf->Get<double>("obstacle_penalty");
+
+  // Parse the optional <time_bonus> element.
+  if (_sdf->HasElement("time_bonus"))
+    this->timeBonus = _sdf->Get<double>("time_bonus");
+
+  // Parse the optional <buoys> element.
+  // Note: Parse this element at the end because we use some of the previous
+  // parameters.
+  if (_sdf->HasElement("buoys"))
+  {
+    auto const &buoysElem = _sdf->GetElement("buoys");
+    if (!this->ParseBuoys(buoysElem))
+    {
+      gzerr << "Score has been disabled" << std::endl;
+      return;
+    }
+  }
+
+  gzmsg << "Task [" << this->TaskName() << "]" << std::endl;
+
+  // Setup ROS node and publisher
+  this->rosNode.reset(new ros::NodeHandle());
+
+  this->animalsPub =
+    this->rosNode->advertise<geographic_msgs::GeoPath>(
+      this->animalsTopic, 10, true);
+
+  this->updateConnection = gazebo::event::Events::ConnectWorldUpdateBegin(
+    std::bind(&WildlifeScoringPlugin::Update, this));
+}
+
+//////////////////////////////////////////////////
+bool WildlifeScoringPlugin::ParseBuoys(sdf::ElementPtr _sdf)
+{
+  GZ_ASSERT(_sdf, "WildlifeScoringPlugin::ParseBuoys(): NULL _sdf pointer");
+
+  // We need at least one buoy.
+  if (!_sdf->HasElement("buoy"))
+  {
+    gzerr << "Unable to find <buoy> element in SDF." << std::endl;
+    return false;
+  }
+
+  auto buoyElem = _sdf->GetElement("buoy");
+
+  // Parse a new buoy.
+  while (buoyElem)
+  {
+    // The buoy's main link.
+    if (!buoyElem->HasElement("link_name"))
+    {
+      gzerr << "Unable to find <buoys><buoy><link_name> element in SDF."
+            << std::endl;
+      return false;
+    }
+
+    const std::string buoyLinkName = buoyElem->Get<std::string>("link_name");
+
+    // The buoy's goal.
+    if (!buoyElem->HasElement("goal"))
+    {
+      gzerr << "Unable to find <buoys><buoy><goal> element in SDF."
+            << std::endl;
+      return false;
+    }
+
+    const std::string buoyGoal = buoyElem->Get<std::string>("goal");
+    if (!this->AddBuoy(buoyLinkName, buoyGoal))
+      return false;
+
+    // Parse the next buoy.
+    buoyElem = buoyElem->GetNextElement("buoy");
+  }
+
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool WildlifeScoringPlugin::AddBuoy(const std::string &_linkName,
+    const std::string &_goal)
+{
+  gazebo::physics::ModelPtr parentModel =
+    this->world->ModelByName(this->animalsModelName);
+  // Sanity check: Make sure that the model exists.
+  if (!parentModel)
+  {
+    gzerr << "Unable to find model [" << animalsModelName << "]" << std::endl;
+    return false;
+  }
+
+  gazebo::physics::LinkPtr link = parentModel->GetLink(_linkName);
+  // Sanity check: Make sure that the link exists.
+  if (!link)
+  {
+    gzerr << "Unable to find link [" << _linkName << "]" << std::endl;
+    return false;
+  }
+
+  BuoyGoal buoyGoal;
+  if (_goal == "avoid")
+    buoyGoal = BuoyGoal::AVOID;
+  else if (_goal == "circumnavigate_clockwise")
+    buoyGoal = BuoyGoal::CIRCUMNAVIGATE_CLOCKWISE;
+  else if (_goal == "circumnavigate_counterclockwise")
+    buoyGoal = BuoyGoal::CIRCUMNAVIGATE_COUNTERCLOCKWISE;
+  else
+  {
+    gzerr << "Unknown <goal> value: [" << _goal << "]" << std::endl;
+    return false;
+  }
+
+  // Save the new buoy.
+  this->buoys.push_back(Buoy(link, buoyGoal, this->engagementDistance));
+
+  return true;
+}
+
+//////////////////////////////////////////////////
+void WildlifeScoringPlugin::Update()
+{
+  // The vehicle is not in the simulation yet.
+  if (!this->vehicleModel)
+    return;
+
+  // Update the state of all buoys.
+  for (auto &buoy : this->buoys)
+  {
+    // Update the vehicle model if needed.
+    if (!buoy.vehicleModel)
+      buoy.SetVehicleModel(this->vehicleModel);
+
+    // Update the buoy state.
+    buoy.Update();
+  }
+
+  // Publish the location of the buoys.
+  this->PublishAnimalLocations();
+}
+
+//////////////////////////////////////////////////
+void WildlifeScoringPlugin::Fail()
+{
+  this->SetScore(this->ScoringPlugin::GetTimeoutScore());
+  this->Finish();
+}
+
+//////////////////////////////////////////////////
+void WildlifeScoringPlugin::PublishAnimalLocations()
+{
+  geographic_msgs::GeoPath geoPathMsg;
+  geoPathMsg.header.stamp = ros::Time::now();
+
+  for (auto const &buoy : this->buoys)
+  {
+    // Conversion from Gazebo Cartesian coordinates to spherical.
+    const ignition::math::Pose3d pose = buoy.link->WorldPose();
+    const ignition::math::Vector3d latlon =
+      this->world->SphericalCoords()->SphericalFromLocal(pose.Pos());
+    const ignition::math::Quaternion<double> orientation = pose.Rot();
+
+    // Fill the GeoPoseStamped message.
+    geographic_msgs::GeoPoseStamped geoPoseMsg;
+    geoPoseMsg.header.stamp = ros::Time::now();
+
+    // We set the buoy type based on its goal.
+    if (buoy.goal == BuoyGoal::AVOID)
+      geoPoseMsg.header.frame_id = "crocodile";
+    else if (buoy.goal == BuoyGoal::CIRCUMNAVIGATE_CLOCKWISE)
+      geoPoseMsg.header.frame_id = "platypus";
+    else if (buoy.goal == BuoyGoal::CIRCUMNAVIGATE_COUNTERCLOCKWISE)
+      geoPoseMsg.header.frame_id = "turtle";
+    else
+      geoPoseMsg.header.frame_id = "unknown";
+
+    geoPoseMsg.pose.position.latitude  = latlon.X();
+    geoPoseMsg.pose.position.longitude = latlon.Y();
+    geoPoseMsg.pose.position.altitude  = latlon.Z();
+    geoPoseMsg.pose.orientation.x = orientation.X();
+    geoPoseMsg.pose.orientation.y = orientation.Y();
+    geoPoseMsg.pose.orientation.z = orientation.Z();
+    geoPoseMsg.pose.orientation.w = orientation.W();
+
+    // Add the GeoPoseStamped message to the GeoPath message that we publish.
+    geoPathMsg.poses.push_back(geoPoseMsg);
+  }
+  this->animalsPub.publish(geoPathMsg);
+}
+
+//////////////////////////////////////////////////
+void WildlifeScoringPlugin::OnCollision()
+{
+  this->numCollisions++;
+}
+
+// Register plugin with gazebo
+GZ_REGISTER_WORLD_PLUGIN(WildlifeScoringPlugin)

--- a/vrx_gazebo/src/wildlife_scoring_plugin.cc
+++ b/vrx_gazebo/src/wildlife_scoring_plugin.cc
@@ -289,7 +289,7 @@ void WildlifeScoringPlugin::PublishAnimalLocations()
 #else
     const ignition::math::Pose3d pose = buoy.link->GetWorldPose().Ign();
     const ignition::math::Vector3d latlon =
-      this->world->GetSphericalCoords()->SphericalFromLocal(pose.Pos());
+      this->world->GetSphericalCoordinates()->SphericalFromLocal(pose.Pos());
 #endif
     const ignition::math::Quaternion<double> orientation = pose.Rot();
 

--- a/vrx_gazebo/worlds/sydneyregatta.xacro
+++ b/vrx_gazebo/worlds/sydneyregatta.xacro
@@ -97,7 +97,7 @@
     </include>
 
     <!-- wildlife buoys for testing -->
-    <include>
+    <!-- <include>
       <name>crocodile_buoy</name>
       <pose>532 -170 0 0 0 0</pose>
       <uri>model://crocodile_buoy</uri>
@@ -113,7 +113,7 @@
       <name>turtle_buoy</name>
       <pose>492 -170 0 0 0 0</pose>
       <uri>model://turtle_buoy</uri>
-    </include>
+    </include> -->
 
   </xacro:macro>
 </world>

--- a/vrx_gazebo/worlds/sydneyregatta.xacro
+++ b/vrx_gazebo/worlds/sydneyregatta.xacro
@@ -96,24 +96,5 @@
       <uri>model://blue_projectile</uri>
     </include>
 
-    <!-- wildlife buoys for testing -->
-    <!-- <include>
-      <name>crocodile_buoy</name>
-      <pose>532 -170 0 0 0 0</pose>
-      <uri>model://crocodile_buoy</uri>
-    </include>
-
-    <include>
-      <name>platypus_buoy</name>
-      <pose>512 -170 0 0 0 0</pose>
-      <uri>model://platypus_buoy</uri>
-    </include>
-
-    <include>
-      <name>turtle_buoy</name>
-      <pose>492 -170 0 0 0 0</pose>
-      <uri>model://turtle_buoy</uri>
-    </include> -->
-
   </xacro:macro>
 </world>

--- a/vrx_gazebo/worlds/wildlife_task.world.xacro
+++ b/vrx_gazebo/worlds/wildlife_task.world.xacro
@@ -1,0 +1,72 @@
+<?xml version="1.0" ?>
+<!-- World containing sydneyregatta model and some course challenges -->
+<sdf version="1.6" xmlns:xacro="http://ros.org/wiki/xacro">
+  <world name="robotx_example_course">
+    <xacro:include filename="$(find vrx_gazebo)/worlds/sydneyregatta.xacro" />
+    <xacro:sydneyregatta />
+    <!--Waves-->
+    <xacro:include filename="$(find wave_gazebo)/world_models/ocean_waves/model.xacro"/>
+    <xacro:ocean_waves/>
+    <!--wind for the wamv-->
+    <xacro:include filename="$(find vrx_gazebo)/worlds/xacros/usv_wind_plugin.xacro"/>
+    <xacro:usv_wind_gazebo direction = "270" ros_update_rate="10">
+      <wind_objs>
+        <wind_obj>
+          <name>wamv</name>
+          <link_name>base_link</link_name>
+          <coeff_vector>.5 .5 .33</coeff_vector>
+        </wind_obj>
+      </wind_objs>
+    </xacro:usv_wind_gazebo>
+
+
+    <!-- The VRX animal buoys -->
+    <include>
+      <uri>model://animal_buoys</uri>
+      <pose>512 -170 0 0 0 0</pose>
+    </include>
+
+    <!-- The scoring plugin -->
+    <plugin name="wildlife_scoring_plugin"
+            filename="libwildlife_scoring_plugin.so">
+      <!-- Common parameters -->
+      <vehicle>wamv</vehicle>
+      <task_name>wildlife_course</task_name>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <collision_buffer>10</collision_buffer>
+      <release_joints>
+        <joint>
+          <name>wamv_external_pivot_joint</name>
+        </joint>
+        <joint>
+          <name>wamv_external_riser</name>
+        </joint>
+      </release_joints>
+
+      <!-- wildlife specific parameters -->
+      <buoys>
+        <buoy>
+          <link_name>crocodile_buoy::link</link_name>
+          <goal>avoid</goal>
+        </buoy>
+        <buoy>
+          <link_name>platypus_buoy::link</link_name>
+          <goal>circumnavigate_clockwise</goal>
+        </buoy>
+        <buoy>
+          <link_name>turtle_buoy::link</link_name>
+          <goal>circumnavigate_counterclockwise</goal>
+        </buoy>
+      </buoys>
+      <animals_model_name>animal_buoys</animals_model_name>
+      <engagement_distance>10.0</engagement_distance>
+      <obstacle_penalty>10.0</obstacle_penalty>
+      <time_bonus>30.0</time_bonus>
+      <animals_topic>/vrx/wildlife/animals/poses</animals_topic>
+
+    </plugin>
+
+  </world>
+</sdf>


### PR DESCRIPTION
See issue #276.

This scoring plugin isn't trivial, so I decided to split it in two pull request. This is the first one:

* It adds a new world (`wildlife_task.world.xacro`).
* It adds a new launch file for launching the previous world (`wildlife.launch`).
* It adds a new model (`animal_buoys`) that combine all the animal buoys into a single model. The reason for this is that it will be easier in the future to create different combinations for each run. Every configuration will be captured into a separate model containing also the `FollowPlugin` parameters. For now, I didn't move the plugins to this new model.
* It adds a new scoring plugin (`wildlife_scoring_plugin`).

The functionality added so far is:
  * The plugin parses all the SDF parameters. 
  * The plugin publishes all the animal poses as documented in the rules.
  * The plugin instantiates a new `Buoy` object for each buoy (animal) and updates its internal state. There are four states: NEVER_ENGAGED, NOT_ENGAGED, ENGAGED and CIRCUMNAVIGATED.
 
The part 2 will include:
   * The logic that decides when a buoy has been circumnavigated.

For testing:
```
roslaunch vrx_gazebo wildlife.launch extra_gazebo_args:=--verbose
```

You can teleoperate the WAM-V with:
```
roslaunch vrx_gazebo usv_joydrive.launch
```

You should see messages of this type:
```
[Dbg] [wildlife_scoring_plugin.cc:63] [WildlifeScoringPlugin::Buoy] crocodile_buoy::link Transition from NOT_ENGAGED to ENGAGED
```

For testing the buoy poses you can type:
```
rostopic echo /vrx/wildlife/animals/poses
```
