### PR TITLE
Update example_component_config.yaml and numeric.yaml for generating compliant WAM-V URDFs

### DIFF
--- a/vrx_gazebo/config/wamv_config/component_compliance/numeric.yaml
+++ b/vrx_gazebo/config/wamv_config/component_compliance/numeric.yaml
@@ -1,68 +1,69 @@
 wamv_camera: 
     num: 3
     allowed_params:
+        name
         x
         y
         z
         R
         P
         Y
-        name
         post_Y
 
 wamv_gps:
     num: 1
     allowed_params:
+        name
         x
         y
         z
         R
         P
         Y
-        name
         post_Y
 
 wamv_imu:
     num: 1
     allowed_params:
+        name
         x
         y
         z
         R
         P
         Y
-        name
         post_Y
 
 lidar:
     num: 2
     allowed_params:
+        name
+        type    
         x
         y
         z
         R
         P
         Y
-        name
         post_Y
-        type
-
-wamv_p3d:
-    num: 0
-    allowed_params:
-        name
 
 wamv_ball_shooter:
     num: 1
     allowed_params:
+        name
         x
         y
         z
         pitch
         yaw
-        name
+
 wamv_pinger:
     num: 1
     allowed_params:
+        name
         position
+
+wamv_p3d:
+    num: 0
+    allowed_params:
         name

--- a/vrx_gazebo/config/wamv_config/component_compliance/numeric.yaml
+++ b/vrx_gazebo/config/wamv_config/component_compliance/numeric.yaml
@@ -9,6 +9,7 @@ wamv_camera:
         P
         Y
         post_Y
+        visualize
 
 wamv_gps:
     num: 1

--- a/vrx_gazebo/config/wamv_config/component_compliance/numeric.yaml
+++ b/vrx_gazebo/config/wamv_config/component_compliance/numeric.yaml
@@ -20,7 +20,6 @@ wamv_gps:
         R
         P
         Y
-        post_Y
 
 wamv_imu:
     num: 1
@@ -32,7 +31,6 @@ wamv_imu:
         R
         P
         Y
-        post_Y
 
 lidar:
     num: 2

--- a/vrx_gazebo/config/wamv_config/example_component_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_component_config.yaml
@@ -51,4 +51,4 @@ wamv_ball_shooter:
       y: -0.3 
       z: 1.3
       pitch: ${radians(-20)}
-      yaw: 0
+      yaw: 0.0

--- a/vrx_gazebo/config/wamv_config/example_component_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_component_config.yaml
@@ -55,3 +55,6 @@ wamv_ball_shooter:
       z: 1.3
       pitch: ${radians(-20)}
       yaw: 0.0
+wamv_pinger:
+    - name: pinger
+      position: 1.0 0 -1.0

--- a/vrx_gazebo/config/wamv_config/example_component_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_component_config.yaml
@@ -25,6 +25,7 @@ wamv_camera:
       R: 0.0
       P: ${radians(15)}
       Y: 0.0
+      post_Y: 0.0
 wamv_gps:
     - name: gps_wamv
       x: -0.85

--- a/vrx_gazebo/config/wamv_config/example_component_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_component_config.yaml
@@ -16,6 +16,7 @@ wamv_camera:
       R: 0.0
       P: ${radians(15)}
       Y: 0.0
+      post_Y: 0.0
     - name: far_left_camera
       visualize: False
       x: 0.75

--- a/vrx_gazebo/config/wamv_config/example_component_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_component_config.yaml
@@ -1,5 +1,6 @@
 wamv_camera:
     - name: front_left_camera
+      visualize: False
       x: 0.75
       y: 0.1
       z: 1.5

--- a/vrx_gazebo/config/wamv_config/example_component_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_component_config.yaml
@@ -7,6 +7,7 @@ wamv_camera:
       R: 0.0
       P: ${radians(15)}
       Y: 0.0
+      post_Y: 0.0
     - name: front_right_camera
       visualize: False
       x: 0.75

--- a/vrx_gazebo/config/wamv_config/example_component_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_component_config.yaml
@@ -9,7 +9,10 @@ wamv_camera:
     - name: front_right_camera
       x: 0.75
       y: -0.1
+      z: 1.5
+      R: 0.0
       P: ${radians(15)}
