### PR TITLE
Fix missing filename extension in generate_worlds.launch

### DIFF
--- a/vrx_gazebo/launch/generate_worlds.launch
+++ b/vrx_gazebo/launch/generate_worlds.launch
@@ -24,6 +24,6 @@
   <arg name="world_name" default="robotx_example_course"/>
   <param name="world_name" value="$(arg world_name)"/>
 
-  <node name="world_gen" pkg="vrx_gazebo" type="generate_worlds" required="true"
+  <node name="world_gen" pkg="vrx_gazebo" type="generate_worlds.py" required="true"
     output="screen"/>
 </launch>


### PR DESCRIPTION
`generate_worlds.launch` is missing a .py extension which causes a crash. The extension was added to the file in PR #269, but this reference to it was overlooked.

To test, it is sufficient to observe that the files in [vrx_gazebo/scripts](https://github.com/osrf/vrx/tree/master/vrx_gazebo/scripts) were renamed in [this commit](https://github.com/osrf/vrx/commit/5589026cf82f9940d7d9ad73406a729edb4a07d1), but the reference in this launch file was not.