### PR TITLE
Suppress tf warnings

### DIFF
--- a/wamv_gazebo/launch/localization_example.launch
+++ b/wamv_gazebo/launch/localization_example.launch
@@ -2,6 +2,9 @@
 <!-- Example of ROS localization using the example wamv with sensors -->
 <launch>
 
+  <!-- Supress tf warnings -->
+  <rosparam param="silent_tf_failure">true</rosparam>
+
   <!-- Kalman filter fusing imu and gps into combined odometry/tf -->
   <node ns="wamv/robot_localization" pkg="robot_localization" type="ekf_localization_node"
         name="ekf_localization" clear_params="false">


### PR DESCRIPTION
Now that [this patch](https://github.com/cra-ros-pkg/robot_localization/pull/705#issuecomment-971376750) has been merged into the `robot_localization` package, we'll need to exercise this functionality.

Until there's a new ROS noetic release, we'll need to install `robot_localization` manually to observe this functionality working.

How to test it:

1. First, compile `robot_localization` from source with our patch:
```
cd <your_vrx_ws>/src
git clone https://github.com/cra-ros-pkg/robot_localization.git
cd ..
catkin_make
```

2. Launch vrx as usual:
```
roslaunch vrx_gazebo vrx.launch
```

3. Launch our localization example
```
roslaunch wamv_gazebo localization_example.launch
```

You shouldn't see any warnings.