+      Y: 0.0
     - name: far_left_camera
       x: 0.75
       y: 0.3

--- a/vrx_gazebo/config/wamv_config/example_component_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_component_config.yaml
@@ -16,6 +16,7 @@ wamv_camera:
       P: ${radians(15)}
       Y: 0.0
     - name: far_left_camera
+      visualize: False
       x: 0.75
       y: 0.3
       z: 1.5

--- a/vrx_gazebo/config/wamv_config/example_component_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_component_config.yaml
@@ -16,7 +16,10 @@ wamv_camera:
     - name: far_left_camera
       x: 0.75
       y: 0.3
+      z: 1.5
+      R: 0.0
       P: ${radians(15)}
+      Y: 0.0
 wamv_gps:
     - name: gps_wamv
       x: -0.85

--- a/vrx_gazebo/config/wamv_config/example_component_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_component_config.yaml
@@ -51,6 +51,7 @@ lidar:
       R: 0.0
       P: ${radians(8)}
       Y: 0.0
+      post_Y: 0.0
 wamv_ball_shooter:
     - name: ball_shooter
       x: 0.55 

--- a/vrx_gazebo/config/wamv_config/example_component_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_component_config.yaml
@@ -8,6 +8,7 @@ wamv_camera:
       P: ${radians(15)}
       Y: 0.0
     - name: front_right_camera
+      visualize: False
       x: 0.75
       y: -0.1
       z: 1.5

--- a/vrx_gazebo/config/wamv_config/example_component_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_component_config.yaml
@@ -30,7 +30,12 @@ wamv_gps:
       Y: 0.0
 wamv_imu:
     - name: imu_wamv
+      x: 0.3
       y: -0.2
+      z: 1.3
+      R: 0.0
+      P: 0.0
+      Y: 0.0
 lidar:
     - name: lidar_wamv
       type: 16_beam

--- a/vrx_gazebo/config/wamv_config/example_component_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_component_config.yaml
@@ -23,6 +23,11 @@ wamv_camera:
 wamv_gps:
     - name: gps_wamv
       x: -0.85
+      y: 0.0
+      z: 1.3
+      R: 0.0
+      P: 0.0
+      Y: 0.0
 wamv_imu:
     - name: imu_wamv
       y: -0.2

--- a/vrx_gazebo/config/wamv_config/example_component_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_component_config.yaml
@@ -2,7 +2,10 @@ wamv_camera:
     - name: front_left_camera
       x: 0.75
       y: 0.1
+      z: 1.5
+      R: 0.0
       P: ${radians(15)}
+      Y: 0.0
     - name: front_right_camera
       x: 0.75
       y: -0.1

--- a/vrx_gazebo/config/wamv_config/example_component_config.yaml
+++ b/vrx_gazebo/config/wamv_config/example_component_config.yaml
@@ -39,7 +39,12 @@ wamv_imu:
 lidar:
     - name: lidar_wamv
       type: 16_beam
+      x: 0.7
+      y: 0.0
+      z: 1.8
+      R: 0.0
       P: ${radians(8)}
+      Y: 0.0
 wamv_ball_shooter:
     - name: ball_shooter
       x: 0.55 


### PR DESCRIPTION
### The current `example_component_config.yaml` lacks two things:

**1. Functional aspect:** It does not include the `wamv_pinger` component! If a custom WAM-V URDF is generated without this component, it still passes the compliance checks, but the sensor is not instantiated. When the Gymkhana task is launched, no data is published to `/wamv/sensors/pingers/pinger/range_bearing` topic. Consequently, it is impossible to localize the black box, and hence complete the task.

**2. Readability:** The example config sets a standard in front of developers, and hence it is common to assume that it is self-contained to its fullest abilities. However, the current version does not include all the allowable parameters for most of the components.

### The current `numeric.yaml` lacks two things:

**1. Functional aspect:** `wamv_gps` and `wamv_imu` do nat have the parameter `post_Y`.

**2. Readability:** Sequence of the components does not match that in the `example_component_config.yaml` file.

### Changes:

The said files have been updated to address the concerns raised above. Particularly, the `example_component_config.yaml` file now contains defination for `wamv_pinger` component, and includes all the allowable parameters for all the components. The `numeric.yaml` file is rearranged to match component sequence as in the `example_component_config.yaml` file, and unnecessary parameters have been removed.