### PR TITLE
Potential fix for wildlife encounter animal poses

### DIFF
--- a/vrx_gazebo/CMakeLists.txt
+++ b/vrx_gazebo/CMakeLists.txt
@@ -394,13 +394,13 @@ install(DIRECTORY include/
 install(PROGRAMS scripts/spawn_wamv.bash
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-if(CATKIN_ENABLE_TESTING)
-  find_package(rostest REQUIRED)
-  add_rostest_gtest(sandisland_test
-                    test/sandisland.test
-                    test/sandisland.cc)
-  target_link_libraries(sandisland_test ${catkin_LIBRARIES})
-endif()
+#if(CATKIN_ENABLE_TESTING)
+#  find_package(rostest REQUIRED)
+#  add_rostest_gtest(sandisland_test
+#                    test/sandisland.test
+#                    test/sandisland.cc)
+#  target_link_libraries(sandisland_test ${catkin_LIBRARIES})
+#endif()
 
 # Python Scripts
 catkin_install_python(PROGRAMS

--- a/vrx_gazebo/CMakeLists.txt
+++ b/vrx_gazebo/CMakeLists.txt
@@ -394,13 +394,13 @@ install(DIRECTORY include/
 install(PROGRAMS scripts/spawn_wamv.bash
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-#if(CATKIN_ENABLE_TESTING)
-#  find_package(rostest REQUIRED)
-#  add_rostest_gtest(sandisland_test
-#                    test/sandisland.test
-#                    test/sandisland.cc)
-#  target_link_libraries(sandisland_test ${catkin_LIBRARIES})
-#endif()
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  add_rostest_gtest(sandisland_test
+                    test/sandisland.test
+                    test/sandisland.cc)
+  target_link_libraries(sandisland_test ${catkin_LIBRARIES})
+endif()
 
 # Python Scripts
 catkin_install_python(PROGRAMS

--- a/vrx_gazebo/src/wildlife_scoring_plugin.cc
+++ b/vrx_gazebo/src/wildlife_scoring_plugin.cc
@@ -461,13 +461,13 @@ void WildlifeScoringPlugin::PublishAnimalLocations()
     // Conversion from Gazebo Cartesian coordinates to spherical.
 #if GAZEBO_MAJOR_VERSION >= 8
     const ignition::math::Pose3d pose = buoy.link->WorldPose();
-    const ignition::math::Vector3d position = 
+    const ignition::math::Vector3d position =
       this->world->SphericalCoords()->GlobalFromLocal(pose.Pos());
     const ignition::math::Vector3d latlon =
       this->world->SphericalCoords()->SphericalFromLocal(position);
 #else
     const ignition::math::Pose3d pose = buoy.link->GetWorldPose().Ign();
-    const ignition::math::Vector3d position = 
+    const ignition::math::Vector3d position =
       this->world->GetSphericalCoordinates()->GlobalFromLocal(pose.Pos());
     const ignition::math::Vector3d latlon =
       this->world->GetSphericalCoordinates()->SphericalFromLocal(position);

--- a/vrx_gazebo/src/wildlife_scoring_plugin.cc
+++ b/vrx_gazebo/src/wildlife_scoring_plugin.cc
@@ -461,12 +461,14 @@ void WildlifeScoringPlugin::PublishAnimalLocations()
     // Conversion from Gazebo Cartesian coordinates to spherical.
 #if GAZEBO_MAJOR_VERSION >= 8
     const ignition::math::Pose3d pose = buoy.link->WorldPose();
-    const ignition::math::Vector3d position = this->world->SphericalCoords()->GlobalFromLocal(pose.Pos());
+    const ignition::math::Vector3d position = 
+      this->world->SphericalCoords()->GlobalFromLocal(pose.Pos());
     const ignition::math::Vector3d latlon =
       this->world->SphericalCoords()->SphericalFromLocal(position);
 #else
     const ignition::math::Pose3d pose = buoy.link->GetWorldPose().Ign();
-    const ignition::math::Vector3d position = this->world->GetSphericalCoordinates()->GlobalFromLocal(pose.Pos());
+    const ignition::math::Vector3d position = 
+      this->world->GetSphericalCoordinates()->GlobalFromLocal(pose.Pos());
     const ignition::math::Vector3d latlon =
       this->world->GetSphericalCoordinates()->SphericalFromLocal(position);
 #endif

--- a/vrx_gazebo/src/wildlife_scoring_plugin.cc
+++ b/vrx_gazebo/src/wildlife_scoring_plugin.cc
@@ -461,12 +461,14 @@ void WildlifeScoringPlugin::PublishAnimalLocations()
     // Conversion from Gazebo Cartesian coordinates to spherical.
 #if GAZEBO_MAJOR_VERSION >= 8
     const ignition::math::Pose3d pose = buoy.link->WorldPose();
+    const ignition::math::Vector3d position = this->world->SphericalCoords()->GlobalFromLocal(pose.Pos());
     const ignition::math::Vector3d latlon =
-      this->world->SphericalCoords()->SphericalFromLocal(pose.Pos());
+      this->world->SphericalCoords()->SphericalFromLocal(position);
 #else
     const ignition::math::Pose3d pose = buoy.link->GetWorldPose().Ign();
+    const ignition::math::Vector3d position = this->world->GetSphericalCoordinates()->GlobalFromLocal(pose.Pos());
     const ignition::math::Vector3d latlon =
-      this->world->GetSphericalCoordinates()->SphericalFromLocal(pose.Pos());
+      this->world->GetSphericalCoordinates()->SphericalFromLocal(position);
 #endif
     const ignition::math::Quaternion<double> orientation = pose.Rot();
 


### PR DESCRIPTION
(Issue #420)
This converts the animal xyz coordinates to a global Cartesian frame before calling the ```SphericalFromLocal``` function in ```wildlife_scoring_plugin.cc```. I am unsure exactly why this works, but I properly receive the spherical coordinates from the ```vrx/wildlife/animals/poses``` topic now.

I do notice that the function I added that converts the xyz coordinates to a global Cartesian frame (```GlobalFromLocal```) simply rotates the position of the animals about the Gazebo origin frame (both x and y are negated). 