### PR TITLE
Fix pinger location in gymkhana task 

### DIFF
--- a/vrx_gazebo/include/vrx_gazebo/gymkhana_scoring_plugin.hh
+++ b/vrx_gazebo/include/vrx_gazebo/gymkhana_scoring_plugin.hh
@@ -23,6 +23,7 @@
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/common/Time.hh>
 #include <gazebo/physics/World.hh>
+#include <ignition/math/Vector3.hh>
 #include <vrx_gazebo/scoring_plugin.hh>
 
 class GymkhanaScoringPlugin : public ScoringPlugin
@@ -46,7 +47,7 @@ class GymkhanaScoringPlugin : public ScoringPlugin
   /// \brief Callback for black box station-keeping portion's scoring plugin
   protected: void BlackboxCallback(const vrx_gazebo::Task::ConstPtr& msg);
 
-  /// \brief Set the pinger location periodically.
+  /// \brief Set the pinger location.
   private: void SetPingerPosition() const;
 
   // Documentation inherited.

--- a/vrx_gazebo/include/vrx_gazebo/gymkhana_scoring_plugin.hh
+++ b/vrx_gazebo/include/vrx_gazebo/gymkhana_scoring_plugin.hh
@@ -21,6 +21,7 @@
 #include <ros/ros.h>
 #include <vrx_gazebo/Task.h>
 #include <gazebo/common/Plugin.hh>
+#include <gazebo/common/Time.hh>
 #include <gazebo/physics/World.hh>
 #include <vrx_gazebo/scoring_plugin.hh>
 
@@ -45,6 +46,9 @@ class GymkhanaScoringPlugin : public ScoringPlugin
   /// \brief Callback for black box station-keeping portion's scoring plugin
   protected: void BlackboxCallback(const vrx_gazebo::Task::ConstPtr& msg);
 
+  /// \brief Set the pinger location periodically.
+  private: void SetPingerPosition() const;
+
   // Documentation inherited.
   private: void OnFinished() override;
 
@@ -53,6 +57,9 @@ class GymkhanaScoringPlugin : public ScoringPlugin
 
   /// \brief ROS node handle.
   private: std::unique_ptr<ros::NodeHandle> rosNode;
+
+  /// \brief ROS publisher to set the pinger position.
+  private: ros::Publisher setPingerPub;
 
   /// \brief ROS subscriber to channel navigation portion scoring plugin
   private: ros::Subscriber channelSub;
@@ -68,6 +75,12 @@ class GymkhanaScoringPlugin : public ScoringPlugin
 
   /// \brief Penalty added per collision.
   private: double obstaclePenalty = 0.1;
+
+  /// \brief Position of the pinger.
+  private: ignition::math::Vector3d pingerPosition = {0, 0, 0};
+
+  /// \brief Last time we published a pinger position.
+  private: gazebo::common::Time lastSetPingerPositionTime;
 };
 
 #endif

--- a/vrx_gazebo/launch/gymkhana.launch
+++ b/vrx_gazebo/launch/gymkhana.launch
@@ -76,9 +76,6 @@
               -R $(arg R) -P $(arg P) -Y $(arg Y)
               -urdf -param $(arg namespace)/robot_description -model wamv"/>
 
-  <!-- Set the pinger location -->
-  <node name="set_pinger_position" pkg="vrx_gazebo" type="set_pinger_position.py" output="screen">
-    <rosparam command="load" file="$(arg pinger_params)" />
-  </node>
+  <!-- Pinger visualization -->
   <node name="pinger_visualization" pkg="vrx_gazebo" type="pinger_visualization.py" />
 </launch>

--- a/vrx_gazebo/launch/vrx.launch
+++ b/vrx_gazebo/launch/vrx.launch
@@ -67,10 +67,7 @@
               -R $(arg R) -P $(arg P) -Y $(arg Y)
               -urdf -param $(arg namespace)/robot_description -model wamv"/>
 
-  <!-- Set the pinger location -->
-  <node name="set_pinger_position" pkg="vrx_gazebo" type="set_pinger_position.py" output="screen">
-    <rosparam command="load" file="$(arg pinger_params)" />
-  </node>
+  <!-- Pinger visualization -->
   <node name="pinger_visualization" pkg="vrx_gazebo" type="pinger_visualization.py" />
 
 </launch>

