### PR TITLE
added ability to add wamv_pinger to component.yaml

### DIFF
--- a/vrx_gazebo/config/wamv_config/component_compliance/numeric.yaml
+++ b/vrx_gazebo/config/wamv_config/component_compliance/numeric.yaml
@@ -62,7 +62,7 @@ wamv_ball_shooter:
         yaw
         name
 wamv_pinger:
-    num: 0
+    num: 1
     allowed_params:
         position
         name

--- a/vrx_gazebo/config/wamv_config/component_compliance/numeric.yaml
+++ b/vrx_gazebo/config/wamv_config/component_compliance/numeric.yaml
@@ -61,3 +61,8 @@ wamv_ball_shooter:
         pitch
         yaw
         name
+wamv_pinger:
+    num: 0
+    allowed_params:
+        position
+        name


### PR DESCRIPTION
Edited numeric.yaml such that a ```wamv_pinger``` can be added to a component.yaml if the user chooses to use yaml component generation. Related issue: #423 