### PR TITLE
updating all var_wind_time 1 to 2 to keep within the envelope

### DIFF
--- a/vrx_gazebo/worlds/2022_practice/gymkhana0.world
+++ b/vrx_gazebo/worlds/2022_practice/gymkhana0.world
@@ -160,7 +160,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>0.0</wind_mean_velocity>
       <var_wind_gain_constants>0</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>10</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/gymkhana1.world
+++ b/vrx_gazebo/worlds/2022_practice/gymkhana1.world
@@ -160,7 +160,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>5.0</wind_mean_velocity>
       <var_wind_gain_constants>4.0</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>7</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/gymkhana2.world
+++ b/vrx_gazebo/worlds/2022_practice/gymkhana2.world
@@ -160,7 +160,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>9.0</wind_mean_velocity>
       <var_wind_gain_constants>5.0</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>19</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/perception0.world
+++ b/vrx_gazebo/worlds/2022_practice/perception0.world
@@ -160,7 +160,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>0.0</wind_mean_velocity>
       <var_wind_gain_constants>0</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>10</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/perception1.world
+++ b/vrx_gazebo/worlds/2022_practice/perception1.world
@@ -160,7 +160,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>0.0</wind_mean_velocity>
       <var_wind_gain_constants>0.0</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>10</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/perception2.world
+++ b/vrx_gazebo/worlds/2022_practice/perception2.world
@@ -160,7 +160,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>0.0</wind_mean_velocity>
       <var_wind_gain_constants>0.0</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>10</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/scan_dock_deliver0.world
+++ b/vrx_gazebo/worlds/2022_practice/scan_dock_deliver0.world
@@ -160,7 +160,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>0.0</wind_mean_velocity>
       <var_wind_gain_constants>0</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>10</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/scan_dock_deliver1.world
+++ b/vrx_gazebo/worlds/2022_practice/scan_dock_deliver1.world
@@ -160,7 +160,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>3.0</wind_mean_velocity>
       <var_wind_gain_constants>2.0</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>11</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/scan_dock_deliver2.world
+++ b/vrx_gazebo/worlds/2022_practice/scan_dock_deliver2.world
@@ -160,7 +160,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>8.0</wind_mean_velocity>
       <var_wind_gain_constants>4.0</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>19</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/stationkeeping0.world
+++ b/vrx_gazebo/worlds/2022_practice/stationkeeping0.world
@@ -187,7 +187,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>0.0</wind_mean_velocity>
       <var_wind_gain_constants>0</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>10</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/stationkeeping1.world
+++ b/vrx_gazebo/worlds/2022_practice/stationkeeping1.world
@@ -187,7 +187,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>5.0</wind_mean_velocity>
       <var_wind_gain_constants>2.0</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>15</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/stationkeeping2.world
+++ b/vrx_gazebo/worlds/2022_practice/stationkeeping2.world
@@ -187,7 +187,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>7.0</wind_mean_velocity>
       <var_wind_gain_constants>1.5</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>12</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/wayfinding0.world
+++ b/vrx_gazebo/worlds/2022_practice/wayfinding0.world
@@ -197,7 +197,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>0.0</wind_mean_velocity>
       <var_wind_gain_constants>0</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>10</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/wayfinding1.world
+++ b/vrx_gazebo/worlds/2022_practice/wayfinding1.world
@@ -200,7 +200,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>4.0</wind_mean_velocity>
       <var_wind_gain_constants>2.0</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>15</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/wildlife0.world
+++ b/vrx_gazebo/worlds/2022_practice/wildlife0.world
@@ -160,7 +160,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>0.0</wind_mean_velocity>
       <var_wind_gain_constants>0</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>10</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/wildlife1.world
+++ b/vrx_gazebo/worlds/2022_practice/wildlife1.world
@@ -160,7 +160,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>3.7</wind_mean_velocity>
       <var_wind_gain_constants>3.0</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>12</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/2022_practice/wildlife2.world
+++ b/vrx_gazebo/worlds/2022_practice/wildlife2.world
@@ -160,7 +160,7 @@
       <!-- in degrees -->
       <wind_mean_velocity>6.35</wind_mean_velocity>
       <var_wind_gain_constants>4.1</var_wind_gain_constants>
-      <var_wind_time_constants>1</var_wind_time_constants>
+      <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>11</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>

--- a/vrx_gazebo/worlds/xacros/usv_wind_plugin.xacro
+++ b/vrx_gazebo/worlds/xacros/usv_wind_plugin.xacro
@@ -5,7 +5,7 @@
                          direction:=270
                          mean_vel:=0
                          var_gain:=0
-                         var_time:=1
+                         var_time:=2
                          seed:=''
                          ros_update_rate:=10
                          topic_wind_speed:=/vrx/debug/wind/speed


### PR DESCRIPTION
Partially addresses issue #431 by modifying all values for the var_wind_time parameter so they are within the envelop. (Note that all but one of them were set to 1, so they are now all set to 2. Apparently we aren't relying on this parameter very much.)

Since the change is very minor, I don't think it's necessary to test every example world. To review, please look at the code changes to double check that nothing was changed except to increase `var_wind_time_constants` from 1 to 2, and that this was done for all 18 example files in `vrx_gazebo/worlds/2022_practice` (one of these was already 2, so 17 are changed).

You might also run one of the worlds just to make sure:

```
WORLD=stationkeeping0.world
roslaunch vrx_gazebo vrx.launch verbose:=true \
	  paused:=false \
	  wamv_locked:=true \
	  world:=${HOME}/vrx_ws/src/vrx/vrx_gazebo/worlds/2022_practice/${WORLD}
``` 