### PR TITLE
Draft: Temporary skeleton code for scoring plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ build_*
 *.*~
 vrx_gazebo/models/dock_permutations/*
 *.pyc
+.vscode
+.vscode/*

--- a/vrx_ign/CMakeLists.txt
+++ b/vrx_ign/CMakeLists.txt
@@ -2,8 +2,12 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 
 project(vrx_ign)
 
+include_directories("/opt/ros/galactic/include")
+include_directories("~/vrx_ros2_ws/install/vrx_ros/include")
+
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
+find_package(rclcpp REQUIRED)
 
 find_package(ignition-gazebo6 REQUIRED)
 set(IGN_GAZEBO_VER ${ignition-gazebo6_VERSION_MAJOR})
@@ -21,9 +25,10 @@ set(IGN_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
 find_package(ignition-rendering6 REQUIRED)
 set(IGN_RENDERING_VER ${ignition-rendering6_VERSION_MAJOR})
 find_package(sdformat12 REQUIRED)
+find_package(ignition-physics4 REQUIRED)
+set(IGN_PHYSICS_VER ${ignition-physics4_VERSION_MAJOR})
 
 find_package(std_msgs REQUIRED)
-
 #============================================================================
 # Hooks
 ament_environment_hooks("hooks/resource_paths.dsv.in")
@@ -49,6 +54,8 @@ list(APPEND VRX_IGN_PLUGINS
   SimpleHydrodynamics
   Surface
   WaveVisual
+  DummyPlugin
+  ScoringPlugin
 )
 
 foreach(PLUGIN ${VRX_IGN_PLUGINS})
@@ -57,6 +64,7 @@ foreach(PLUGIN ${VRX_IGN_PLUGINS})
     ignition-gazebo${IGN_GAZEBO_VER}::core
     ignition-plugin${IGN_PLUGIN_VER}::ignition-plugin${IGN_PLUGIN_VER}
     ignition-rendering${IGN_RENDERING_VER}::ignition-rendering${IGN_RENDERING_VER}
+    ignition-physics${IGN_PHYSICS_VER}::ignition-physics${IGN_PHYSICS_VER}
     Waves
   )
 endforeach()

--- a/vrx_ign/package.xml
+++ b/vrx_ign/package.xml
@@ -16,6 +16,7 @@
   <build_depend>ament_cmake_python</build_depend>
   <build_depend>vrx_ros</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>rclcpp</build_depend>
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>launch</exec_depend>

--- a/vrx_ign/src/DummyPlugin.cc
+++ b/vrx_ign/src/DummyPlugin.cc
@@ -1,0 +1,37 @@
+#include <ignition/plugin/Register.hh>
+
+#include "DummyPlugin.hh"
+
+using namespace ignition;
+using namespace gazebo;
+using namespace systems;
+
+DummyPlugin::DummyPlugin()
+{
+    //
+}
+
+void DummyPlugin::Configure(const Entity &_entity,
+    const std::shared_ptr<const sdf::Element> &_sdf,
+    EntityComponentManager &_ecm,
+    EventManager &/*_eventMgr*/)
+{
+    //
+    return;
+}
+
+void DummyPlugin::PostUpdate(
+    const ignition::gazebo::UpdateInfo &_info,
+    const ignition::gazebo::EntityComponentManager &_ecm)
+{
+    //
+    return;
+}
+
+
+
+
+IGNITION_ADD_PLUGIN(DummyPlugin,
+                    ignition::gazebo::System,
+                    DummyPlugin::ISystemConfigure,
+                    DummyPlugin::ISystemPostUpdate)

