### PR TITLE
Add a xacro for generating gymkhana worlds

### DIFF
--- a/vrx_gazebo/worlds/xacros/gymkhana.xacro
+++ b/vrx_gazebo/worlds/xacros/gymkhana.xacro
@@ -30,7 +30,7 @@
       <contact_debug_topic>/vrx/debug/contact</contact_debug_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
-      <running_state_duration>300</running_state_duration>
+      <running_state_duration>${running_duration}</running_state_duration>
       <!-- Per-plugin flag, different from env var VRX_EXIT_ON_COMPLETION.
            Respect top-level plugin finished status. -->
       <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
@@ -48,7 +48,7 @@
       <per_plugin_exit_on_completion>false</per_plugin_exit_on_completion>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
-      <running_state_duration>300</running_state_duration>
+      <running_state_duration>${running_duration}</running_state_duration>
       <collision_buffer>10</collision_buffer>
       <release_joints>
         <joint>
@@ -84,7 +84,7 @@
       <goal_pose_cart>${gx} ${gy} 0</goal_pose_cart>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
-      <running_state_duration>300</running_state_duration>
+      <running_state_duration>${running_duration}</running_state_duration>
       <release_joints>
         <joint>
           <name>wamv_external_pivot_joint</name>

--- a/vrx_gazebo/worlds/xacros/gymkhana.xacro
+++ b/vrx_gazebo/worlds/xacros/gymkhana.xacro
@@ -25,7 +25,7 @@
     <plugin name="gymkhana_scoring_plugin"
             filename="libgymkhana_vrx_scoring_plugin.so">
       <vehicle>wamv</vehicle>
-      <task_name>${gymkhana}</task_name>
+      <task_name>${name}</task_name>
       <task_info_topic>/vrx/task/info</task_info_topic>
       <contact_debug_topic>/vrx/debug/contact</contact_debug_topic>
       <initial_state_duration>10</initial_state_duration>
@@ -58,7 +58,7 @@
           <name>wamv_external_riser</name>
         </joint>
       </release_joints>
-      <course_name>short_navigation_course_0</course_name>
+      <course_name>${nav_uri}</course_name>
       <obstacle_penalty>10.0</obstacle_penalty>
       <gates>
         <xacro:insert_block name="gates"/>

