### PR TITLE
Add CI for gazebosim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,27 @@ jobs:
       image: npslearninglab/watery_robots:galactic_current
     steps:
       - run: sudo chown -R `whoami`:`whoami` .
-      - uses: actions/checkout@v2.4.0
+      - name: Checkout vrx
+        uses: actions/checkout@v2.4.0
         with:
             ref: gazebosim
             path: vrx
 
-      - uses: actions/checkout@v2.4.0
+      - name: Checkout Gazebosim 
+        uses: actions/checkout@v2.4.0
         with:
             repository: ignitionrobotics/ros_ign
             ref: galactic 
             path: ros_ign
        
-     - name: Compile and test
-        id: ci
-        uses: ignition-tooling/action-ignition-ci@focal
+      - name: Set up workspace
+        run: |
+          mkdir -p /tmp/vrx_ws/src;
+          ln -s `pwd` /tmp/vrx_ws/src;
 
+      - name: Build and run tests
+        shell: bash
+        run: |
+          cd /tmp/vrx_ws;
+          source /opt/ros/galactic/setup.bash;
+          IGNITION_VERSION=fortress colcon build --merge-install --executor sequential;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
           cd /tmp/vrx_ws;
           source /opt/ros/galactic/setup.bash;
           IGNITION_VERSION=fortress colcon build --merge-install --executor sequential;
-          IGNITION_VERSION=fortress colcon test --merge-install --executor sequential;
+          IGNITION_VERSION=fortress colcon test --merge-install --executor sequential --return-code-on-test-failure;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,15 @@ jobs:
             ref: galactic 
             path: ros_ign
   
-      - name: Compile and test
-        id: ci
-        uses: gazebo-tooling/action-gz-ci@focal
-        with:
-          codecov-enabled: true
-          doxygen-enabled: true
-          cmake-args: '-DBUILD_TESTING=1'
+      - name: Set up workspace
+        run: |
+          mkdir -p /tmp/vrx_ws/src;
+          ln -s `pwd` /tmp/vrx_ws/src;
 
+      - name: Build and run tests
+        shell: bash
+        run: |
+          cd /tmp/vrx_ws;
+          source /opt/ros/galactic/setup.bash;
+          IGNITION_VERSION=fortress colcon build --merge-install --executor sequential;
+          IGNITION_VERSION=fortress colcon test --merge-install --executor sequential;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,9 @@ jobs:
   
       - name: Compile and test
         id: ci
-        uses: gazebo-tooling/ubuntu-ci-action@focal
+        uses: gazebo-tooling/action-gz-ci@focal
         with:
           codecov-enabled: true
           doxygen-enabled: true
           cmake-args: '-DBUILD_TESTING=1'
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,24 @@ name: Ubuntu CI
 on: [pull_request]
 
 jobs:
-  test-gazebo11-noetic:
+  test-fortress-galactic:
 
     runs-on: ubuntu-20.04
     container: 
-      image: npslearninglab/watery_robots:noetic_current
+      image: npslearninglab/watery_robots:galactic_current
     steps:
       - run: sudo chown -R `whoami`:`whoami` .
-      - uses: actions/checkout@v2
-  
-      - name: Static code checking
-        run: sh tools/code_check.sh
+      - uses: actions/checkout@v2.4.0
+        with:
+            ref: gazebosim
+            path: vrx
 
+      - uses: actions/checkout@v2.4.0
+        with:
+            repository: ignitionrobotics/ros_ign
+            ref: galactic 
+            path: ros_ign
+       
       - name: Set up workspace
         run: |
           mkdir -p /tmp/vrx_ws/src;
@@ -24,56 +30,5 @@ jobs:
         shell: bash
         run: |
           cd /tmp/vrx_ws;
-          source /opt/ros/noetic/setup.bash;
-          catkin_make -j1;
-          catkin_make run_tests -j1;
-
-  test-gazebo9-melodic:
-
-    runs-on: ubuntu-18.04
-    container: 
-      image: npslearninglab/watery_robots:melodic_current
-    steps:
-      - run: sudo chown -R `whoami`:`whoami` .
-      - uses: actions/checkout@v2
-  
-      - name: Static code checking
-        run: sh tools/code_check.sh
-
-      - name: Set up workspace
-        run: |
-          mkdir -p /tmp/vrx_ws/src;
-          ln -s `pwd` /tmp/vrx_ws/src;
-
-      - name: Build and run tests
-        shell: bash
-        run: |
-          cd /tmp/vrx_ws;
-          source /opt/ros/melodic/setup.bash;
-          catkin_make -j1;
-          catkin_make run_tests -j1;
-
-  test-gazebo7-kinetic:
-
-    runs-on: ubuntu-18.04
-    container: 
-      image: npslearninglab/watery_robots:kinetic_current
-    steps:
-      - run: sudo chown -R `whoami`:`whoami` .
-      - uses: actions/checkout@v2
-  
-      - name: Static code checking
-        run: sh tools/code_check.sh
-
-      - name: Set up workspace
-        run: |
-          mkdir -p /tmp/vrx_ws/src;
-          ln -s `pwd` /tmp/vrx_ws/src;
-
-      - name: Build and run tests
-        shell: bash
-        run: |
-          cd /tmp/vrx_ws;
-          source /opt/ros/kinetic/setup.bash;
-          catkin_make -j1;
-          catkin_make run_tests -j1;
+          source /opt/ros/galactic/setup.bash;
+          IGNITION_VERSION=fortress colcon build --merge-install --executor sequential;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,5 @@ jobs:
           cd /tmp/vrx_ws;
           source /opt/ros/galactic/setup.bash;
           IGNITION_VERSION=fortress colcon build --merge-install --executor sequential;