--- a/vrx_ign/src/DummyPlugin.hh
+++ b/vrx_ign/src/DummyPlugin.hh
@@ -1,0 +1,48 @@
+#ifndef DUMMY_VRX_PLUGIN_HH_
+#define DUMMY_VRX_PLUGIN_HH_
+
+#include <memory>
+#include <ignition/gazebo/System.hh>
+#include <sdf/sdf.hh>
+
+namespace ignition
+{
+namespace gazebo
+{
+inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+namespace systems
+{
+    // Forward declaration
+    class DummyPluginPrivate;
+    
+    /// \brief Doc (MD)
+    /// Doc (cont)
+    class DummyPlugin
+        : public System,
+          public ISystemConfigure,
+          public ISystemPostUpdate
+    {
+        /// \brief Constructor
+        public: DummyPlugin();
+        
+        /// \brief Destructor
+        public: ~DummyPlugin() override = default;
+
+        // Documentation inherited
+        public: void Configure(const Entity &_entity,
+                           const std::shared_ptr<const sdf::Element> &_sdf,
+                           EntityComponentManager &_ecm,
+                           EventManager &_eventMgr) override;
+
+        // Documentation inherited
+        public: void PostUpdate(
+                    const ignition::gazebo::UpdateInfo &_info,
+                    const ignition::gazebo::EntityComponentManager &_ecm) override;
+        
+    };
+}
+}
+}
+}
+
+#endif

--- a/vrx_ign/src/ScoringPlugin.cc
+++ b/vrx_ign/src/ScoringPlugin.cc
@@ -1,0 +1,14 @@
+#include <ignition/common/Console.hh>
+#include <ignition/physics/Joint.hh>
+#include <ignition/plugin/Register.hh>
+
+#include "ScoringPlugin.hh"
+
+using namespace ignition;
+using namespace gazebo;
+using namespace systems;
+
+IGNITION_ADD_PLUGIN(ScoringPlugin,
+                    ignition::gazebo::System,
+                    ScoringPlugin::ISystemConfigure,
+                    ScoringPlugin::ISystemPostUpdate)

