### PR TITLE
Adding wind and paused to stationkeeping demonstrations

### DIFF
--- a/vrx_gazebo/launch/station_keeping.launch
+++ b/vrx_gazebo/launch/station_keeping.launch
@@ -7,6 +7,8 @@
   <arg name="gui" default="true" />
   <!-- If true, run gazebo in verbose mode -->
   <arg name="verbose" default="false"/>
+  <!-- Start in paused state?-->
+  <arg name="paused" default="false"/>
   <!-- Set various other gazebo arguments-->
   <arg name="extra_gazebo_args" default=""/>
   <!-- Start in a default namespace -->
@@ -36,7 +38,7 @@
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(arg world)"/>
     <arg name="verbose" value="$(arg verbose)"/>
-    <arg name="paused" value="false"/>
+    <arg name="paused" value="$(arg paused)"/>
     <arg name="use_sim_time" value="true"/>
     <arg name="gui" value="$(arg gui)" />
     <arg name="extra_gazebo_args" value="$(arg extra_gazebo_args)"/>

--- a/vrx_gazebo/worlds/stationkeeping_task.world.xacro
+++ b/vrx_gazebo/worlds/stationkeeping_task.world.xacro
@@ -7,9 +7,14 @@
     <!--Waves-->
     <xacro:include filename="$(find wave_gazebo)/world_models/ocean_waves/model.xacro"/>
     <xacro:ocean_waves scale="2.5"/>
-    <!--wind for the wamv-->
+    <!--Wind-->
     <xacro:include filename="$(find vrx_gazebo)/worlds/xacros/usv_wind_plugin.xacro"/>
-    <xacro:usv_wind_gazebo>
+    <xacro:usv_wind_gazebo
+	direction="270"
+	mean_vel="0"
+	var_gain="0"
+	var_time="10"
+	seed="42">
       <wind_objs>
         <wind_obj>
           <name>wamv</name>


### PR DESCRIPTION
This PR makes some small tweaks to the launch and world files for the station-keeping task demo.  These were created as part of the kickoff demonstration to illustrate parameterized wind for testing.  Exposing the `paused` argument in the launch file is typical and expected.