### PR TITLE
Fix spherical coordinates FromLocal calls

### DIFF
--- a/vrx_gazebo/config/wamv_config/component_compliance/numeric.yaml
+++ b/vrx_gazebo/config/wamv_config/component_compliance/numeric.yaml
@@ -61,3 +61,8 @@ wamv_ball_shooter:
         pitch
         yaw
         name
+wamv_pinger:
+    num: 1
+    allowed_params:
+        position
+        name

--- a/vrx_gazebo/include/vrx_gazebo/scoring_plugin.hh
+++ b/vrx_gazebo/include/vrx_gazebo/scoring_plugin.hh
@@ -26,6 +26,7 @@
 #include <gazebo/common/Events.hh>
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/common/Time.hh>
+#include <ignition/math/SphericalCoordinates.hh>
 #include <gazebo/physics/World.hh>
 #include <sdf/sdf.hh>
 #include <gazebo/transport/transport.hh>
@@ -232,6 +233,9 @@ class ScoringPlugin : public gazebo::WorldPlugin
 
   /// \brief Silent mode enabled?
   protected: bool silent = false;
+
+  /// \brief Spherical coordinates conversions.
+  protected: ignition::math::SphericalCoordinates sc;
 
   /// \brief gazebo node pointer
   private: gazebo::transport::NodePtr gzNode;

