### PR TITLE
Simple shapes as collision elements in the 2022 placards

### DIFF
--- a/vrx_gazebo/models/dock_2016/model.sdf.erb
+++ b/vrx_gazebo/models/dock_2016/model.sdf.erb
@@ -76,12 +76,12 @@
       <pose><%=placard_x%> <%=placard_y%> <%=placard_z%> <%=placard_roll%> <%=placard_pitch%> <%=placard_yaw%></pose>
       <include>
         <static>true</static>
-        <pose> 0 0 0.25 0 0 0</pose>
+        <pose>0 0 0.25 0 0 0</pose>
         <uri>model://placard</uri>
       </include>
       <link name="link_symbols">
         <static>true</static>
-        <pose> 0 0.07 0.75 0 0 0 </pose>
+        <pose>0 0.07 0.75 0 0 0</pose>
           <visual name="visual_circle">
           <pose>0 0 0 1.571 0 0</pose>
           <geometry>

--- a/vrx_gazebo/models/dock_2016_dynamic/model.sdf.erb
+++ b/vrx_gazebo/models/dock_2016_dynamic/model.sdf.erb
@@ -74,14 +74,14 @@
     <model name="dock_2016_placard<%= i %>">
       <pose><%=placard_x%> <%=placard_y%> <%=placard_z%> <%=placard_roll%> <%=placard_pitch%> <%=placard_yaw%></pose>
       <include>
-        <pose> 0 0 0.25 0 0 0</pose>
+        <pose>0 0 0.25 0 0 0</pose>
         <uri>model://placard</uri>
       </include>
       <link name="link_symbols">
         <inertial>
           <mass>0.01</mass>
         </inertial>
-        <pose> 0 0.1 0.75 0 0 0 </pose>
+        <pose>0 0.1 0.75 0 0 0</pose>
         <visual name="visual_circle">
           <pose>0 0 0 1.571 0 0</pose>
           <geometry>

--- a/vrx_gazebo/models/dock_2018_dynamic/model.sdf.erb
+++ b/vrx_gazebo/models/dock_2018_dynamic/model.sdf.erb
@@ -80,9 +80,9 @@
       </include>
       <link name="link_symbols">
         <% if i == 1%>
-        <pose> 0 -0.1 0.75 0 0 0 </pose>
+        <pose>0 -0.1 0.75 0 0 0</pose>
         <% else %>
-        <pose> 0 0.1 0.75 0 0 0 </pose>
+        <pose>0 0.1 0.75 0 0 0</pose>
         <% end %>
         <visual name="visual_circle">
           <pose>0 0 0 1.571 0 0</pose>

--- a/vrx_gazebo/models/dock_2022/model.sdf.erb
+++ b/vrx_gazebo/models/dock_2022/model.sdf.erb
@@ -76,12 +76,12 @@
       <pose><%=placard_x%> <%=placard_y%> <%=placard_z%> <%=placard_roll%> <%=placard_pitch%> <%=placard_yaw%></pose>
       <include>
         <static>true</static>
-        <pose> 0 -0.2 0.25 0 0 3.14159</pose>
+        <pose>0 -0.2 0.25 0 0 3.14159</pose>
         <uri>model://placard_2022</uri>
       </include>
       <link name="link_symbols">
         <static>true</static>
-        <pose> 0 0.07 0 0 0 0 </pose>
+        <pose>0 0.07 0 0 0 0 </pose>
         <visual name="visual_circle">
           <pose>0 0 0 1.571 0 0</pose>
           <geometry>

--- a/vrx_gazebo/models/dock_2022_dynamic/model.sdf.erb
+++ b/vrx_gazebo/models/dock_2022_dynamic/model.sdf.erb
@@ -81,7 +81,7 @@
         <inertial>
           <mass>0.01</mass>
         </inertial>
-        <pose> 0 0.1 0 0 0 0 </pose>
+        <pose>0 0.1 0 0 0 0</pose>
 	      <visual name="visual_circle">
           <pose>0 0 0 1.571 0 0</pose>
           <geometry>

--- a/vrx_gazebo/models/placard_2022/model.sdf
+++ b/vrx_gazebo/models/placard_2022/model.sdf
@@ -4,11 +4,60 @@
     <pose>0 0 1 0 0 0</pose>
     <!-- The white placard -->
     <link name="link">
-      <collision name="collision">
+      <collision name="collision_1">
+        <pose>-0.9234 0.0 1.164 0.0 0.0 0.0</pose>
         <geometry>
-          <mesh>
-            <uri>file://placard_2022/meshes/placard_2022.dae</uri>
-          </mesh>
+          <box>
+            <size>0.153199 0.500 0.672</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="collision_2">
+        <pose>-0.596803 0.0 1.41357 -3.14159 -1.5708 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.17285 0.5 0.5</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="collision_3">
+        <pose>0.326598 0.0 1.35111 0.0 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>1.3468 0.500 0.29777</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="collision_4">
+        <pose>0.070527 0.0 1.07723 0.0 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>0.834664 0.500 0.25</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="collision_6">
+        <pose>0.326598 0.0 0.890117 0.0 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>1.3468 0.500 0.124233</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="collision_5">
+        <pose>0.868936 0.0 1.07723 1.5708 0.0 1.5708</pose>
+        <geometry>
+          <box>
+            <size>0.500 0.25 0.262128</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="collision_7">
+        <pose>0.0 0.0 -0.336 0.0 0.0 0.0</pose>
+        <geometry>
+          <box>
+            <size>2.000 0.500 2.328</size>
+          </box>
         </geometry>
       </collision>
       <visual name="visual">


### PR DESCRIPTION
This pull request replaces the collision element of the 2022 placard. Before we were using the mesh directly. We're now using a few boxes strategically placed. Usually simple shapes offer better performance than meshes while checking collisions.

![placard_simple_shapes](https://user-images.githubusercontent.com/1440739/132712101-520ecf99-53f1-4b52-b901-893ee0136d57.jpg)