--- a/vrx_gazebo/worlds/xacros/gymkhana.xacro
+++ b/vrx_gazebo/worlds/xacros/gymkhana.xacro
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<world xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:macro name="gymkhana" params="name='gymkhana' 
+   nav_uri:=short_navigation_course0
+   obstacle_uri:=obstacle_course
+   nx:=-524 ny:=186 nz:=0 nR:=0 nP:=0 nY:=-1.44 
+   ox:=-477 oy:=275 oz:=0 oR:=0 oP:=0 oY:=2.54 
+   gx:=-483 gy:=295.5 
+   running_duration:=300 **gates">
+    <!-- The navigation course -->
+    <include>
+      <name>${name}_navigation_course</name>
+      <uri>model://${nav_uri}</uri>
+      <pose>${nx} ${ny} ${nz} ${nR} ${nP} ${nY}</pose>
+    </include>
+
+    <!-- The obstacle course -->
+    <include>
+      <name>${name}_obstacle_course</name>
+      <uri>model://${obstacle_uri}</uri>
+      <pose>${ox} ${oy} ${oz} ${oR} ${oP} ${oY}</pose>
+    </include>
+
+    <!-- Top-level scoring plugin -->
+    <plugin name="gymkhana_scoring_plugin"
+            filename="libgymkhana_vrx_scoring_plugin.so">
+      <vehicle>wamv</vehicle>
+      <task_name>${gymkhana}</task_name>
+      <task_info_topic>/vrx/task/info</task_info_topic>
+      <contact_debug_topic>/vrx/debug/contact</contact_debug_topic>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <!-- Per-plugin flag, different from env var VRX_EXIT_ON_COMPLETION.
+           Respect top-level plugin finished status. -->
+      <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
+      <obstacle_penalty>1</obstacle_penalty>
+    </plugin>
+
+    <!-- Scoring plugin for buoy channel portion -->
+    <plugin name="navigation_scoring_plugin"
+            filename="libnavigation_scoring_plugin.so">
+      <vehicle>wamv</vehicle>
+      <task_name>gymkhana_channel</task_name>
+      <task_info_topic>/vrx/gymkhana_channel/task/info</task_info_topic>
+      <contact_debug_topic>/vrx/gymkhana_channel/debug/contact</contact_debug_topic>
+      <!-- Keep Gazebo running after this sub-task is completed -->
+      <per_plugin_exit_on_completion>false</per_plugin_exit_on_completion>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <collision_buffer>10</collision_buffer>
+      <release_joints>
+        <joint>
+          <name>wamv_external_pivot_joint</name>
+        </joint>
+        <joint>
+          <name>wamv_external_riser</name>
+        </joint>
+      </release_joints>
+      <course_name>short_navigation_course_0</course_name>
+      <obstacle_penalty>10.0</obstacle_penalty>
+      <gates>
+        <xacro:insert_block name="gates"/>
+       </gates>
+      <silent>true</silent>
+    </plugin>
+
+    <!-- Scoring plugin for acoustic pinger portion -->
+    <plugin name="stationkeeping_scoring_plugin"
+          filename="libstationkeeping_scoring_plugin.so">
+      <vehicle>wamv</vehicle>
+      <task_name>gymkhana_blackbox</task_name>
+      <mean_error_topic>/vrx/gymkhana_blackbox/mean_pose_error</mean_error_topic>
+      <pose_error_topic>/vrx/gymkhana_blackbox/pose_error</pose_error_topic>
+      <goal_topic>/vrx/gymkhana_blackbox/goal</goal_topic>
+      <task_info_topic>/vrx/gymkhana_blackbox/task/info</task_info_topic>
+      <contact_debug_topic>/vrx/gymkhana_blackbox/debug/contact</contact_debug_topic>
+      <!-- Keep Gazebo running after this sub-task is completed -->
+      <per_plugin_exit_on_completion>false</per_plugin_exit_on_completion>
+      <!-- Disable heading error -->
+      <head_error_on>false</head_error_on>
+      <!-- Goal as Cartesian coordinates -->
+      <goal_pose_cart>${gx} ${gy} 0</goal_pose_cart>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_joints>
+        <joint>
+          <name>wamv_external_pivot_joint</name>
+        </joint>
+        <joint>
+          <name>wamv_external_riser</name>
+        </joint>
+      </release_joints>
+      <markers>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
+      </markers>
+      <silent>true</silent>
+    </plugin>
+
+  </xacro:macro>
+</world>

--- a/vrx_gazebo/worlds/xacros/gymkhana.xacro
+++ b/vrx_gazebo/worlds/xacros/gymkhana.xacro
@@ -58,7 +58,7 @@
           <name>wamv_external_riser</name>
         </joint>
       </release_joints>
-      <course_name>${nav_uri}</course_name>
+      <course_name>${name}_navigation_course</course_name>
       <obstacle_penalty>10.0</obstacle_penalty>
       <gates>
         <xacro:insert_block name="gates"/>

--- a/vrx_gazebo/worlds/xacros/include_all_xacros.xacro
+++ b/vrx_gazebo/worlds/xacros/include_all_xacros.xacro
@@ -20,6 +20,7 @@
     <xacro:include filename="$(find vrx_gazebo)/worlds/xacros/wayfinding.xacro" />
     <xacro:include filename="$(find vrx_gazebo)/worlds/xacros/wildlife.xacro" />
     <xacro:include filename="$(find vrx_gazebo)/worlds/xacros/scan_dock_deliver.xacro" />
+    <xacro:include filename="$(find vrx_gazebo)/worlds/xacros/gymkhana.xacro" />
     <xacro:include filename="$(find vrx_gazebo)/worlds/xacros/insert_model.xacro" />
   </xacro:macro>
 </world>