--- a/vrx_gazebo/src/perception_scoring_plugin.cc
+++ b/vrx_gazebo/src/perception_scoring_plugin.cc
@@ -407,13 +407,9 @@ void PerceptionScoringPlugin::OnAttempt(
       // Snippet from UUV Simulator SphericalCoordinatesROSInterfacePlugin.cc
       ignition::math::Vector3d scVec(_msg->pose.position.latitude,
         _msg->pose.position.longitude, 0);
-      #if GAZEBO_MAJOR_VERSION >= 8
-        ignition::math::Vector3d cartVec =
-          this->sc.LocalFromSphericalPosition(scVec);
-      #else
-        ignition::math::Vector3d cartVec =
-        this->world->GetSphericalCoordinates()->LocalFromSpherical(scVec);
-      #endif
+      ignition::math::Vector3d cartVec =
+        this->sc.LocalFromSphericalPosition(scVec);
+
       // Get current pose of the current object
       #if GAZEBO_MAJOR_VERSION >= 8
         ignition::math::Pose3d truePose = obj.modelPtr->WorldPose();

--- a/vrx_gazebo/src/perception_scoring_plugin.cc
+++ b/vrx_gazebo/src/perception_scoring_plugin.cc
@@ -409,7 +409,7 @@ void PerceptionScoringPlugin::OnAttempt(
         _msg->pose.position.longitude, 0);
       #if GAZEBO_MAJOR_VERSION >= 8
         ignition::math::Vector3d cartVec =
-        this->world->SphericalCoords()->LocalFromSpherical(scVec);
+          this->sc.LocalFromSphericalPosition(scVec);
       #else
         ignition::math::Vector3d cartVec =
         this->world->GetSphericalCoordinates()->LocalFromSpherical(scVec);

--- a/vrx_gazebo/src/scoring_plugin.cc
+++ b/vrx_gazebo/src/scoring_plugin.cc
@@ -44,7 +44,11 @@ void ScoringPlugin::Load(gazebo::physics::WorldPtr _world,
   }
 
   // Initialize spherical coordinates.
+#if GAZEBO_MAJOR_VERSION >= 8
   auto gzSC = _world->SphericalCoords();
+#else
+  auto gzSC = _world->GetSphericalCoordinates();
+#endif
   this->sc.SetLatitudeReference(gzSC->LatitudeReference());
   this->sc.SetLongitudeReference(gzSC->LongitudeReference());
   this->sc.SetElevationReference(gzSC->GetElevationReference());

--- a/vrx_gazebo/src/scoring_plugin.cc
+++ b/vrx_gazebo/src/scoring_plugin.cc
@@ -43,6 +43,13 @@ void ScoringPlugin::Load(gazebo::physics::WorldPtr _world,
     return;
   }
 
+  // Initialize spherical coordinates.
+  auto gzSC = _world->SphericalCoords();
+  this->sc.SetLatitudeReference(gzSC->LatitudeReference());
+  this->sc.SetLongitudeReference(gzSC->LongitudeReference());
+  this->sc.SetElevationReference(gzSC->GetElevationReference());
+  this->sc.SetHeadingOffset(gzSC->HeadingOffset());
+
   this->readyTime.Set(this->initialStateDuration);
   this->runningTime = this->readyTime + this->readyStateDuration;
   this->finishTime = this->runningTime + this->runningStateDuration;

--- a/vrx_gazebo/src/stationkeeping_scoring_plugin.cc
+++ b/vrx_gazebo/src/stationkeeping_scoring_plugin.cc
@@ -98,15 +98,19 @@ void StationkeepingScoringPlugin::Load(gazebo::physics::WorldPtr _world,
     scVec.X(IGN_RTOD(scVec.X()));
     scVec.Y(IGN_RTOD(scVec.Y()));
 #elif GAZEBO_MAJOR_VERSION >= 8
-    const ignition::math::Vector3d position =
-      _world->SphericalCoords()->GlobalFromLocal(cartVec);
     ignition::math::Vector3d scVec =
-      _world->SphericalCoords()->SphericalFromLocal(position);
+      _world->SphericalCoords()->PositionTransform(cartVec,
+        gazebo::common::SphericalCoordinates::CoordinateType::GLOBAL,
+        gazebo::common::SphericalCoordinates::CoordinateType::SPHERICAL);
+    scVec.X(IGN_RTOD(scVec.X()));
+    scVec.Y(IGN_RTOD(scVec.Y()));
 #else
-    const ignition::math::Vector3d position =
-      _world->GetSphericalCoordinates()->GlobalFromLocal(cartVec);
     ignition::math::Vector3d scVec =
-      _world->GetSphericalCoordinates()->SphericalFromLocal(position);
+      _world->GetSphericalCoordinates()->PositionTransform(cartVec,
+        gazebo::common::SphericalCoordinates::CoordinateType::GLOBAL,
+        gazebo::common::SphericalCoordinates::CoordinateType::SPHERICAL);
+    scVec.X(IGN_RTOD(scVec.X()));
+    scVec.Y(IGN_RTOD(scVec.Y()));
 #endif
 
     // Store spherical 2D location

--- a/vrx_gazebo/src/stationkeeping_scoring_plugin.cc
+++ b/vrx_gazebo/src/stationkeeping_scoring_plugin.cc
@@ -66,14 +66,8 @@ void StationkeepingScoringPlugin::Load(gazebo::physics::WorldPtr _world,
     // Convert lat/lon to local
     // Snippet from UUV Simulator SphericalCoordinatesROSInterfacePlugin.cc
     ignition::math::Vector3d scVec(this->goalLat, this->goalLon, 0.0);
-
-#if GAZEBO_MAJOR_VERSION >= 8
     ignition::math::Vector3d cartVec =
       this->sc.LocalFromSphericalPosition(scVec);
-#else
-    ignition::math::Vector3d cartVec =
-      _world->GetSphericalCoordinates()->LocalFromSpherical(scVec);
-#endif
 
     // Store local 2D location and yaw
     this->goalX = cartVec.X();
@@ -93,7 +87,7 @@ void StationkeepingScoringPlugin::Load(gazebo::physics::WorldPtr _world,
     // Snippet from UUV Simulator SphericalCoordinatesROSInterfacePlugin.cc
     ignition::math::Vector3d cartVec(this->goalX, this->goalY, xyz.Z());
 
-#if GAZEBO_MAJOR_VERSION >= 8
+#if GAZEBO_MAJOR_VERSION >= 11
     // There's a known bug with the SphericalFromLocal() computation.
     // We use our own SphericalCoordinates object from Ignition Math and we call
     // PositionTransform() directly containing the correct version.
@@ -103,6 +97,11 @@ void StationkeepingScoringPlugin::Load(gazebo::physics::WorldPtr _world,
         ignition::math::SphericalCoordinates::CoordinateType::SPHERICAL);
     scVec.X(IGN_RTOD(scVec.X()));
     scVec.Y(IGN_RTOD(scVec.Y()));
+#elif GAZEBO_MAJOR_VERSION >= 8
+    const ignition::math::Vector3d position =
+      _world->SphericalCoords()->GlobalFromLocal(cartVec);
+    ignition::math::Vector3d scVec =
+      _world->SphericalCoords()->SphericalFromLocal(position);
 #else
     const ignition::math::Vector3d position =
       _world->GetSphericalCoordinates()->GlobalFromLocal(cartVec);

--- a/vrx_gazebo/src/stationkeeping_scoring_plugin.cc
+++ b/vrx_gazebo/src/stationkeeping_scoring_plugin.cc
@@ -87,31 +87,11 @@ void StationkeepingScoringPlugin::Load(gazebo::physics::WorldPtr _world,
     // Snippet from UUV Simulator SphericalCoordinatesROSInterfacePlugin.cc
     ignition::math::Vector3d cartVec(this->goalX, this->goalY, xyz.Z());
 
-#if GAZEBO_MAJOR_VERSION >= 11
-    // There's a known bug with the SphericalFromLocal() computation.
-    // We use our own SphericalCoordinates object from Ignition Math and we call
-    // PositionTransform() directly containing the correct version.
-    ignition::math::Vector3d scVec =
-      this->sc.PositionTransform(cartVec,
-        ignition::math::SphericalCoordinates::CoordinateType::LOCAL2,
-        ignition::math::SphericalCoordinates::CoordinateType::SPHERICAL);
+    auto in = ignition::math::SphericalCoordinates::CoordinateType::GLOBAL;
+    auto out = ignition::math::SphericalCoordinates::CoordinateType::SPHERICAL;
+    auto scVec = this->sc.PositionTransform(cartVec, in, out);
     scVec.X(IGN_RTOD(scVec.X()));
     scVec.Y(IGN_RTOD(scVec.Y()));
-#elif GAZEBO_MAJOR_VERSION >= 8
-    ignition::math::Vector3d scVec =
-      _world->SphericalCoords()->PositionTransform(cartVec,
-        gazebo::common::SphericalCoordinates::CoordinateType::GLOBAL,
-        gazebo::common::SphericalCoordinates::CoordinateType::SPHERICAL);
-    scVec.X(IGN_RTOD(scVec.X()));
-    scVec.Y(IGN_RTOD(scVec.Y()));
-#else
-    ignition::math::Vector3d scVec =
-      _world->GetSphericalCoordinates()->PositionTransform(cartVec,
-        gazebo::common::SphericalCoordinates::CoordinateType::GLOBAL,
-        gazebo::common::SphericalCoordinates::CoordinateType::SPHERICAL);
-    scVec.X(IGN_RTOD(scVec.X()));
-    scVec.Y(IGN_RTOD(scVec.Y()));
-#endif
 
     // Store spherical 2D location
     this->goalLat = scVec.X();

--- a/vrx_gazebo/src/stationkeeping_scoring_plugin.cc
+++ b/vrx_gazebo/src/stationkeeping_scoring_plugin.cc
@@ -105,7 +105,7 @@ void StationkeepingScoringPlugin::Load(gazebo::physics::WorldPtr _world,
     scVec.Y(IGN_RTOD(scVec.Y()));
 #else
     const ignition::math::Vector3d position =
-      this->world->SphericalCoords()->GlobalFromLocal(cartVec);
+      _world->GetSphericalCoordinates()->GlobalFromLocal(cartVec);
     ignition::math::Vector3d scVec =
       _world->GetSphericalCoordinates()->SphericalFromLocal(position);
 #endif

--- a/vrx_gazebo/src/stationkeeping_scoring_plugin.cc
+++ b/vrx_gazebo/src/stationkeeping_scoring_plugin.cc
@@ -69,7 +69,7 @@ void StationkeepingScoringPlugin::Load(gazebo::physics::WorldPtr _world,
 
 #if GAZEBO_MAJOR_VERSION >= 8
     ignition::math::Vector3d cartVec =
-      _world->SphericalCoords()->LocalFromSpherical(scVec);
+      this->sc.LocalFromSphericalPosition(scVec);
 #else
     ignition::math::Vector3d cartVec =
       _world->GetSphericalCoordinates()->LocalFromSpherical(scVec);
@@ -94,11 +94,20 @@ void StationkeepingScoringPlugin::Load(gazebo::physics::WorldPtr _world,
     ignition::math::Vector3d cartVec(this->goalX, this->goalY, xyz.Z());
 
 #if GAZEBO_MAJOR_VERSION >= 8
+    // There's a known bug with the SphericalFromLocal() computation.
+    // We use our own SphericalCoordinates object from Ignition Math and we call
+    // PositionTransform() directly containing the correct version.
     ignition::math::Vector3d scVec =
-      _world->SphericalCoords()->SphericalFromLocal(cartVec);
+      this->sc.PositionTransform(cartVec,
+        ignition::math::SphericalCoordinates::CoordinateType::LOCAL2,
+        ignition::math::SphericalCoordinates::CoordinateType::SPHERICAL);
+    scVec.X(IGN_RTOD(scVec.X()));
+    scVec.Y(IGN_RTOD(scVec.Y()));
 #else
+    const ignition::math::Vector3d position =
+      this->world->SphericalCoords()->GlobalFromLocal(cartVec);
     ignition::math::Vector3d scVec =
-      _world->GetSphericalCoordinates()->SphericalFromLocal(cartVec);
+      _world->GetSphericalCoordinates()->SphericalFromLocal(position);
 #endif
 
     // Store spherical 2D location

--- a/vrx_gazebo/src/wayfinding_scoring_plugin.cc
+++ b/vrx_gazebo/src/wayfinding_scoring_plugin.cc
@@ -74,7 +74,7 @@ void WayfindingScoringPlugin::Load(gazebo::physics::WorldPtr _world,
 
 #if GAZEBO_MAJOR_VERSION >= 8
     ignition::math::Vector3d cartVec =
-      _world->SphericalCoords()->LocalFromSpherical(scVec);
+      this->sc.LocalFromSphericalPosition(scVec);
 #else
     ignition::math::Vector3d cartVec =
       _world->GetSphericalCoordinates()->LocalFromSpherical(scVec);

--- a/vrx_gazebo/src/wayfinding_scoring_plugin.cc
+++ b/vrx_gazebo/src/wayfinding_scoring_plugin.cc
@@ -22,7 +22,6 @@
 #include <std_msgs/String.h>
 #include <cmath>
 #include <gazebo/common/Console.hh>
-#include <gazebo/common/SphericalCoordinates.hh>
 #include <ignition/math/Quaternion.hh>
 #include <ignition/math/Vector3.hh>
 #include <gazebo/physics/Model.hh>
@@ -72,13 +71,8 @@ void WayfindingScoringPlugin::Load(gazebo::physics::WorldPtr _world,
     //  snippet from UUV Simulator SphericalCoordinatesROSInterfacePlugin.cc
     ignition::math::Vector3d scVec(latlonyaw.X(), latlonyaw.Y(), 0.0);
 
-#if GAZEBO_MAJOR_VERSION >= 8
     ignition::math::Vector3d cartVec =
       this->sc.LocalFromSphericalPosition(scVec);
-#else
-    ignition::math::Vector3d cartVec =
-      _world->GetSphericalCoordinates()->LocalFromSpherical(scVec);
-#endif
 
     cartVec.Z() = latlonyaw.Z();
 

--- a/vrx_gazebo/src/wildlife_scoring_plugin.cc
+++ b/vrx_gazebo/src/wildlife_scoring_plugin.cc
@@ -474,7 +474,7 @@ void WildlifeScoringPlugin::PublishAnimalLocations()
 #elif GAZEBO_MAJOR_VERSION >= 8
     const ignition::math::Pose3d pose = buoy.link->WorldPose();
     ignition::math::Vector3d latlon =
-      _world->SphericalCoords()->PositionTransform(pose.Pos(),
+      this->world->SphericalCoords()->PositionTransform(pose.Pos(),
         gazebo::common::SphericalCoordinates::CoordinateType::GLOBAL,
         gazebo::common::SphericalCoordinates::CoordinateType::SPHERICAL);
     latlon.X(IGN_RTOD(latlon.X()));
@@ -482,7 +482,7 @@ void WildlifeScoringPlugin::PublishAnimalLocations()
 #else
     const ignition::math::Pose3d pose = buoy.link->GetWorldPose().Ign();
     ignition::math::Vector3d latlon =
-      _world->GetSphericalCoordinates()->PositionTransform(pose.Pos(),
+      this->world->GetSphericalCoordinates()->PositionTransform(pose.Pos(),
         gazebo::common::SphericalCoordinates::CoordinateType::GLOBAL,
         gazebo::common::SphericalCoordinates::CoordinateType::SPHERICAL);
     latlon.X(IGN_RTOD(latlon.X()));

--- a/vrx_gazebo/src/wildlife_scoring_plugin.cc
+++ b/vrx_gazebo/src/wildlife_scoring_plugin.cc
@@ -472,7 +472,7 @@ void WildlifeScoringPlugin::PublishAnimalLocations()
     latlon.X(IGN_RTOD(latlon.X()));
     latlon.Y(IGN_RTOD(latlon.Y()));
 #elif GAZEBO_MAJOR_VERSION >= 8
-    const ignition::math::Pose3d pose = buoy.link->WorldPose().Ign();
+    const ignition::math::Pose3d pose = buoy.link->WorldPose();
     const ignition::math::Vector3d position =
       this->world->SphericalCoords()->GlobalFromLocal(pose.Pos());
     const ignition::math::Vector3d latlon =

--- a/vrx_gazebo/src/wildlife_scoring_plugin.cc
+++ b/vrx_gazebo/src/wildlife_scoring_plugin.cc
@@ -459,35 +459,18 @@ void WildlifeScoringPlugin::PublishAnimalLocations()
   for (auto const &buoy : this->buoys)
   {
     // Conversion from Gazebo Cartesian coordinates to spherical.
-#if GAZEBO_MAJOR_VERSION >= 11
+#if GAZEBO_MAJOR_VERSION >= 8
     const ignition::math::Pose3d pose = buoy.link->WorldPose();
-
-    // There's a known bug with the SphericalFromLocal() computation.
-    // We use our own SphericalCoordinates object from Ignition Math and we call
-    // PositionTransform() directly containing the correct version.
-    ignition::math::Vector3d latlon =
-      this->sc.PositionTransform(pose.Pos(),
-        ignition::math::SphericalCoordinates::CoordinateType::LOCAL2,
-        ignition::math::SphericalCoordinates::CoordinateType::SPHERICAL);
-    latlon.X(IGN_RTOD(latlon.X()));
-    latlon.Y(IGN_RTOD(latlon.Y()));
-#elif GAZEBO_MAJOR_VERSION >= 8
-    const ignition::math::Pose3d pose = buoy.link->WorldPose();
-    ignition::math::Vector3d latlon =
-      this->world->SphericalCoords()->PositionTransform(pose.Pos(),
-        gazebo::common::SphericalCoordinates::CoordinateType::GLOBAL,
-        gazebo::common::SphericalCoordinates::CoordinateType::SPHERICAL);
-    latlon.X(IGN_RTOD(latlon.X()));
-    latlon.Y(IGN_RTOD(latlon.Y()));
 #else
     const ignition::math::Pose3d pose = buoy.link->GetWorldPose().Ign();
-    ignition::math::Vector3d latlon =
-      this->world->GetSphericalCoordinates()->PositionTransform(pose.Pos(),
-        gazebo::common::SphericalCoordinates::CoordinateType::GLOBAL,
-        gazebo::common::SphericalCoordinates::CoordinateType::SPHERICAL);
+#endif
+
+    auto in = ignition::math::SphericalCoordinates::CoordinateType::GLOBAL;
+    auto out = ignition::math::SphericalCoordinates::CoordinateType::SPHERICAL;
+    auto latlon = this->sc.PositionTransform(pose.Pos(), in, out);
     latlon.X(IGN_RTOD(latlon.X()));
     latlon.Y(IGN_RTOD(latlon.Y()));
-#endif
+
     const ignition::math::Quaternion<double> orientation = pose.Rot();
 
     // Fill the GeoPoseStamped message.

--- a/vrx_gazebo/src/wildlife_scoring_plugin.cc
+++ b/vrx_gazebo/src/wildlife_scoring_plugin.cc
@@ -459,7 +459,7 @@ void WildlifeScoringPlugin::PublishAnimalLocations()
   for (auto const &buoy : this->buoys)
   {
     // Conversion from Gazebo Cartesian coordinates to spherical.
-#if GAZEBO_MAJOR_VERSION >= 8
+#if GAZEBO_MAJOR_VERSION >= 11
     const ignition::math::Pose3d pose = buoy.link->WorldPose();
 
     // There's a known bug with the SphericalFromLocal() computation.
@@ -471,6 +471,12 @@ void WildlifeScoringPlugin::PublishAnimalLocations()
         ignition::math::SphericalCoordinates::CoordinateType::SPHERICAL);
     latlon.X(IGN_RTOD(latlon.X()));
     latlon.Y(IGN_RTOD(latlon.Y()));
+#elif GAZEBO_MAJOR_VERSION >= 8
+    const ignition::math::Pose3d pose = buoy.link->WorldPose().Ign();
+    const ignition::math::Vector3d position =
+      this->world->SphericalCoords()->GlobalFromLocal(pose.Pos());
+    const ignition::math::Vector3d latlon =
+      this->world->SphericalCoords()->SphericalFromLocal(position);
 #else
     const ignition::math::Pose3d pose = buoy.link->GetWorldPose().Ign();
     const ignition::math::Vector3d position =

--- a/vrx_gazebo/src/wildlife_scoring_plugin.cc
+++ b/vrx_gazebo/src/wildlife_scoring_plugin.cc
@@ -473,16 +473,20 @@ void WildlifeScoringPlugin::PublishAnimalLocations()
     latlon.Y(IGN_RTOD(latlon.Y()));
 #elif GAZEBO_MAJOR_VERSION >= 8
     const ignition::math::Pose3d pose = buoy.link->WorldPose();
-    const ignition::math::Vector3d position =
-      this->world->SphericalCoords()->GlobalFromLocal(pose.Pos());
-    const ignition::math::Vector3d latlon =
-      this->world->SphericalCoords()->SphericalFromLocal(position);
+    ignition::math::Vector3d latlon =
+      _world->SphericalCoords()->PositionTransform(pose.Pos(),
+        gazebo::common::SphericalCoordinates::CoordinateType::GLOBAL,
+        gazebo::common::SphericalCoordinates::CoordinateType::SPHERICAL);
+    latlon.X(IGN_RTOD(latlon.X()));
+    latlon.Y(IGN_RTOD(latlon.Y()));
 #else
     const ignition::math::Pose3d pose = buoy.link->GetWorldPose().Ign();
-    const ignition::math::Vector3d position =
-      this->world->GetSphericalCoordinates()->GlobalFromLocal(pose.Pos());
-    const ignition::math::Vector3d latlon =
-      this->world->GetSphericalCoordinates()->SphericalFromLocal(position);
+    ignition::math::Vector3d latlon =
+      _world->GetSphericalCoordinates()->PositionTransform(pose.Pos(),
+        gazebo::common::SphericalCoordinates::CoordinateType::GLOBAL,
+        gazebo::common::SphericalCoordinates::CoordinateType::SPHERICAL);
+    latlon.X(IGN_RTOD(latlon.X()));
+    latlon.Y(IGN_RTOD(latlon.Y()));
 #endif
     const ignition::math::Quaternion<double> orientation = pose.Rot();
 

--- a/wave_gazebo_plugins/include/wave_gazebo_plugins/Wavefield.hh
+++ b/wave_gazebo_plugins/include/wave_gazebo_plugins/Wavefield.hh
@@ -42,7 +42,7 @@ namespace asv
   class WaveParametersPrivate;
 
   /// \brief A class to manage the parameters for generating a wave
-    /// in a wave field.
+  /// in a wave field.
   class WaveParameters
   {
     /// \brief Destructor.
@@ -185,19 +185,19 @@ namespace asv
   class WavefieldSampler
   {
     /// \brief Compute the depth at a point directly
-        /// (no sampling or interpolation).
+    /// (no sampling or interpolation).
     ///
     /// This method solves for (x, y) that when input into the
-        /// Gerstner wave function
+    /// Gerstner wave function
     /// gives the coordinates of the supplied parameter
-        /// _point (_point.x(), _point.y()),
+    /// _point (_point.x(), _point.y()),
     /// and also computes the wave height pz at this point.
     /// The depth h = pz - point.z().
     /// This is a numerical method that uses a multi-variate
-        /// Newton solver to solve
+    /// Newton solver to solve
     /// the two dimensional non-linear system. In general it is not as fast as
     /// sampling from a discretised wave field with an efficient
-        /// line intersection algorithm.
+    /// line intersection algorithm.
     ///
     /// \param[in] _waveParams  Gerstner wave parameters.
     /// \param[in] _point       The point at which we want the depth.


### PR DESCRIPTION
See issue #420 and pull request #421 where there's a detailed conversation.

As described in [this pull request](https://github.com/ignitionrobotics/ign-math/pull/235), the `*FromLocal*()` functions contain a bug that has been fixed in Ignition Math. This patch instantiates a new ignition::math::SphericalCoordinates member variable in the base scoring plugin to be used for any derived scoring plugins.

Note that even in the updated version we still can't use `*FromLocal*()` directly, as it contains the version with the issue to preserve old behavior. In order to use the corrected version we need to call `PositionTransform()` directly. 