### PR TITLE
Remove p3d from sensor config example

### DIFF
--- a/vrx_gazebo/config/wamv_config/example_sensor_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_sensor_config.yaml
@@ -17,8 +17,6 @@ wamv_gps:
 wamv_imu:
     - name: imu_wamv
       y: -0.2
-wamv_p3d:
-    - name: p3d_wamv
 lidar:
     - name: lidar_wamv
       type: 16_beam


### PR DESCRIPTION
We don't allow a `p3d` sensor (ground truth) as part of the `sensor_config.yaml` anymore. However the example that we're shipping includes a `p3d` sensor.