--- a/vrx_gazebo/worlds/2022_practice/gymkhana0.world
+++ b/vrx_gazebo/worlds/2022_practice/gymkhana0.world
@@ -205,6 +205,8 @@
            Respect top-level plugin finished status. -->
       <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
       <obstacle_penalty>1</obstacle_penalty>
+      <set_position_topic_name>/wamv/sensors/pingers/pinger/set_pinger_position</set_position_topic_name>
+      <pinger_position>-503 302.5 0</pinger_position>
     </plugin>
     <!-- Scoring plugin for buoy channel portion -->
     <plugin filename="libnavigation_scoring_plugin.so" name="navigation_scoring_plugin">

--- a/vrx_gazebo/worlds/2022_practice/gymkhana1.world
+++ b/vrx_gazebo/worlds/2022_practice/gymkhana1.world
@@ -205,6 +205,8 @@
            Respect top-level plugin finished status. -->
       <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
       <obstacle_penalty>1</obstacle_penalty>
+      <set_position_topic_name>/wamv/sensors/pingers/pinger/set_pinger_position</set_position_topic_name>
+      <pinger_position>-495 265 0</pinger_position>
     </plugin>
     <!-- Scoring plugin for buoy channel portion -->
     <plugin filename="libnavigation_scoring_plugin.so" name="navigation_scoring_plugin">

--- a/vrx_gazebo/worlds/2022_practice/gymkhana2.world
+++ b/vrx_gazebo/worlds/2022_practice/gymkhana2.world
@@ -205,6 +205,8 @@
            Respect top-level plugin finished status. -->
       <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
       <obstacle_penalty>1</obstacle_penalty>
+      <set_position_topic_name>/wamv/sensors/pingers/pinger/set_pinger_position</set_position_topic_name>
+      <pinger_position>-533 293 0</pinger_position>
     </plugin>
     <!-- Scoring plugin for buoy channel portion -->
     <plugin filename="libnavigation_scoring_plugin.so" name="navigation_scoring_plugin">

--- a/vrx_gazebo/worlds/gymkhana.world.xacro
+++ b/vrx_gazebo/worlds/gymkhana.world.xacro
@@ -52,6 +52,8 @@
            Respect top-level plugin finished status. -->
       <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
       <obstacle_penalty>1</obstacle_penalty>
+      <set_position_topic_name>/wamv/sensors/pingers/pinger/set_pinger_position</set_position_topic_name>
+      <pinger_position>-483 295.5 0</pinger_position>
     </plugin>
 
     <!-- Scoring plugin for buoy channel portion -->

--- a/vrx_gazebo/worlds/xacros/gymkhana.xacro
+++ b/vrx_gazebo/worlds/xacros/gymkhana.xacro
@@ -35,6 +35,8 @@
            Respect top-level plugin finished status. -->
       <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
       <obstacle_penalty>1</obstacle_penalty>
+      <set_position_topic_name>/wamv/sensors/pingers/pinger/set_pinger_position</set_position_topic_name>
+      <pinger_position>${gx} ${gy} 0</pinger_position>
     </plugin>
 
     <!-- Scoring plugin for buoy channel portion -->


### PR DESCRIPTION
See issue #437. 

How to test it?

* Launch any of the `2022_practice` gymkhana worlds **(change the path to the world accordingly)**:

```
roslaunch vrx_gazebo gymkhana.launch verbose:=true world:=/home/caguero/vrx2022_ws/src/vrx/vrx_gazebo/worlds/2022_practice/gymkhana0.world
```

* Echo the set_pinger_position topic. Open a new terminal and run:

```
rostopic echo /wamv/sensors/pingers/pinger/set_pinger_position
```

You should observe that the pinger location is set to something different than the content of the `pinger.yaml` (-483, 295.5, 0).

* You can also teleoperate the robot to that location and echo the acoustic pinger:

```
/wamv/sensors/pingers/pinger/range_bearing
```

Verify that the range is close to `0`.