--- a/vrx_ign/src/ScoringPlugin.hh
+++ b/vrx_ign/src/ScoringPlugin.hh
@@ -1,0 +1,273 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef VRX_GAZEBO_SCORING_PLUGIN_HH_
+#define VRX_GAZEBO_SCORING_PLUGIN_HH_
+
+#include <rclcpp/rclcpp.hpp>
+#include <memory>
+#include <string>
+#include <vector>
+#include <ignition/math/SphericalCoordinates.hh>
+#include <ignition/gazebo/System.hh>
+#include <ignition/common.hh>
+#include <ignition/transport.hh>
+#include <ignition/physics.hh>
+#include <ignition/math/SphericalCoordinates.hh>
+#include <sdf/sdf.hh>
+
+namespace ignition
+{
+namespace gazebo
+{
+inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
+namespace systems
+{
+
+class ScoringPlugin 
+        : public System,
+          public ISystemConfigure,
+          public ISystemPostUpdate 
+    {
+        /// \brief Class constructor
+        public: ScoringPlugin();
+
+        /// \brief Shutdown Gazebo and ROS
+        public: void Exit();
+
+        // Documentation inherited
+        public: void Configure(const Entity &_entity,
+                           const std::shared_ptr<const sdf::Element> &_sdf,
+                           EntityComponentManager &_ecm,
+                           EventManager &_eventMgr) override;
+
+        /// \brief Get the current score.
+        /// \return The current score.
+        protected: double Score() const;
+
+        /// \brief Set the score.
+        /// \param[in] _newScore The new score.
+        protected: void SetScore(double _newScore);
+
+        /// \brief Get the task name.
+        /// \return Task name.
+        protected: std::string TaskName() const;
+
+        /// \brief Get the task state.
+        /// \return Task state.
+        protected: std::string TaskState() const;
+
+        /// \brief Elapsed time in the running state.
+        /// \return The elapsed time in the running state.
+        protected: ignition::common::Time ElapsedTime() const;
+
+        /// \brief Remaining time in the running state.
+        /// \return The remaining time in the running state.
+        protected: ignition::common::Time RemainingTime() const;
+
+        /// \brief Finish the current task.
+        /// This will set the "finished" flag in the task message to true.
+        protected: void Finish();
+
+        /// \brief Tries to release the vehicle in case is locked.
+        protected: virtual void ReleaseVehicle();
+
+        /// \brief Set the score in case of timeout
+        protected: void SetTimeoutScore(double _timeoutScore);
+
+        /// \brief Get the timeoutScore
+        protected: double GetTimeoutScore() const;
+
+        /// \brief Get running duration
+        protected: double GetRunningStateDuration() const;
+
+        /// \brief Get the number of WAM-V collisions.
+        protected: unsigned int GetNumCollisions() const;
+
+        /// \brief Callback executed at every world update.
+        public: void PostUpdate(
+                    const ignition::gazebo::UpdateInfo &_info,
+                    const ignition::gazebo::EntityComponentManager &_ecm) override;
+
+        /// \brief Update all time-related variables.
+        private: void UpdateTime();
+
+        /// \brief Update the state of the current task.
+        private: void UpdateTaskState();
+
+        /// \brief Update the task stats message.
+        private: void UpdateTaskMessage();
+
+        /// \brief Publish the task stats over a ROS topic.
+        private: void PublishStats();
+
+        /// \brief Callback executed when the task state transition into "ready".
+        private: virtual void OnReady();
+
+        /// \brief Callback executed when the task state transition into "running".
+        private: virtual void OnRunning();
+
+        /// \brief Callback executed when the task state transition into "finished".
+        protected: virtual void OnFinished();
+
+        /// \brief Callback executed when a collision is detected for the WAMV.
+        private: virtual void OnCollision();
+
+        /// \brief Callback function when collision occurs in the world.
+        /// \param[in] _contacts List of all collisions from last simulation iteration
+        private: void OnCollisionMsg(ignition::msgs::ConstContactsSharedPtr &_contacts);
+
+        /// \brief Parse all SDF parameters.
+        /// \return True when all parameters were successfully parsed or false
+        /// otherwise.
+        private: bool ParseSDFParameters();
+
+        /// \brief Parse the joints section of the SDF block.
+        /// \return True when all parameters were successfully parsed or false
+        /// otherwise.
+        private: bool ParseJoints();
+
+        /// \brief A world pointer.
+        protected: ignition::physics::World3dPtr world;
+
+        /// \brief The name of the task.
+        protected: std::string taskName = "undefined";
+
+        /// \brief The name of the vehicle to score.
+        protected: std::string vehicleName;
+
+        /// \brief Pointer to the vehicle to score.
+        protected: ignition::physics::Model3dPtr vehicleModel;
+
+        /// \brief Last collision time.
+        protected: ignition::common::Time lastCollisionTime;
+
+        /// \brief Silent mode enabled?
+        protected: bool silent = false;
+
+        /// \brief Spherical coordinates conversions.
+        protected: ignition::math::SphericalCoordinates sc;
+
+        /// \brief gazebo node pointer
+        private: ignition::transport::Node *gzNode;
+
+        /// \brief Collision detection node subscriber
+        // TODO
+        
+        /// \brief gazebo server control publisher
+        // TODO
+
+        /// \brief Topic where the task stats are published.
+        private: std::string taskInfoTopic = "/vrx/task/info";
+
+        /// \brief Bool flag for debug.
+        private: bool debug = true;
+
+        /// \brief Topic where debug collision is published.
+        private: std::string contactDebugTopic = "/vrx/debug/contact";
+
+        /// \brief The score.
+        private: double score = 0.0;
+
+        /// \brief Pointer to the SDF plugin element.
+        private: sdf::ElementPtr sdf;
+
+        /// \brief Duration (seconds) of the initial state.
+        private: double initialStateDuration = 30.0;
+
+        /// \brief Duration (seconds) of the ready state.
+        private: double readyStateDuration = 60.0;
+
+        /// \brief Duration (seconds) of the running state (max task time).
+        protected: double runningStateDuration = 300.0;
+
+        /// \brief Absolute time specifying the start of the ready state.
+        private: ignition::common::Time readyTime;
+
+        /// \brief Absolute time specifying the start of the running state.
+        private: ignition::common::Time runningTime;
+
+        /// \brief Absolute time specifying the start of the finish state.
+        private: ignition::common::Time finishTime;
+
+        /// \brief Current time (simulation).
+        private: ignition::common::Time currentTime;
+
+        // \brief Elapsed time since the start of the task (running state).
+        private: ignition::common::Time elapsedTime;
+
+        /// \brief Remaining time since the start of the task (running state).
+        private: ignition::common::Time remainingTime;
+
+        /// \brief Collision buffer.
+        private: float collisionBuffer = 3.0;
+
+        /// \brief Collisions counter.
+        private: int collisionCounter = 0;
+
+        /// \brief Collision list.
+        private: std::vector<std::string> collisionList;
+
+        /// \brief Collisions timestamps.
+        private: std::vector<ignition::common::Time> collisionTimestamps;
+
+        /// \brief Whether the current task has timed out or not.
+        private: bool timedOut = false;
+
+        /// \brief Time at which the last message was sent.
+        private: ignition::common::Time lastStatsSent = gazebo::common::Time::Zero;
+
+        /// \brief The task state.
+        private: std::string taskState = "initial";
+        
+        /// \brief The next task message to be published.
+        //TODO: Create Ros2 task msg, include and declare
+
+        /// \brief ROS Contact Msg.
+        //TODO: Create ros2 contact msg, include and declare
+
+        /// \brief The name of the joints to be dettached during ReleaseVehicle().
+        private: std::vector<std::string> lockJointNames;
+
+        /// \brief ROS node handle.
+        //TODO: ROS2 equivalet of node handle
+        //private: std::unique_ptr<ros::NodeHandle> rosNode;
+
+        /// \brief Publisher for the task state.
+        //TODO: declare ros2 pub
+        // protected: ros::Publisher taskPub;
+
+        /// \brief Publisher for the collision.
+        //TODO declare ros2 pub
+        // private: ros::Publisher contactPub;
+
+        
+        /// \brief Score in case of timeout - added for Navigation task
+        private: double timeoutScore = -1;
+
+        /// \brief Whether to shut down after last gate is crossed.
+        private: bool perPluginExitOnCompletion = true;
+
+        /// \brief Number of WAM-V collisions.
+        private: unsigned int numCollisions = 0u;
+
+        };
+}
+}
+}
+}
+#endif

