### PR TITLE
Removed set pinger position node from vrx.launch as well

### DIFF
--- a/vrx_gazebo/launch/vrx.launch
+++ b/vrx_gazebo/launch/vrx.launch
@@ -68,9 +68,6 @@
               -urdf -param $(arg namespace)/robot_description -model wamv"/>
 
   <!-- Set the pinger location -->
-  <node name="set_pinger_position" pkg="vrx_gazebo" type="set_pinger_position.py" output="screen">
-    <rosparam command="load" file="$(arg pinger_params)" />
-  </node>
   <node name="pinger_visualization" pkg="vrx_gazebo" type="pinger_visualization.py" />
 
 </launch>


### PR DESCRIPTION
@caguero I was able to replicate your fix with success. I noticed that you removed the set_pinger_position node from gymkhana.launch. Would it make sense to remove it from vrx.launch as well (as shown in this PR)? Personally, I have my code set up such that vrx.launch is always called and the world file we want is passed in as a separate arg. I am not sure if anyone else does it like this, but if they did, they would still run into the pinger issue.