### PR TITLE
Propulsion configuration demo launch file

### DIFF
--- a/vrx_gazebo/launch/demo_thrusterconfigs.launch
+++ b/vrx_gazebo/launch/demo_thrusterconfigs.launch
@@ -1,0 +1,131 @@
+<?xml version="1.0"?>
+<launch>
+  <env name="ROSCONSOLE_CONFIG_FILE" value="$(find vrx_gazebo)/config/custom_rosconsole.conf"/>
+  <!-- Gazebo world to load -->
+  <arg name="world" default="$(find vrx_gazebo)/worlds/example_course.world" />
+  <!-- If true, run gazebo GUI -->
+  <arg name="gui" default="true" />
+  <!-- If true, run gazebo in verbose mode -->
+  <arg name="verbose" default="false"/>
+  <!-- If true, start in paused state -->
+  <arg name="paused"  default="true"/>
+  <!-- Set various other gazebo arguments-->
+  <arg name="extra_gazebo_args" default=""/>
+  <!-- Start in a default namespace -->
+  <arg name="namespace" default="wamv"/>
+
+  <!-- Initial USV location and attitude-->
+  <arg name="x" default="532" />
+  <arg name="y" default="-162" />
+  <arg name="z" default="0" />
+  <arg name="P" default="0" />
+  <arg name="R" default="0" />
+  <arg name="Y" default="-2.15" />
+
+  <!-- If true, show non-competition ROS topics (/gazebo/model_states, /vrx/debug/wind/direction, etc.)-->
+  <arg name="non_competition_mode" default="true"/>
+  <arg name="enable_ros_network" value="$(arg non_competition_mode)"/>
+  <env name="VRX_DEBUG" value="$(arg non_competition_mode)"/>
+  <env unless="$(arg non_competition_mode)" name="GAZEBO_MODEL_PATH" value="$(find vrx_gazebo)/models:$(find wamv_gazebo)/models:$(find wamv_description)/models:$(optenv GAZEBO_MODEL_PATH)"/>
+
+  <!-- Allow user specified thruster configurations
+       H = stern trusters on each hull
+       T = H with a lateral thruster
+       X = "holonomic" configuration -->
+  <arg name="thrust_config" default="H" />
+
+  <!-- Do you want to enable sensors? -->
+  <arg name="camera_enabled"       default="false" />
+  <arg name="gps_enabled"          default="false" />
+  <arg name="imu_enabled"          default="false" />
+  <arg name="lidar_enabled"        default="false" />
+  <arg name="ground_truth_enabled" default="false" />
+
+  <!-- Start Gazebo with the world file -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="world_name"   value="$(arg world)"/>
+    <arg name="verbose"      value="$(arg verbose)"/>
+    <arg name="paused"       value="$(arg paused)"/>
+    <arg name="use_sim_time" value="true"/>
+    <arg name="gui"          value="$(arg gui)" />
+    <arg name="enable_ros_network" value="$(arg enable_ros_network)"/>
+    <arg name="extra_gazebo_args" value="$(arg extra_gazebo_args)"/>
+  </include>
+
+  <!-- Load robot models -->
+  <arg name="urdf" default="$(find wamv_gazebo)/urdf/wamv_gazebo.urdf.xacro"/>
+  <!-- H -->
+  <arg name="namespaceH" default="wamvH"/>
+  <arg name="thrust_configH" default="H" />
+
+  <param name="$(arg namespaceH)/robot_description"
+         command="$(find xacro)/xacro &#x002D;&#x002D;inorder '$(arg urdf)'
+         thruster_config:=$(arg thrust_configH)
+         camera_enabled:=$(arg camera_enabled)
+         gps_enabled:=$(arg gps_enabled)
+         imu_enabled:=$(arg imu_enabled)
+         lidar_enabled:=$(arg lidar_enabled)
+         ground_truth_enabled:=$(arg ground_truth_enabled)
+         namespace:=$(arg namespaceH) "/>
+
+  <!-- Spawn model in Gazebo, script depending on non_competition_mode -->
+  <node name="spawn_modelH" pkg="gazebo_ros" type="spawn_model" if="$(arg non_competition_mode)"
+        args="-x 552 -y -166 -z $(arg z)
+              -R $(arg R) -P $(arg P) -Y $(arg Y)
+              -urdf -param $(arg namespaceH)/robot_description -model wamvH"/>
+
+  <node name="spawn_wamvH" pkg="vrx_gazebo" type="spawn_wamv.bash" unless="$(arg non_competition_mode)"
+        args="-x $(arg x) -y $(arg y) -z $(arg z)
+              -R $(arg R) -P $(arg P) -Y $(arg Y)
+              --urdf $(arg urdf) --model wamvH"/>
+
+    <!-- T -->
+  <arg name="namespaceT" default="wamvT"/>
+  <arg name="thrust_configT" default="T" />
+
+  <param name="$(arg namespaceT)/robot_description"
+         command="$(find xacro)/xacro &#x002D;&#x002D;inorder '$(arg urdf)'
+         thruster_config:=$(arg thrust_configT)
+         camera_enabled:=$(arg camera_enabled)
+         gps_enabled:=$(arg gps_enabled)
+         imu_enabled:=$(arg imu_enabled)
+         lidar_enabled:=$(arg lidar_enabled)
+         ground_truth_enabled:=$(arg ground_truth_enabled)
+         namespace:=$(arg namespaceT) "/>
+
+  <!-- Spawn model in Gazebo, script depending on non_competition_mode -->
+  <node name="spawn_modelT" pkg="gazebo_ros" type="spawn_model" if="$(arg non_competition_mode)"
+        args="-x 542 -y -164 -z $(arg z)
+              -R $(arg R) -P $(arg P) -Y $(arg Y)
+              -urdf -param $(arg namespaceT)/robot_description -model wamvT"/>
+
+  <node name="spawn_wamvT" pkg="vrx_gazebo" type="spawn_wamv.bash" unless="$(arg non_competition_mode)"
+        args="-x $(eval arg('x')) -y $(eval arg('y')+10) -z $(arg z)
+              -R $(arg R) -P $(arg P) -Y $(arg Y)
+              --urdf $(arg urdf) --model wamvT"/>
+
+    <!-- X -->
+  <arg name="namespaceX" default="wamvX"/>
+  <arg name="thrust_configX" default="X" />
+
+  <param name="$(arg namespaceX)/robot_description"
+         command="$(find xacro)/xacro &#x002D;&#x002D;inorder '$(arg urdf)'
+         thruster_config:=$(arg thrust_configX)
+         camera_enabled:=$(arg camera_enabled)
+         gps_enabled:=$(arg gps_enabled)
+         imu_enabled:=$(arg imu_enabled)
+         lidar_enabled:=$(arg lidar_enabled)
+         ground_truth_enabled:=$(arg ground_truth_enabled)
+         namespace:=$(arg namespaceX) "/>
+
+  <!-- Spawn model in Gazebo, script depending on non_competition_mode -->
+  <node name="spawn_modelX" pkg="gazebo_ros" type="spawn_model" if="$(arg non_competition_mode)"
+        args="-x 532 -y -162 -z $(arg z)
+              -R $(arg R) -P $(arg P) -Y $(arg Y)
+              -urdf -param $(arg namespaceX)/robot_description -model wamvX"/>
+
+  <node name="spawn_wamvX" pkg="vrx_gazebo" type="spawn_wamv.bash" unless="$(arg non_competition_mode)"
+        args="-x $(eval arg('x')) -y $(eval arg('y')+10) -z $(arg z)
+              -R $(arg R) -P $(arg P) -Y $(arg Y)
+              --urdf $(arg urdf) --model wamvX"/>
+</launch>


### PR DESCRIPTION
As part of documenting the propulsion configuration, I created a launch file to spawn the three variants in the same Sydney world.  This PR just adds the launch file, so should not affect anything else.  Just keeping the launch file for posterity.

Test by running 

```
roslaunch vrx_gazebo demo_thrusterconfigs.launch 
```

Added last section of wiki: https://github.com/osrf/vrx/wiki/tutorials-PropulsionConfiguration