--- a/vrx_ign/src/ScoringPlugin.hh
+++ b/vrx_ign/src/ScoringPlugin.hh
@@ -30,6 +30,10 @@
 #include <ignition/math/SphericalCoordinates.hh>
 #include <sdf/sdf.hh>
 
+#include "vrx_ros/msg/contact.hpp"
+#include "vrx_ros/msg/task.hpp"
+
+
 namespace ignition
 {
 namespace gazebo
@@ -142,7 +146,8 @@ class ScoringPlugin
         private: bool ParseJoints();
 
         /// \brief A world pointer.
-        protected: ignition::physics::World3dPtr world;
+        //TODO: How to define world ptr?
+        // protected: ignition::physics::World3dPtr world;
 
         /// \brief The name of the task.
         protected: std::string taskName = "undefined";
@@ -151,7 +156,8 @@ class ScoringPlugin
         protected: std::string vehicleName;
 
         /// \brief Pointer to the vehicle to score.
-        protected: ignition::physics::Model3dPtr vehicleModel;
+        //TODO: How to define model ptr?
+        // protected: ignition::physics::Model3dPtr vehicleModel;
 
         /// \brief Last collision time.
         protected: ignition::common::Time lastCollisionTime;
@@ -170,6 +176,7 @@ class ScoringPlugin
         
         /// \brief gazebo server control publisher
         // TODO
+        ignition::transport::Node::Publisher *serverControlPub;
 
         /// \brief Topic where the task stats are published.
         private: std::string taskInfoTopic = "/vrx/task/info";
@@ -229,33 +236,37 @@ class ScoringPlugin
         private: bool timedOut = false;
 
         /// \brief Time at which the last message was sent.
-        private: ignition::common::Time lastStatsSent = gazebo::common::Time::Zero;
+        private: ignition::common::Time lastStatsSent;
 
         /// \brief The task state.
         private: std::string taskState = "initial";
         
         /// \brief The next task message to be published.
         //TODO: Create Ros2 task msg, include and declare
+        private: vrx_ros::msg::Task taskMsg;
 
         /// \brief ROS Contact Msg.
         //TODO: Create ros2 contact msg, include and declare
+        private: vrx_ros::msg::Contact contactMsg;
 
         /// \brief The name of the joints to be dettached during ReleaseVehicle().
         private: std::vector<std::string> lockJointNames;
 
         /// \brief ROS node handle.
-        //TODO: ROS2 equivalet of node handle
+        //TODO: ROS2 equivalet of node handle??
         //private: std::unique_ptr<ros::NodeHandle> rosNode;
 
         /// \brief Publisher for the task state.
         //TODO: declare ros2 pub
+        protected: rclcpp::Publisher<vrx_ros::msg::Task> taskPub;
         // protected: ros::Publisher taskPub;
 
         /// \brief Publisher for the collision.
         //TODO declare ros2 pub
+        private: rclcpp::Publisher<vrx_ros::msg::Contact> contactPub;
         // private: ros::Publisher contactPub;
 
-        
+
         /// \brief Score in case of timeout - added for Navigation task
         private: double timeoutScore = -1;
 

--- a/vrx_ros/CMakeLists.txt
+++ b/vrx_ros/CMakeLists.txt
@@ -18,6 +18,18 @@ find_package(sensor_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+set(msg_files
+  "msg/Task.msg"
+  "msg/Contact.msg"
+ )
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+)
+ament_export_dependencies(rosidl_default_runtime)
+
 
 add_executable(optical_frame_publisher src/optical_frame_publisher.cc)
 ament_target_dependencies(optical_frame_publisher

--- a/vrx_ros/msg/Contact.msg
+++ b/vrx_ros/msg/Contact.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+string collision1
+string collision2

--- a/vrx_ros/msg/Task.msg
+++ b/vrx_ros/msg/Task.msg
@@ -1,0 +1,29 @@
+# Task name.
+string name
+
+# Task state.
+string state
+
+# Absolute sim time when this task will be in "ready" state (ROS time).
+builtin_interfaces/Time ready_time
+
+# Absolute sim time when this task will be in "running" state (ROS time).
+builtin_interfaces/Time running_time
+
+# Time elapsed since task started (ROS time). This is the current sim time
+# minus start time.
+# When the elapsed time reaches the task timeout, `timed_out` is set to true.
+builtin_interfaces/Duration elapsed_time
+
+# Remaining time until the task times out (ROS time).
+builtin_interfaces/Duration remaining_time
+
+# True if task timed out.
+bool timed_out
+
+# Number of collisions.
+uint32 num_collisions
+
+# The score.
+float64 score
+

--- a/vrx_ros/package.xml
+++ b/vrx_ros/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>vrx_ros</name>
   <version>0.0.0</version>
   <description>VRX ROS resources</description>
@@ -12,7 +12,8 @@
   <author>Carlos Agüero</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
+  <build_depend>rosidl_default_generators</build_depend>
+  
   <depend>geometry_msgs</depend>
   <depend>mavros_msgs</depend>
   <depend>rclcpp</depend>
@@ -22,8 +23,12 @@
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  
+  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This PR contains the ported code for `ScoringPlugin.hh` and a basic skeleton for `ScoringPugin.cc.` The purpose of this is only for temporarily having something in place so that it doesn't block anyone else's work (if it depends on the scoring plugin), while I work on finalizing the implementations in ScoringPlugin.cc.

**Note:** The code in this PR follows a similar structure as `vrx_gazebo`, i.e. some messages have been implemented in ROS 2 instead of ignition transport. I am currently working on changing the implementations to `ignition::transport`. I have also ported the source code for `ScoringPlugin.cc` locally and can include that in this PR too, if required.

**Issues:**
- I had to hard-code two include_dirs in CMakeLists.txt since the compiler wasn't able to find these package paths. I have therefore kept this request as a draft right now. Can you look into what I might have to do differently in CMake so that these paths are found? 