### PR TITLE
Fix water scaling and wind

### DIFF
--- a/vrx_gazebo/src/ball_shooter_plugin.cc
+++ b/vrx_gazebo/src/ball_shooter_plugin.cc
@@ -28,7 +28,7 @@ using namespace gazebo;
 void BallShooterPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 {
   gazebo::physics::WorldPtr world =
-    gazebo::physics::get_world("robotx_example_course");
+    gazebo::physics::get_world();
 
   GZ_ASSERT(_model != nullptr, "Received NULL model pointer");
 

--- a/vrx_gazebo/worlds/gymkhana.world.xacro
+++ b/vrx_gazebo/worlds/gymkhana.world.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0" ?>
 <!-- World containing sandisland model and some course challenges -->
 <sdf version="1.6" xmlns:xacro="http://ros.org/wiki/xacro">
-  <world name="gymkhana">
+  <world name="vrx_gymkhana">
     <xacro:include filename="$(find vrx_gazebo)/worlds/sydneyregatta.xacro" />
     <xacro:sydneyregatta />
 
     <!--Waves-->
     <xacro:include filename="$(find wave_gazebo)/world_models/ocean_waves/model.xacro"/>
-    <xacro:ocean_waves />
+    <xacro:ocean_waves scale="2.5"/>
 
     <!--Wind. Note, wind parameters are set in the plugin.-->
     <xacro:include filename="$(find vrx_gazebo)/worlds/xacros/usv_wind_plugin.xacro"/>

--- a/vrx_gazebo/worlds/perception_task.world.xacro
+++ b/vrx_gazebo/worlds/perception_task.world.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 <!-- World containing sandisland model and some course challenges -->
 <sdf version="1.6" xmlns:xacro="http://ros.org/wiki/xacro">
-  <world name="perception_task_example">
+  <world name="vrx_perception">
     <xacro:include filename="$(find vrx_gazebo)/worlds/sydneyregatta.xacro" />
     <xacro:sydneyregatta />
     <!--Waves-->
     <xacro:include filename="$(find wave_gazebo)/world_models/ocean_waves/model.xacro"/>
-    <xacro:ocean_waves/>
+    <xacro:ocean_waves scale="2.5"/>
     <!-- Include all the objects we plan to use for perception.
        Stash them out of the field of view for now -->
     <include>

--- a/vrx_gazebo/worlds/scan_dock_deliver.world.xacro
+++ b/vrx_gazebo/worlds/scan_dock_deliver.world.xacro
@@ -1,19 +1,19 @@
 <?xml version="1.0" ?>
 <!-- World containing sydneyregatta model and some course challenges -->
 <sdf version="1.6" xmlns:xacro="http://ros.org/wiki/xacro">
-  <world name="robotx_example_course">
+  <world name="vrx_scan_dock_deliver">
     <xacro:include filename="$(find vrx_gazebo)/worlds/sydneyregatta.xacro" />
     <xacro:sydneyregatta />
     <!--Waves-->
     <xacro:include filename="$(find wave_gazebo)/world_models/ocean_waves/model.xacro"/>
-    <xacro:ocean_waves/>
+    <xacro:ocean_waves scale="2.5"/>
     <!--wind for the wamv-->
     <xacro:include filename="$(find vrx_gazebo)/worlds/xacros/usv_wind_plugin.xacro"/>
     <xacro:usv_wind_gazebo>
       <wind_objs>
         <wind_obj>
           <name>wamv</name>
-          <link_name>base_link</link_name>
+          <link_name>wamv/base_link</link_name>
           <coeff_vector>.5 .5 .33</coeff_vector>
         </wind_obj>
       </wind_objs>
@@ -30,38 +30,6 @@
       <uri>model://dock_2022</uri>
       <pose>554 -233 0 0 0 0</pose>
     </include>
-
-    <!-- Uncomment to visualize the bay #1 activation zone -->
-    <!-- <model name="activation_placard1">
-      <static>true</static>
-      <link name="link">
-        <visual name="visual">
-          <pose>72.75 0 0 0 0 0</pose>
-          <geometry>
-            <box>
-              <size>1.5 4 2</size>
-            </box>
-          </geometry>
-          <transparency>0.8</transparency>
-        </visual>
-      </link>
-    </model> -->
-
-    <!-- Uncomment to visualize the bay #2 activation zone -->
-    <!-- <model name="activation_placard2">
-      <static>true</static>
-      <link name="link">
-        <visual name="visual">
-          <pose>61.75 0 0 0 0 0</pose>
-          <geometry>
-            <box>
-              <size>1.5 4 2</size>
-            </box>
-          </geometry>
-          <transparency>0.8</transparency>
-        </visual>
-      </link>
-    </model> -->
 
   </world>
 </sdf>

--- a/vrx_gazebo/worlds/stationkeeping_task.world.xacro
+++ b/vrx_gazebo/worlds/stationkeeping_task.world.xacro
@@ -1,19 +1,19 @@
 <?xml version="1.0" ?>
 <!-- World containing sandisland model and some course challenges -->
 <sdf version="1.6" xmlns:xacro="http://ros.org/wiki/xacro">
-  <world name="robotx_stationkeeping">
+  <world name="vrx_stationkeeping">
     <xacro:include filename="$(find vrx_gazebo)/worlds/sydneyregatta.xacro" />
     <xacro:sydneyregatta />
     <!--Waves-->
     <xacro:include filename="$(find wave_gazebo)/world_models/ocean_waves/model.xacro"/>
-    <xacro:ocean_waves/>
+    <xacro:ocean_waves scale="2.5"/>
     <!--wind for the wamv-->
     <xacro:include filename="$(find vrx_gazebo)/worlds/xacros/usv_wind_plugin.xacro"/>
     <xacro:usv_wind_gazebo>
       <wind_objs>
         <wind_obj>
           <name>wamv</name>
-          <link_name>base_link</link_name>
+          <link_name>wamv/base_link</link_name>
           <coeff_vector>.5 .5 .33</coeff_vector>
         </wind_obj>
       </wind_objs>

--- a/vrx_gazebo/worlds/sydneyregatta.world.xacro
+++ b/vrx_gazebo/worlds/sydneyregatta.world.xacro
@@ -13,7 +13,7 @@
       <wind_objs>
         <wind_obj>
           <name>wamv</name>
-          <link_name>base_link</link_name>
+          <link_name>wamv/base_link</link_name>
           <coeff_vector>0.5 0.5 0.33</coeff_vector>
         </wind_obj>
       </wind_objs>

--- a/vrx_gazebo/worlds/wayfinding_task.world.xacro
+++ b/vrx_gazebo/worlds/wayfinding_task.world.xacro
@@ -1,19 +1,19 @@
 <?xml version="1.0" ?>
 <!-- World containing sandisland model and some course challenges -->
 <sdf version="1.6" xmlns:xacro="http://ros.org/wiki/xacro">
-  <world name="robotx_wayfinding">
+  <world name="vrx_wayfinding">
     <xacro:include filename="$(find vrx_gazebo)/worlds/sydneyregatta.xacro" />
     <xacro:sydneyregatta />
     <!--Waves-->
     <xacro:include filename="$(find wave_gazebo)/world_models/ocean_waves/model.xacro"/>
-    <xacro:ocean_waves/>
+    <xacro:ocean_waves scale="2.5"/>
     <!--wind for the wamv-->
     <xacro:include filename="$(find vrx_gazebo)/worlds/xacros/usv_wind_plugin.xacro"/>
     <xacro:usv_wind_gazebo>
       <wind_objs>
         <wind_obj>
           <name>wamv</name>
-          <link_name>base_link</link_name>
+          <link_name>wamv/base_link</link_name>
           <coeff_vector>.5 .5 .33</coeff_vector>
         </wind_obj>
       </wind_objs>

--- a/vrx_gazebo/worlds/wildlife_task.world.xacro
+++ b/vrx_gazebo/worlds/wildlife_task.world.xacro
@@ -1,19 +1,19 @@
 <?xml version="1.0" ?>
 <!-- World containing sydneyregatta model and some course challenges -->
 <sdf version="1.6" xmlns:xacro="http://ros.org/wiki/xacro">
-  <world name="robotx_example_course">
+  <world name="vrx_wildlife">
     <xacro:include filename="$(find vrx_gazebo)/worlds/sydneyregatta.xacro" />
     <xacro:sydneyregatta />
     <!--Waves-->
     <xacro:include filename="$(find wave_gazebo)/world_models/ocean_waves/model.xacro"/>
-    <xacro:ocean_waves/>
+    <xacro:ocean_waves scale="2.5"/>
     <!--wind for the wamv-->
     <xacro:include filename="$(find vrx_gazebo)/worlds/xacros/usv_wind_plugin.xacro"/>
     <xacro:usv_wind_gazebo direction = "270" ros_update_rate="10">
       <wind_objs>
         <wind_obj>
           <name>wamv</name>
-          <link_name>base_link</link_name>
+          <link_name>wamv/base_link</link_name>
           <coeff_vector>.5 .5 .33</coeff_vector>
         </wind_obj>
       </wind_objs>


### PR DESCRIPTION
This pull requests adjusts the `scale` parameter of the ocean waves to cover the entire Sydney Regatta world. I also fixed some incorrect link name that is needed for the wind plugin.

See the water behavior before this pull request:
![robotx_example_course_gzclient_camera(1)-2021-09-08T22_53_46 966238](https://user-images.githubusercontent.com/1440739/132584871-620d6b9b-6851-4c56-9d55-85738bc04945.jpg)

And this is the water behavior after this pull request:
![robotx_example_course_gzclient_camera(1)-2021-09-08T22_53_10 334966](https://user-images.githubusercontent.com/1440739/132584851-bb2c438a-ee73-4c81-83e9-184724a69dd9.jpg)

How to test it:

Go to the [VRX 2022 competition wiki page](https://github.com/osrf/vrx/wiki/vrx_2022-task_tutorials), scroll down to the very bottom and open all individual tutorials for each task. You should see in all the worlds the water covering the entire arena.
