### PR TITLE
Finish Gymkhana when failing crossing the navigation channel

### DIFF
--- a/vrx_gazebo/include/vrx_gazebo/scoring_plugin.hh
+++ b/vrx_gazebo/include/vrx_gazebo/scoring_plugin.hh
@@ -331,7 +331,7 @@ class ScoringPlugin : public gazebo::WorldPlugin
   private: ros::Publisher contactPub;
 
   /// \brief Score in case of timeout - added for Navigation task
-  private: double timeoutScore = -1.0;
+  private: double timeoutScore = 200.0;
 
   /// \brief Whether to shut down after last gate is crossed.
   private: bool perPluginExitOnCompletion = true;

--- a/vrx_gazebo/src/gymkhana_scoring_plugin.cc
+++ b/vrx_gazebo/src/gymkhana_scoring_plugin.cc
@@ -123,9 +123,12 @@ void GymkhanaScoringPlugin::ChannelCallback(
     // Determine whether channel has been crossed before timeout
     if (!this->channelCrossed)
     {
-      if (msg->state == "finished" && !msg->timed_out)
+      if (msg->state == "finished")
       {
-        this->channelCrossed = true;
+        if (msg->score == this->ScoringPlugin::GetTimeoutScore())
+          this->Finish();
+        else
+          this->channelCrossed = true;
       }
     }
   }

--- a/vrx_gazebo/src/navigation_scoring_plugin.cc
+++ b/vrx_gazebo/src/navigation_scoring_plugin.cc
@@ -140,12 +140,6 @@ void NavigationScoringPlugin::Load(gazebo::physics::WorldPtr _world,
   // Save number of gates
   this->numGates = this->gates.size();
 
-  // Set default score in case of timeout.
-  double timeoutScore = 2.0 * this->GetRunningStateDuration() /
-                        static_cast<double>(this->numGates);
-  gzmsg << "Setting timeoutScore = " << timeoutScore << std::endl;
-  this->ScoringPlugin::SetTimeoutScore(timeoutScore);
-
   gzmsg << "Task [" << this->TaskName() << "]" << std::endl;
 
   this->updateConnection = gazebo::event::Events::ConnectWorldUpdateBegin(


### PR DESCRIPTION
There is an issue with our current combination of navigation and gymkhana scoring plugins. If the navigation scoring plugin decides to terminate (because the WAM-V performs an illegal maneuver such as crossing a gate backwards or out of order), the gymkhana scoring plugin didn't know about it and continued enabling the scoring as if the team has crossed the channel.

This PR fixes this issue by checking the actual score coming from the navigation channel task message. If we detect that the score is the `timeout_score`, then, the gymkhana task shouldn't continue.

How to test it?

1. Run any gymkhana task (**change the path to the world file**):

```
roslaunch vrx_gazebo vrx.launch world:=/home/caguero/vrx2022_phase2_ws/src/vrx-docker/generated/task_generated/gymkhana/worlds/gymkhana0.world verbose:=true wamv_locked:=true
```

2. Run the joystick controller:
```
 roslaunch vrx_gazebo usv_joydrive.launch
```

Teleoperate the WAM-V and make two illegal movements. Try crossing an uncrossed gate backwards and skipping a gate. The gymkhana runs should terminate. The score should be MAX.

Additionally, complete the navigation channel correctly and verify that the task continues. The score should drop substantially when crossing the channel from MAX to a few meters (70-100).