### PR TITLE
Deconflicting plugin name with VORC

### DIFF
--- a/vrx_gazebo/CMakeLists.txt
+++ b/vrx_gazebo/CMakeLists.txt
@@ -222,13 +222,13 @@ install(TARGETS wayfinding_scoring_plugin
 )
 
 # Plugin for scoring gymkhana task
-add_library(gymkhana_scoring_plugin src/gymkhana_scoring_plugin.cc)
-target_link_libraries(gymkhana_scoring_plugin
+add_library(gymkhana_vrx_scoring_plugin src/gymkhana_scoring_plugin.cc)
+target_link_libraries(gymkhana_vrx_scoring_plugin
   ${catkin_LIBRARIES}
   scoring_plugin
 )
 
-install(TARGETS gymkhana_scoring_plugin
+install(TARGETS gymkhana_vrx_scoring_plugin
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/vrx_gazebo/worlds/gymkhana.world.xacro
+++ b/vrx_gazebo/worlds/gymkhana.world.xacro
@@ -40,7 +40,7 @@
 
     <!-- Top-level scoring plugin -->
     <plugin name="gymkhana_scoring_plugin"
-            filename="libgymkhana_scoring_plugin.so">
+            filename="libgymkhana_vrx_scoring_plugin.so">
       <vehicle>wamv</vehicle>
       <task_name>gymkhana</task_name>
       <task_info_topic>/vrx/task/info</task_info_topic>


### PR DESCRIPTION
The name Gymkhana plugin name was already in use by VORC, so introducing the same name in VRX introduces a build error.  This changes the plugin library name, leaving the source file names that same.

Currently working on testing with VORC - would appreciate someone testing with the VRX Gymkhana task scoring.