### PR TITLE
Add linear interp

### DIFF
--- a/usv_gazebo_plugins/CMakeLists.txt
+++ b/usv_gazebo_plugins/CMakeLists.txt
@@ -19,8 +19,8 @@ catkin_package(
   CATKIN_DEPENDS message_runtime gazebo_dev roscpp wave_gazebo_plugins
 )
 
-# Plugins require c++11
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+# Plugins require c++17
+set(CMAKE_CXX_FLAGS "-std=c++17 ${CMAKE_CXX_FLAGS}")
 
 include_directories( include
   ${catkin_INCLUDE_DIRS}

--- a/usv_gazebo_plugins/include/usv_gazebo_plugins/usv_gazebo_thrust_plugin.hh
+++ b/usv_gazebo_plugins/include/usv_gazebo_plugins/usv_gazebo_thrust_plugin.hh
@@ -69,8 +69,12 @@ namespace gazebo
     /// \brief Link where thrust force is applied.
     public: physics::LinkPtr link;
 
-    /// \brief Thruster mapping (0=linear; 1=GLF, nonlinear).
+    /// \brief Thruster mapping (0=linear; 1=GLF, nonlinear; 2=linear interp).
     public: int mappingType;
+
+    /// \brief Lookup map of cmd values -> force values
+    ///        for use in mappingType=2,linear interp
+    public: std::map<double, double> cmdForceMap;
 
     /// \brief Topic name for incoming ROS thruster commands.
     public: std::string cmdTopic;
@@ -135,7 +139,8 @@ namespace gazebo
   ///   <enableAngle>: If true, thruster will have adjustable angle.
   ///                  If false, thruster will have constant angle.
   ///   Optional elements:
-  ///   <mappingType>: Thruster mapping (0=linear; 1=GLF, nonlinear),
+  ///   <mappingType>: Thruster mapping (0=linear; 1=GLF, nonlinear;
+  ///                  2=linear interp),
   ///   default is 0
   ///   <maxCmd>:Maximum of thrust commands,
   ///   defualt is 1.0
@@ -145,6 +150,10 @@ namespace gazebo
   ///   default is 250.0 N
   ///   <maxForceRev>: Maximum reverse force [N].
   ///   default is -100.0 N
+  ///   <cmdValues>: values of thrust commands corresponding to thrust forces
+  ///   default is minCmd maxCmd
+  ///   <forceValues>: values of thrust forces corresponding to thrust commands
+  ///   default is maxForceRev maxForceFwd
   ///   <maxAngle>: Absolute value of maximum thruster angle [radians].
   ///   default is pi/2
   ///
@@ -184,6 +193,46 @@ namespace gazebo
   ///        <maxAngle>1.57</maxAngle>
   ///      </thruster>
   ///    </plugin>
+  ///
+  /// Here is an equivalent example but using a mapping type of 2,linear interp:
+  ///
+  ///    <plugin name="example" filename="libusv_gazebo_thrust_plugin.so">
+  ///      <!-- General plugin parameters -->
+  ///      <cmdTimeout>1.0</cmdTimeout>
+  ///
+  ///      <thruster>
+  ///        <linkName>left_propeller_link</linkName>
+  ///        <propJointName>left_engine_propeller_joint</propJointName>
+  ///        <engineJointName>left_chasis_engine_joint</engineJointName>
+  ///        <cmdTopic>left_thrust_cmd</cmdTopic>
+  ///        <angleTopic>left_thrust_angle</angleTopic>
+  ///        <enableAngle>false</enableAngle>
+  ///        <mappingType>2</mappingType>
+  ///        <maxCmd>1.0</maxCmd>
+  ///        <minCmd>-1.0</minCmd>
+  ///        <maxForceFwd>250.0</maxForceFwd>
+  ///        <maxForceRev>-100.0</maxForceRev>
+  ///        <cmdValues>-1.0 0 1.0</cmdValues>
+  ///        <ForceValues>-100.0 0 250.0</cmdValues>
+  ///        <maxAngle>1.57</maxAngle>
+  ///      </thruster>
+  ///      <thruster>
+  ///        <linkName>right_propeller_link</linkName>
+  ///        <propJointName>right_engine_propeller_joint</propJointName>
+  ///        <engineJointName>right_chasis_engine_joint</engineJointName>
+  ///        <cmdTopic>right_thrust_cmd</cmdTopic>
+  ///        <angleTopic>right_thrust_angle</angleTopic>
+  ///        <enableAngle>false</enableAngle>
+  ///        <mappingType>2</mappingType>
+  ///        <maxCmd>1.0</maxCmd>
+  ///        <minCmd>-1.0</minCmd>
+  ///        <maxForceFwd>250.0</maxForceFwd>
+  ///        <maxForceRev>-100.0</maxForceRev>
+  ///        <cmdValues>-1.0 0 1.0</cmdValues>
+  ///        <ForceValues>-100.0 0 250.0</cmdValues>
+  ///        <maxAngle>1.57</maxAngle>
+  ///      </thruster>
+  ///    </plugin>
 
   class UsvThrust : public ModelPlugin
   {
@@ -209,6 +258,22 @@ namespace gazebo
     private: double SdfParamDouble(sdf::ElementPtr _sdfPtr,
                                    const std::string &_paramName,
                                    const double _defaultVal) const;
+
+    /// \brief Convenience function for getting SDF parameters.
+    /// \param[in] _sdfPtr Pointer to an SDF element to parse.
+    /// \param[in] _paramName The name of the vector element to parse.
+    /// \param[in] _defaultVal The default vector value returned if the element
+    /// does not exist.
+    /// \return The vector value parsed.
+    private: std::vector<double> SdfParamVector(
+                                sdf::ElementPtr _sdfPtr,
+                                const std::string &_paramName,
+                                const std::string _defaultValString) const;
+
+    /// \brief Conversion of a string to a double vector
+    /// \param[in] _input The string to convert to a vector of doubles.
+    /// \return The vector converted from the input string.
+    private: std::vector<double> StrToVector(std::string _input) const;
 
     /// \brief Takes ROS Drive commands and scales them by max thrust.
     /// \param[in] _cmd ROS drive command.
@@ -244,6 +309,14 @@ namespace gazebo
     private: double GlfThrustCmd(const double _cmd,
                                  const double _maxPos,
                                  const double _maxNeg) const;
+
+    /// \brief Uses linear interpolatoin between given thrust command
+    /// to thruster force mapping.
+    /// \param[in] _cmd Thrust command.
+    /// \param[in] _cmdForceMap Mapping b/t thrust command and thrust force.
+    /// \return Thrust force [N].
+    private: double LinearInterpThrustCmd(const double _cmd,
+                            const std::map<double, double> _cmdForceMap) const;
 
     /// \brief Rotate engine using engine joint PID
     /// \param[in] _i Index of thruster whose engine will be rotated

--- a/usv_gazebo_plugins/include/usv_gazebo_plugins/usv_gazebo_thrust_plugin.hh
+++ b/usv_gazebo_plugins/include/usv_gazebo_plugins/usv_gazebo_thrust_plugin.hh
@@ -51,8 +51,11 @@ namespace gazebo
     /// \param[in] _msg The thrust angle message to process.
     public: void OnThrustAngle(const std_msgs::Float32::ConstPtr &_msg);
 
-    /// \brief Maximum abs val of incoming command.
+    /// \brief Maximum val of incoming command.
     public: double maxCmd;
+
+    /// \brief Minimum val of incoming command.
+    public: double minCmd;
 
     /// \brief Max forward force in Newtons.
     public: double maxForceFwd;
@@ -134,8 +137,10 @@ namespace gazebo
   ///   Optional elements:
   ///   <mappingType>: Thruster mapping (0=linear; 1=GLF, nonlinear),
   ///   default is 0
-  ///   <maxCmd>:Maximum (abs val) of thrust commands,
+  ///   <maxCmd>:Maximum of thrust commands,
   ///   defualt is 1.0
+  ///   <minCmd>:Minimum of thrust commands,
+  ///   defualt is -1.0
   ///   <maxForceFwd>: Maximum forward force [N].
   ///   default is 250.0 N
   ///   <maxForceRev>: Maximum reverse force [N].
@@ -159,6 +164,7 @@ namespace gazebo
   ///        <enableAngle>false</enableAngle>
   ///        <mappingType>1</mappingType>
   ///        <maxCmd>1.0</maxCmd>
+  ///        <minCmd>-1.0</minCmd>
   ///        <maxForceFwd>250.0</maxForceFwd>
   ///        <maxForceRev>-100.0</maxForceRev>
   ///        <maxAngle>1.57</maxAngle>
@@ -172,6 +178,7 @@ namespace gazebo
   ///        <enableAngle>false</enableAngle>
   ///        <mappingType>1</mappingType>
   ///        <maxCmd>1.0</maxCmd>
+  ///        <minCmd>-1.0</minCmd>
   ///        <maxForceFwd>250.0</maxForceFwd>
   ///        <maxForceRev>-100.0</maxForceRev>
   ///        <maxAngle>1.57</maxAngle>
@@ -208,6 +215,7 @@ namespace gazebo
     /// \return Value scaled and saturated.
     private: double ScaleThrustCmd(const double _cmd,
                                    const double _max_cmd,
+                                   const double _min_cmd,
                                    const double _max_pos,
                                    const double _max_neg) const;
 

--- a/usv_gazebo_plugins/src/usv_gazebo_thrust_plugin.cc
+++ b/usv_gazebo_plugins/src/usv_gazebo_thrust_plugin.cc
@@ -366,6 +366,12 @@ void UsvThrust::Update()
       // Adjust thruster engine joint angle with PID
       this->RotateEngine(i, now - this->thrusters[i].lastAngleUpdateTime);
 
+      // Apply input command clamping
+      this->thrusters[i].currCmd = std::min(this->thrusters[i].currCmd,
+                                            this->thrusters[i].maxCmd);
+      this->thrusters[i].currCmd = std::max(this->thrusters[i].currCmd,
+                                            this->thrusters[i].minCmd);
+
       // Apply the thrust mapping
       ignition::math::Vector3d tforcev(0, 0, 0);
       switch (this->thrusters[i].mappingType)
@@ -389,6 +395,10 @@ void UsvThrust::Update()
               this->thrusters[i].mappingType);
             break;
       }