--- a/vrx_gazebo/worlds/xacros/scan_dock_deliver.xacro
+++ b/vrx_gazebo/worlds/xacros/scan_dock_deliver.xacro
@@ -26,8 +26,6 @@
     </xacro:if>
 
     <!-- Plugin to detect if the projectile entered the hole -->
-    <!-- Debug: Run this command to face this hole -->
-    <!-- gz model -m wamv -x -555.21 -y 229.75 -z 0 -Y 3.14159 -->
     <plugin name="contain_placard1_big_plugin" filename="libContainPlugin.so">
       <enabled>true</enabled>
       <entity>blue_projectile::link</entity>
@@ -41,8 +39,6 @@
     </plugin>
 
     <!-- Plugin to detect if the projectile entered the hole -->
-    <!-- Debug: Run this command to face this hole -->
-    <!-- gz model -m wamv -x -555.28 -y 230.32 -z 0 -Y 3.01159 -->
     <plugin name="contain_placard1_small_plugin" filename="libContainPlugin.so">
       <enabled>true</enabled>
       <entity>blue_projectile::link</entity>
@@ -56,8 +52,6 @@
     </plugin>
 
     <!-- Plugin to detect if the projectile entered the hole -->
-    <!-- Debug: Run this command to face this hole -->
-    <!-- gz model -m wamv -x -555.21 -y 223.75 -z 0 -Y 3.14159 -->
     <plugin name="contain_placard2_big_plugin" filename="libContainPlugin.so">
       <enabled>true</enabled>
       <entity>blue_projectile::link</entity>
@@ -71,8 +65,6 @@
     </plugin>
 
     <!-- Plugin to detect if the projectile entered the hole -->
-    <!-- Debug: Run this command to face this hole -->
-    <!-- gz model -m wamv -x -555.25 -y 223.75 -z 0 -Y 2.91159 -->
     <plugin name="contain_placard2_small_plugin" filename="libContainPlugin.so">
       <enabled>true</enabled>
       <entity>blue_projectile::link</entity>
@@ -86,8 +78,6 @@
     </plugin>
 
     <!-- Plugin to detect if the projectile entered the hole -->
-    <!-- Debug: Run this command to face this hole -->
-    <!-- gz model -m wamv -x -555.25 -y 217.75 -z 0 -Y 3.14159 -->
     <plugin name="contain_placard3_big_plugin" filename="libContainPlugin.so">
       <enabled>true</enabled>
       <entity>blue_projectile::link</entity>
@@ -101,8 +91,6 @@
     </plugin>
 
     <!-- Plugin to detect if the projectile entered the hole -->
-    <!-- Debug: Run this command to face this hole -->
-    <!-- gz model -m wamv -x -555.25 -y 217.75 -z 0 -Y 2.89159 -->
     <plugin name="contain_placard3_small_plugin" filename="libContainPlugin.so">
       <enabled>true</enabled>
       <entity>blue_projectile::link</entity>

--- a/vrx_gazebo/worlds/xacros/scan_dock_deliver.xacro
+++ b/vrx_gazebo/worlds/xacros/scan_dock_deliver.xacro
@@ -11,7 +11,6 @@
     lb_x:=90 lb_y:=70 lb_z:=0 lb_R:=0 lb_P:=0 lb_Y:=0
     enable_color_checker:=false
 		task_name:=scan_dock_deliver">
-    <!-- The 2018 dock with the two placards -->
     <include>
       <uri>model://${uri}</uri>
       <pose>${x} ${y} ${z} ${R} ${P} ${Y}</pose>


### PR DESCRIPTION
Adds gymkhana.xacro, for use with the `generate_worlds` script to create practice worlds. This PR should be tested in conjunction with [PR 41](https://github.com/osrf/vrx-docker/pull/41) in the `vrx-docker` repo, using the testing instructions listed there.