### PR TITLE
Added Cmat in hydrodynamic forces equation

### DIFF
--- a/usv_gazebo_plugins/src/usv_gazebo_dynamics_plugin.cc
+++ b/usv_gazebo_plugins/src/usv_gazebo_dynamics_plugin.cc
@@ -256,6 +256,7 @@ void UsvDynamicsPlugin::Update()
   Cmat(1, 5) = this->paramXdotU * kVelLinearBody.X();
   Cmat(5, 0) = this->paramYdotV * kVelLinearBody.Y();
   Cmat(5, 1) = this->paramXdotU * kVelLinearBody.X();
+  const Eigen::VectorXd kCmat = Cmat * state;
 
   // Drag
   Dmat(0, 0) = this->paramXu + this->paramXuu * std::abs(kVelLinearBody.X());
@@ -277,7 +278,7 @@ void UsvDynamicsPlugin::Update()
   tf2::Transform xformV = tf2::Transform(vq);
 
   // Sum all forces - in body frame
-  const Eigen::VectorXd kForceSum = kAmassVec + kDvec;
+  const Eigen::VectorXd kForceSum = kAmassVec + kCmat + kDvec;
 
   // Forces in fixed frame
   ROS_DEBUG_STREAM_THROTTLE(1.0, "forceSum :\n" << kForceSum);


### PR DESCRIPTION
This PR modifies the hydrodynamic forces equation in `usv_gazebo_dynamics_plugin.cc` to include the Coriolis centripetal matrix for added mass, `Cmat`. 

As mentioned in  #441, the model used in the code does not match the [Theory of operation](https://github.com/bsb808/robotx_docs/blob/master/theoryofoperation/theory_of_operation.pdf) (see eq. 1).

**Note:** There also seem to be differences in the terms present in `Cmat` in [Theory of operation](https://github.com/bsb808/robotx_docs/blob/master/theoryofoperation/theory_of_operation.pdf), [this paper](https://wiki.nps.edu/display/BB/Publications?preview=/1173263776/1173263778/PID6131719.pdf) and [this definition](https://github.com/osrf/vrx/blob/94385d0a800b5be7a2f29c664a1044ba4f243b2f/usv_gazebo_plugins/src/usv_gazebo_dynamics_plugin.cc#L254-L258). These differences have not been addressed in this PR.

Need to verify if switching to this model is causing any unexpected behaviour in the USV. Do you remember if `Cmat` was purposely omitted, and if so, the reason for doing so?