### PR TITLE
Fix timeout score issue

### DIFF
--- a/vrx_gazebo/include/vrx_gazebo/scoring_plugin.hh
+++ b/vrx_gazebo/include/vrx_gazebo/scoring_plugin.hh
@@ -331,7 +331,7 @@ class ScoringPlugin : public gazebo::WorldPlugin
   private: ros::Publisher contactPub;
 
   /// \brief Score in case of timeout - added for Navigation task
-  private: double timeoutScore = 200.0;
+  private: double timeoutScore = -1;
 
   /// \brief Whether to shut down after last gate is crossed.
   private: bool perPluginExitOnCompletion = true;

--- a/vrx_gazebo/src/gymkhana_scoring_plugin.cc
+++ b/vrx_gazebo/src/gymkhana_scoring_plugin.cc
@@ -110,7 +110,7 @@ void GymkhanaScoringPlugin::Update()
   }
   else
   {
-    this->ScoringPlugin::SetScore(this->ScoringPlugin::GetTimeoutScore());
+    this->ScoringPlugin::SetScore(200);
   }
 }
 
@@ -125,7 +125,7 @@ void GymkhanaScoringPlugin::ChannelCallback(
     {
       if (msg->state == "finished")
       {
-        if (msg->score == this->ScoringPlugin::GetTimeoutScore())
+        if (msg->score == 200)
           this->Finish();
         else
           this->channelCrossed = true;

--- a/vrx_gazebo/src/gymkhana_scoring_plugin.cc
+++ b/vrx_gazebo/src/gymkhana_scoring_plugin.cc
@@ -158,9 +158,7 @@ void GymkhanaScoringPlugin::SetPingerPosition() const
 void GymkhanaScoringPlugin::OnFinished()
 {
   double penalty = this->GetNumCollisions() * this->obstaclePenalty;
-
-  if (this->Score() < std::numeric_limits<double>::max())
-    this->SetTimeoutScore(this->Score() + penalty);
+  this->SetTimeoutScore(this->Score() + penalty);
 
   ScoringPlugin::OnFinished();
 }

--- a/vrx_gazebo/src/navigation_scoring_plugin.cc
+++ b/vrx_gazebo/src/navigation_scoring_plugin.cc
@@ -140,6 +140,11 @@ void NavigationScoringPlugin::Load(gazebo::physics::WorldPtr _world,
   // Save number of gates
   this->numGates = this->gates.size();
 
+  // Set default score in case of timeout.
+  double timeoutScore = 200;
+  gzmsg << "Setting timeoutScore = " << timeoutScore << std::endl;
+  this->ScoringPlugin::SetTimeoutScore(timeoutScore);
+
   gzmsg << "Task [" << this->TaskName() << "]" << std::endl;
 
   this->updateConnection = gazebo::event::Events::ConnectWorldUpdateBegin(


### PR DESCRIPTION
I introduced an issue in #449 changing the default value of `timeoutScore` from `-1` to `200`. See how we're using `timeoutScore` in [scoring_plugin.cc::OnFinished()](https://github.com/osrf/vrx/blob/master/vrx_gazebo/src/scoring_plugin.cc#L278-L281). 

The original intent of that block of code is to update the current score to the `timeoutScore` only when `timeoutScore` is set. We were assuming that if `timeoutScore` isn't set, its value will be negative. Our change in #449 breaks this convention causing the score to always be updated to `timeoutScore` when a task timeouts. This is problematic in tasks such as stationkeeping or wayfinding because the task will always timeout.

How to test it?

1. Launch a stationkeeping task (**update the world path**) and verify that after the timeout, the score is reasonable (not `200`):

```
roslaunch vrx_gazebo vrx.launch world:=/home/caguero/vrx2022_phase3/src/vrx-docker/generated/task_generated/stationkeeping/worlds/stationkeeping0.world verbose:=true wamv_locked:=true
```
```
rostopic echo /vrx/task/info
```

2.1 Launch a gymkhana task (**update the world path**):
```
roslaunch vrx_gazebo vrx.launch world:=/home/caguero/vrx2022_phase3/src/vrx-docker/generated/task_generated/gymkhana/worlds/gymkhana0.world verbose:=true wamv_locked:=true
```
```
roslaunch vrx_gazebo usv_joydrive.launch
```
```
rostopic echo /vrx/task/info
```

Verify that crossing the channel and letting the task timeout you get a value lower than `200`.

2.2 Launch a gymkhana task as 2.1:

Verify that leaving the task to timeout without crossing the channel returns a score of `200`.

2.3 Launch a gymkhana task as 2.1:

Verify that making an illegal move (crossing a gate backwards or skipping a gate) terminates the run and returns a score of `200`.





