### PR TITLE
Fix pinger.launch

### DIFF
--- a/vrx_gazebo/launch/pinger.launch
+++ b/vrx_gazebo/launch/pinger.launch
@@ -3,5 +3,5 @@
   <node name="set_pinger_position" pkg="vrx_gazebo" type="set_pinger_position.py" output="screen">
     <rosparam command="load" file="$(find vrx_gazebo)/config/pinger.yaml" />
   </node>
-  <node name="pinger_visualisation" pkg="vrx_gazebo" type="pinger_visualisation.py" />
+  <node name="pinger_visualisation" pkg="vrx_gazebo" type="pinger_visualization.py" />
 </launch>

--- a/vrx_gazebo/launch/pinger.launch
+++ b/vrx_gazebo/launch/pinger.launch
@@ -3,5 +3,5 @@
   <node name="set_pinger_position" pkg="vrx_gazebo" type="set_pinger_position.py" output="screen">
     <rosparam command="load" file="$(find vrx_gazebo)/config/pinger.yaml" />
   </node>
-  <node name="pinger_visualisation" pkg="vrx_gazebo" type="pinger_visualization.py" />
+  <node name="pinger_vizualisation" pkg="vrx_gazebo" type="pinger_visualization.py" />
 </launch>

--- a/vrx_gazebo/launch/pinger.launch
+++ b/vrx_gazebo/launch/pinger.launch
@@ -3,5 +3,5 @@
   <node name="set_pinger_position" pkg="vrx_gazebo" type="set_pinger_position.py" output="screen">
     <rosparam command="load" file="$(find vrx_gazebo)/config/pinger.yaml" />
   </node>
-  <node name="pinger_vizualisation" pkg="vrx_gazebo" type="pinger_visualization.py" />
+  <node name="pinger_visualization" pkg="vrx_gazebo" type="pinger_visualization.py" />
 </launch>


### PR DESCRIPTION
While testing the [acoustic pinger tutorial](https://github.com/osrf/vrx/wiki/acoustic_pinger_tutorial), the following command failed:

```
 roslaunch vrx_gazebo pinger.launch
```

with this error message:

```
ERROR: cannot launch node of type [vrx_gazebo/pinger_visualisation.py]: Cannot locate node of type [pinger_visualisation.py] in package [vrx_gazebo]. Make sure file exists in package path and permission is set to executable (chmod +x)
```

The problem is that `pinger.launch` contains a typo. This pull request fixes it.