### PR TITLE
Made placard symbol subscriber enable latching

### DIFF
--- a/vrx_gazebo/src/light_buoy_plugin.cc
+++ b/vrx_gazebo/src/light_buoy_plugin.cc
@@ -136,7 +136,7 @@ void LightBuoyPlugin::Load(gazebo::rendering::VisualPtr _parent,
 
   gzNode->Init();
   this->colorSub = this->gzNode->Subscribe
-    (this->gzColorsTopic, &LightBuoyPlugin::ChangePatternTo, this);
+    (this->gzColorsTopic, &LightBuoyPlugin::ChangePatternTo, this, true);
 }
 
 //////////////////////////////////////////////////

--- a/vrx_gazebo/src/placard_plugin.cc
+++ b/vrx_gazebo/src/placard_plugin.cc
@@ -91,7 +91,7 @@ void PlacardPlugin::Load(gazebo::rendering::VisualPtr _parent,
 
   this->gzNode->Init();
   this->symbolSub = gzNode->Subscribe(this->symbolSubTopic,
-    &PlacardPlugin::ChangeSymbolTo, this);
+    &PlacardPlugin::ChangeSymbolTo, this, true);
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
The solution that solved issue #451 for me was to make the gazebo subscriber within placard_plugin.cc allow latching. This way once even if the msgs are published before the subscriber is instantiated, the subscriber can still just get the last published message.

@M1chaelM, I apologize that I cannot think of a way to for you to replicate the issue without running my code, however, I think it makes sense as well to make this subscriber enable latching since the placard symbols are only ever published once. Please let me know if you are interested in seeing the behavior I am describing in #451 more in depth. You should also see that this change does not break anything, at least to my knowledge.

Update: I recently encountered the same issue for the STC buoy. It seemed that the subscriber was too late to instantiate, and it did not receive the published msg containing the lights information from the ```scan_dock_scoring_plugin.cc```. Therefore, the STC buoy was always black. The fix was to make this STC code related subscriber also latching.

This is the documentation I referenced: 
https://osrf-distributions.s3.amazonaws.com/gazebo/api/1.4.0/classgazebo_1_1transport_1_1Node.html#a92eab7694fab5eaf46c8ea046212e662