### PR TITLE
Adding number of collisions to the task message

### DIFF
--- a/vrx_gazebo/include/vrx_gazebo/gymkhana_scoring_plugin.hh
+++ b/vrx_gazebo/include/vrx_gazebo/gymkhana_scoring_plugin.hh
@@ -46,9 +46,6 @@ class GymkhanaScoringPlugin : public ScoringPlugin
   protected: void BlackboxCallback(const vrx_gazebo::Task::ConstPtr& msg);
 
   // Documentation inherited.
-  private: void OnCollision() override;
-
-  // Documentation inherited.
   private: void OnFinished() override;
 
   /// \brief Pointer to the update event connection.
@@ -68,9 +65,6 @@ class GymkhanaScoringPlugin : public ScoringPlugin
 
   /// \brief Cumulative error from black box station keeping portion
   private: double blackboxScore = 0.0;
-
-  /// \brief The number of WAM-V collisions.
-  private: unsigned int numCollisions = 0;
 
   /// \brief Penalty added per collision.
   private: double obstaclePenalty = 0.1;

--- a/vrx_gazebo/include/vrx_gazebo/navigation_scoring_plugin.hh
+++ b/vrx_gazebo/include/vrx_gazebo/navigation_scoring_plugin.hh
@@ -166,9 +166,6 @@ class NavigationScoringPlugin : public ScoringPlugin
   /// \brief Set the score to 0 and change to state to "finish".
   private: void Fail();
 
-  // Documentation inherited.
-  private: void OnCollision() override;
-
   // Name of Course
   private: gazebo::physics::ModelPtr course;
 
@@ -180,9 +177,6 @@ class NavigationScoringPlugin : public ScoringPlugin
 
   /// \brief Pointer to the update event connection.
   private: gazebo::event::ConnectionPtr updateConnection;
-
-  /// \brief The number of WAM-V collisions.
-  private: unsigned int numCollisions = 0;
 
   /// \brief Number of points deducted per collision.
   private: double obstaclePenalty = 10.0;

--- a/vrx_gazebo/include/vrx_gazebo/scoring_plugin.hh
+++ b/vrx_gazebo/include/vrx_gazebo/scoring_plugin.hh
@@ -322,6 +322,9 @@ class ScoringPlugin : public gazebo::WorldPlugin
 
   /// \brief Whether to shut down after last gate is crossed.
   private: bool perPluginExitOnCompletion = true;
+
+  /// \brief Number of WAM-V collisions.
+  private: unsigned int numCollisions = 0u;
 };
 
 #endif

--- a/vrx_gazebo/include/vrx_gazebo/scoring_plugin.hh
+++ b/vrx_gazebo/include/vrx_gazebo/scoring_plugin.hh
@@ -163,10 +163,13 @@ class ScoringPlugin : public gazebo::WorldPlugin
   protected: void SetTimeoutScore(double _timeoutScore);
 
   /// \brief Get the timeoutScore
-  protected: double GetTimeoutScore();
+  protected: double GetTimeoutScore() const;
 
   /// \brief Get running duration
-  protected: double GetRunningStateDuration();
+  protected: double GetRunningStateDuration() const;
+
+  /// \brief Get the number of WAM-V collisions.
+  protected: unsigned int GetNumCollisions() const;
 
   /// \brief Callback executed at every world update.
   private: void Update();

--- a/vrx_gazebo/msg/Task.msg
+++ b/vrx_gazebo/msg/Task.msg
@@ -23,3 +23,6 @@ bool timed_out
 
 # The score.
 float64 score
+
+# Number of collisions.
+uint32 num_collisions

--- a/vrx_gazebo/msg/Task.msg
+++ b/vrx_gazebo/msg/Task.msg
@@ -21,8 +21,8 @@ duration remaining_time
 # True if task timed out.
 bool timed_out
 
-# The score.
-float64 score
-
 # Number of collisions.
 uint32 num_collisions
+
+# The score.
+float64 score

--- a/vrx_gazebo/src/gymkhana_scoring_plugin.cc
+++ b/vrx_gazebo/src/gymkhana_scoring_plugin.cc
@@ -102,15 +102,9 @@ void GymkhanaScoringPlugin::BlackboxCallback(
 }
 
 //////////////////////////////////////////////////
