### PR TITLE
Ball Shooter Model: Partial fix for XML format

### DIFF
--- a/vrx_gazebo/models/ball_shooter/meshes/ball_shooter.dae
+++ b/vrx_gazebo/models/ball_shooter/meshes/ball_shooter.dae
@@ -2,16 +2,12 @@
 <COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
   <asset>
     <contributor>
-      <author/>
+      <author></author>
       <authoring_tool>FBX COLLADA exporter</authoring_tool>
-      <comments/>
+      <comments></comments>
     </contributor>
     <created>2021-08-12T21:51:49Z</created>
-    <keywords/>
     <modified>2021-08-12T21:51:49Z</modified>
-    <revision/>
-    <subject/>
-    <title/>
     <unit meter="0.025400" name="centimeter"/>
     <up_axis>Z_UP</up_axis>
   </asset>


### PR DESCRIPTION
See Issue #344 for explanation.

Original error message is...

```
[ERROR] [1631215004.480044470, 413.401000000]: Could not load resource [package://vrx_gazebo/models/ball_shooter/meshes/ball_shooter.dae]: Collada: package://vrx_gazebo/models/ball_shooter/meshes/ball_shooter.dae - Expected end of <author> element.
```

Appears that the process didn't like the single XML tags, so removed empty tags in this PR.  

Still missing texture images as described in Issue #344