### PR TITLE
remove addition of zero Z valued grid point

### DIFF
--- a/usv_gazebo_plugins/src/usv_gazebo_dynamics_plugin.cc
+++ b/usv_gazebo_plugins/src/usv_gazebo_dynamics_plugin.cc
@@ -327,19 +327,16 @@ void UsvDynamicsPlugin::Update()
 
       // Compute the depth at the grid point.
       double simTime = kTimeNow.Double();
-      // double depth = WavefieldSampler::ComputeDepthDirectly(
-      //  *waveParams, X, simTime);
       double depth = 0.0;
       if (waveParams)
       {
+        // depth = WavefieldSampler::ComputeDepthDirectly(
+        // *waveParams, X, simTime);
         depth = WavefieldSampler::ComputeDepthSimply(*waveParams, X, simTime);
       }
 
-      // Vertical wave displacement.
-      double dz = depth + X.Z();
-
       // Total z location of boat grid point relative to water surface
-      double  deltaZ = (this->waterLevel + dz) - kDdz;
+      double  deltaZ = (this->waterLevel + depth) - kDdz;
       deltaZ = std::max(deltaZ, 0.0);  // enforce only upward buoy force
       deltaZ = std::min(deltaZ, this->paramHullRadius);
       // Buoyancy force at grid point


### PR DESCRIPTION
X.Z() never gets populated with a nonzero value besides it's initial construction value of 0. Thus this addition is extraneous.

Co-authored-by: Jonathan <jonathan.r.eastridge.civ@us.navy.mil>