-void GymkhanaScoringPlugin::OnCollision()
-{
-  ++this->numCollisions;
-}
-
-//////////////////////////////////////////////////
 void GymkhanaScoringPlugin::OnFinished()
 {
-  double penalty = this->numCollisions * this->obstaclePenalty;
+  double penalty = this->GetNumCollisions() * this->obstaclePenalty;
 
   if (this->Score() < std::numeric_limits<double>::max())
     this->SetTimeoutScore(this->Score() + penalty);

--- a/vrx_gazebo/src/navigation_scoring_plugin.cc
+++ b/vrx_gazebo/src/navigation_scoring_plugin.cc
@@ -253,7 +253,7 @@ void NavigationScoringPlugin::Update()
   // Current score
   this->ScoringPlugin::SetScore(std::min(this->GetRunningStateDuration(),
     this->ElapsedTime().Double() +
-    this->numCollisions * this->obstaclePenalty)/this->numGates);
+    this->numCollisions * this->obstaclePenalty) / this->numGates);
 
 #if GAZEBO_MAJOR_VERSION >= 8
   const auto robotPose = this->vehicleModel->WorldPose();
@@ -317,12 +317,6 @@ void NavigationScoringPlugin::Fail()
 {
   this->SetScore(this->ScoringPlugin::GetTimeoutScore());
   this->Finish();
-}
-
-//////////////////////////////////////////////////
-void NavigationScoringPlugin::OnCollision()
-{
-  this->numCollisions++;
 }
 
 // Register plugin with gazebo

--- a/vrx_gazebo/src/navigation_scoring_plugin.cc
+++ b/vrx_gazebo/src/navigation_scoring_plugin.cc
@@ -253,7 +253,7 @@ void NavigationScoringPlugin::Update()
   // Current score
   this->ScoringPlugin::SetScore(std::min(this->GetRunningStateDuration(),
     this->ElapsedTime().Double() +
-    this->numCollisions * this->obstaclePenalty) / this->numGates);
+    this->GetNumCollisions() * this->obstaclePenalty) / this->numGates);
 
 #if GAZEBO_MAJOR_VERSION >= 8
   const auto robotPose = this->vehicleModel->WorldPose();

--- a/vrx_gazebo/src/scoring_plugin.cc
+++ b/vrx_gazebo/src/scoring_plugin.cc
@@ -205,6 +205,7 @@ void ScoringPlugin::UpdateTaskMessage()
   this->taskMsg.remaining_time.fromSec(this->remainingTime.Double());
   this->taskMsg.timed_out = this->timedOut;
   this->taskMsg.score = this->score;
+  this->taskMsg.num_collisions = this->numCollisions;
 }
 
 //////////////////////////////////////////////////
@@ -237,19 +238,19 @@ void ScoringPlugin::ReleaseVehicle()
 
   this->lockJointNames.clear();
 
-  gzmsg << "Vehicle released" << std::endl;
+  gzmsg << "ScoringPlugin::Vehicle released" << std::endl;
 }
 
 //////////////////////////////////////////////////
 void ScoringPlugin::OnReady()
 {
-  gzmsg << "OnReady" << std::endl;
+  gzmsg << "ScoringPlugin::OnReady" << std::endl;
 }
 
 //////////////////////////////////////////////////
 void ScoringPlugin::OnRunning()
 {
-  gzmsg << "OnRunning" << std::endl;
+  gzmsg << "ScoringPlugin::OnRunning" << std::endl;
 }
 
 //////////////////////////////////////////////////
@@ -269,6 +270,7 @@ void ScoringPlugin::OnFinished()
 //////////////////////////////////////////////////
 void ScoringPlugin::OnCollision()
 {
+  ++this->numCollisions;
 }
 
 //////////////////////////////////////////////////

--- a/vrx_gazebo/src/scoring_plugin.cc
+++ b/vrx_gazebo/src/scoring_plugin.cc
@@ -484,12 +484,17 @@ void ScoringPlugin::SetTimeoutScore(double _timeoutScore)
   this->timeoutScore = _timeoutScore;
 }
 
-double ScoringPlugin::GetTimeoutScore()
+double ScoringPlugin::GetTimeoutScore() const
 {
   return this->timeoutScore;
 }
 
-double ScoringPlugin::GetRunningStateDuration()
+double ScoringPlugin::GetRunningStateDuration() const
 {
   return this->runningStateDuration;
+}
+
+unsigned int ScoringPlugin::GetNumCollisions() const
+{
+  return this->numCollisions;
 }


### PR DESCRIPTION
I moved the logic to account for the collisions to the base scoring plugin and include it in the task message.