-          IGNITION_VERSION=fortress colcon test --merge-install --executor sequential --return-code-on-test-failure --event-handlers console_direct+;
+          IGNITION_VERSION=fortress colcon test --merge-install --executor sequential --packages-skip-regex ros_ign* --return-code-on-test-failure --event-handlers console_direct+;
  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
             ref: galactic 
             path: ros_ign
        
+     - name: Compile and test
+        id: ci
+        uses: ignition-tooling/action-ignition-ci@focal
+
       - name: Set up workspace
         run: |
           mkdir -p /tmp/vrx_ws/src;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
        
      - name: Compile and test
         id: ci
-        uses: ignition-tooling/action-ignition-ci@focal
+        uses: gazebo-tooling/ubuntu-ci-action@focal
 
       - name: Set up workspace
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,7 @@ jobs:
             ref: galactic 
             path: ros_ign
        
-      - name: Set up workspace
-        run: |
-          mkdir -p /tmp/vrx_ws/src;
-          ln -s `pwd` /tmp/vrx_ws/src;
+     - name: Compile and test
+        id: ci
+        uses: ignition-tooling/action-ignition-ci@focal
 
-      - name: Build and run tests
-        shell: bash
-        run: |
-          cd /tmp/vrx_ws;
-          source /opt/ros/galactic/setup.bash;
-          IGNITION_VERSION=fortress colcon build --merge-install --executor sequential;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,6 @@ jobs:
             ref: galactic 
             path: ros_ign
        
-     - name: Compile and test
-        id: ci
-        uses: gazebo-tooling/action-gz-ci@focal
-
       - name: Set up workspace
         run: |
           mkdir -p /tmp/vrx_ws/src;
@@ -38,3 +34,4 @@ jobs:
           cd /tmp/vrx_ws;
           source /opt/ros/galactic/setup.bash;
           IGNITION_VERSION=fortress colcon build --merge-install --executor sequential;
+          IGNITION_VERSION=fortress colcon test --merge-install --executor sequential;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
        
      - name: Compile and test
         id: ci
-        uses: gazebo-tooling/ubuntu-ci-action@focal
+        uses: gazebo-tooling/action-gz-ci@focal
 
       - name: Set up workspace
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,5 @@ jobs:
           cd /tmp/vrx_ws;
           source /opt/ros/galactic/setup.bash;
           IGNITION_VERSION=fortress colcon build --merge-install --executor sequential;
-          IGNITION_VERSION=fortress colcon test --merge-install --executor sequential --return-code-on-test-failure;
+          IGNITION_VERSION=fortress colcon test --merge-install --executor sequential --return-code-on-test-failure --event-handlers console_direct+;
+ 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,11 @@ jobs:
             repository: ignitionrobotics/ros_ign
             ref: galactic 
             path: ros_ign
-       
-      - name: Set up workspace
-        run: |
-          mkdir -p /tmp/vrx_ws/src;
-          ln -s `pwd` /tmp/vrx_ws/src;
-
-      - name: Build and run tests
-        shell: bash
-        run: |
-          cd /tmp/vrx_ws;
-          source /opt/ros/galactic/setup.bash;
-          IGNITION_VERSION=fortress colcon build --merge-install --executor sequential;
-          IGNITION_VERSION=fortress colcon test --merge-install --executor sequential;
+  
+      - name: Compile and test
+        id: ci
+        uses: gazebo-tooling/ubuntu-ci-action@focal
+        with:
+          codecov-enabled: true
+          doxygen-enabled: true
+          cmake-args: '-DBUILD_TESTING=1'


### PR DESCRIPTION
Very basic Galactic/fortress CI.

Looking around the internet, it seems that there are a few efforts underway to provide github actions to build and test gazebosim/ros2 projects. 
* For example, the Gazebosim repository uses this workflow: https://github.com/gazebosim/gz-sim/blob/ign-gazebo6/.github/workflows/ci.yml
* However, it doesn't seem to be functional right now, and the vast majority of PRs are being merged with failed checks.
* So, for now I think we should take a simple approach and just see whether the build succeeds with `colcon`.
* Later we can also add static checking.
* When the fancier build and test tools are working better we can switch over.

To test:
* Review the output details and verify that they say what we expect them to say.