+
+      // Apply thrust clamping
+      tforcev.X() = std::max(tforcev.X(), this->thrusters[i].maxForceFwd);
+      tforcev.X() = std::min(tforcev.X(), this->thrusters[i].maxForceRev);
 
       // Apply force for each thruster
       this->thrusters[i].link->AddLinkForce(tforcev);

--- a/usv_gazebo_plugins/src/usv_gazebo_thrust_plugin.cc
+++ b/usv_gazebo_plugins/src/usv_gazebo_thrust_plugin.cc
@@ -232,6 +232,7 @@ void UsvThrust::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
       }
 
       thruster.maxCmd = this->SdfParamDouble(thrusterSDF, "maxCmd", 1.0);
+      thruster.minCmd = this->SdfParamDouble(thrusterSDF, "minCmd", -1.0);
       thruster.maxForceFwd =
         this->SdfParamDouble(thrusterSDF, "maxForceFwd", 250.0);
       thruster.maxForceRev =
@@ -297,7 +298,7 @@ void UsvThrust::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
 
 //////////////////////////////////////////////////
 double UsvThrust::ScaleThrustCmd(const double _cmd, const double _maxCmd,
-  const double _maxPos, const double _maxNeg) const
+  const double _minCmd, const double _maxPos, const double _maxNeg) const
 {
   double val = 0.0;
   if (_cmd >= 0.0)
@@ -308,7 +309,8 @@ double UsvThrust::ScaleThrustCmd(const double _cmd, const double _maxCmd,
   else
   {
     double absMaxNeg = std::abs(_maxNeg);
-    val = _cmd / _maxCmd * absMaxNeg;
+    double absMinCmd = std::abs(_minCmd);
+    val = _cmd / absMinCmd * absMaxNeg;
     val = std::max(val, -1.0 * absMaxNeg);
   }
   return val;
@@ -372,6 +374,7 @@ void UsvThrust::Update()
           tforcev.X() = this->ScaleThrustCmd(this->thrusters[i].currCmd/
                                             this->thrusters[i].maxCmd,
                                             this->thrusters[i].maxCmd,
+                                            this->thrusters[i].minCmd,
                                             this->thrusters[i].maxForceFwd,
                                             this->thrusters[i].maxForceRev);
           break;

--- a/wamv_gazebo/urdf/thruster_layouts/wamv_gazebo_thruster_config.xacro
+++ b/wamv_gazebo/urdf/thruster_layouts/wamv_gazebo_thruster_config.xacro
@@ -13,6 +13,7 @@
       <!-- Optional Parameters -->
       <mappingType>1</mappingType>
       <maxCmd>1.0</maxCmd>
+      <minCmd>-1.0</minCmd>
       <maxForceFwd>250.0</maxForceFwd>
       <maxForceRev>-100.0</maxForceRev>
       <maxAngle>${pi/2}</maxAngle>

--- a/wave_gazebo_plugins/CMakeLists.txt
+++ b/wave_gazebo_plugins/CMakeLists.txt
@@ -2,21 +2,13 @@ cmake_minimum_required(VERSION 2.8.3)
 project(wave_gazebo_plugins)
 
 ###############################################################################
-# Compile as C++11, supported in ROS Kinetic and newer
 
-#set(CMAKE_CXX_STANDARD 11)
-#set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-# For this package set as C++14
 include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX14)
-    set(CMAKE_CXX_FLAGS "-std=c++14")
-elseif(COMPILER_SUPPORTS_CXX0X)
-    set(CMAKE_CXX_FLAGS "-std=c++0x")
+CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
+if(COMPILER_SUPPORTS_CXX17)
+    add_compile_options(-std=c++17)
 else()
-    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++14 support. Please use a different C++ compiler.")
+    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++17 support. Please use a different C++ compiler.")
 endif()
 
 # Set policy for CMake 3.1+. Use OLD policy to let FindBoost.cmake, dependency


### PR DESCRIPTION
related issue: #477 

From commit message:

> this mappingType allows users to specify a mapping of thrust commands and thrust forces as seen typically in thrust profile datasheets; linear interpolation using the two nearest points in the mapping is done to compute the actual thrust force from a thrust command


Again if you could ignore the previous commits for now and just review based on the latest commit prevalent that would be appreciated. I'll rebase this branch based on the input of the other PRs I have made. Sorry about that, its just easier for me to develop. Thank you.