### PR TITLE
pinning checkout action to v2.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       image: npslearninglab/watery_robots:noetic_current
     steps:
       - run: sudo chown -R `whoami`:`whoami` .
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.0
   
       - name: Static code checking
         run: sh tools/code_check.sh
@@ -35,7 +35,7 @@ jobs:
       image: npslearninglab/watery_robots:melodic_current
     steps:
       - run: sudo chown -R `whoami`:`whoami` .
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.0
   
       - name: Static code checking
         run: sh tools/code_check.sh
@@ -60,7 +60,7 @@ jobs:
       image: npslearninglab/watery_robots:kinetic_current
     steps:
       - run: sudo chown -R `whoami`:`whoami` .
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.4.0
   
       - name: Static code checking
         run: sh tools/code_check.sh


### PR DESCRIPTION
This PR addresses issue #468 by explicitly using version 2.4.0 of the checkout action. To test, simply observe that the CI for the noetic-gazebo11 test image does not fail.