### PR TITLE
adding 2022 elements to vrx.launch

### DIFF
--- a/vrx_gazebo/launch/vrx.launch
+++ b/vrx_gazebo/launch/vrx.launch
@@ -15,6 +15,9 @@
   <arg name="wamv_locked" default="false" />
   <!-- Start paused? -->
   <arg name="paused" default="false"/>
+  <!-- Acoustic pinger position(s) -->
+  <arg name="pinger_params" default="$(find vrx_gazebo)/config/pinger.yaml"/>
+
   <!-- Initial USV location and attitude-->
   <arg name="x" default="532" />
   <arg name="y" default="-162" />
@@ -63,4 +66,11 @@
         args="-x $(arg x) -y $(arg y) -z $(arg z)
               -R $(arg R) -P $(arg P) -Y $(arg Y)
               -urdf -param $(arg namespace)/robot_description -model wamv"/>
+
+  <!-- Set the pinger location -->
+  <node name="set_pinger_position" pkg="vrx_gazebo" type="set_pinger_position.py" output="screen">
+    <rosparam command="load" file="$(arg pinger_params)" />
+  </node>
+  <node name="pinger_visualization" pkg="vrx_gazebo" type="pinger_visualization.py" />
+
 </launch>

--- a/vrx_gazebo/worlds/example_course.world.xacro
+++ b/vrx_gazebo/worlds/example_course.world.xacro
@@ -7,7 +7,6 @@
     <!--Waves-->
     <xacro:include filename="$(find wave_gazebo)/world_models/ocean_waves/model.xacro"/>
     <xacro:ocean_waves scale="2.5"/>
-
     <xacro:include filename="$(find vrx_gazebo)/worlds/xacros/usv_wind_plugin.xacro"/>
     <xacro:usv_wind_gazebo>
       <wind_objs>
@@ -18,5 +17,51 @@
         </wind_obj>
       </wind_objs>
     </xacro:usv_wind_gazebo>
+
+    <!-- The light buoy -->
+    <include>
+      <uri>model://robotx_light_buoy</uri>
+      <pose>511 -218 0.25 0 0 0</pose>
+    </include>
+
+    <!-- The 2022 dock with the placards -->
+    <include>
+      <uri>model://dock_2022</uri>
+      <pose>554 -233 0 0 0 0</pose>
+    </include>
+
+    <!-- The VRX animal buoys -->
+    <include>
+      <name>crocodile_buoy</name>
+      <pose>552 -170 0 0 0 0</pose>
+      <uri>model://crocodile_buoy</uri>
+    </include>
+
+    <include>
+      <name>platypus_buoy</name>
+      <pose>512 -170 0 0 0 0</pose>
+      <uri>model://platypus_buoy</uri>
+    </include>
+
+    <include>
+      <name>turtle_buoy</name>
+      <pose>472 -170 0 0 0 0</pose>
+      <uri>model://turtle_buoy</uri>
+    </include>
+
+    <!-- The navigation course -->
+    <include>
+      <uri>model://short_navigation_course0</uri>
+      <pose>475 -185 0 0 0 1.0</pose>
+    </include>
+
+    <!-- The obstacle course -->
+    <include>
+      <name>buoys</name>
+      <uri>model://obstacle_course</uri>
+      <pose>420 -295 0 0 0 1.1</pose>
+    </include>
+
+
   </world>
 </sdf>


### PR DESCRIPTION
This resolves issue #279

To test, run:
```
roslaunch vrx_gazebo vrx.launch
```
You should see the light buoy, docks, gymkhana course and our 3 animals:

![vrx_2022_launch](https://user-images.githubusercontent.com/8611855/132930465-43161c89-a962-49e5-b973-3c6387f1a62c.png)
