### PR TITLE
Add mesh geometry to BuoyancyPlugin

### DIFF
--- a/usv_gazebo_plugins/CMakeLists.txt
+++ b/usv_gazebo_plugins/CMakeLists.txt
@@ -19,8 +19,8 @@ catkin_package(
   CATKIN_DEPENDS message_runtime gazebo_dev roscpp wave_gazebo_plugins
 )
 
-# Plugins require c++11
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+# Plugins require c++17
+set(CMAKE_CXX_FLAGS "-std=c++17 ${CMAKE_CXX_FLAGS}")
 
 include_directories( include
   ${catkin_INCLUDE_DIRS}

--- a/usv_gazebo_plugins/include/usv_gazebo_plugins/polyhedron_volume.hh
+++ b/usv_gazebo_plugins/include/usv_gazebo_plugins/polyhedron_volume.hh
@@ -86,6 +86,11 @@ namespace buoyancy
                                            double l,
                                            int n);
 
+    /// \brief Generate a mesh polyhedron centered at origin
+    /// @param filename: filename of mesh
+    /// @return Polyhedron object
+    public: static Polyhedron makeMesh(std::string filename);
+
     /// \brief Compute full volume and center of buoyancy of the polyhedron
     /// @return Volume object with volume and centroid
     public: Volume ComputeFullVolume();
@@ -98,6 +103,10 @@ namespace buoyancy
     public: Volume SubmergedVolume(const ignition::math::Vector3d &x,
                                    const ignition::math::Quaterniond &q,
                                    Plane &plane);
+
+    /// \brief Get Object vertices
+    /// @return Vertices of the polyhedron
+    public: std::vector<ignition::math::Vector3d> GetVertices();
 
     /// \brief Computes volume and centroid of tetrahedron
     /// tetrahedron formed by triangle + arbitrary point

--- a/usv_gazebo_plugins/include/usv_gazebo_plugins/shape_volume.hh
+++ b/usv_gazebo_plugins/include/usv_gazebo_plugins/shape_volume.hh
@@ -33,7 +33,8 @@ namespace buoyancy
     None,
     Box,
     Sphere,
-    Cylinder
+    Cylinder,
+    Mesh
   };
 
   /// \brief Parent shape object for volume objects
@@ -141,6 +142,28 @@ namespace buoyancy
 
     /// \brief Radius of sphere
     double r;
+  };
+
+  /// \brief Mesh shape volume
+  struct MeshVolume : public ShapeVolume
+  {
+    /// \brief Default constructor
+    /// @param filename: filename of the mesh
+    explicit MeshVolume(std::string filename);
+
+    /// \brief Display string for mesh shape
+    std::string Display() override;
+
+    // Documentation inherited.
+    Volume CalculateVolume(const ignition::math::Pose3d& pose,
+                           double fluidLevel) override;
+
+    /// \brief Filename of mesh
+    std::string filename;
+
+    private:
+    /// \brief Polyhedron defining a mesh
+    Polyhedron polyhedron;
   };
 
   /// \brief Custom exception for parsing errors

--- a/wamv_gazebo/urdf/buoyancy/wamv_buoyancy_plugin.xacro
+++ b/wamv_gazebo/urdf/buoyancy/wamv_buoyancy_plugin.xacro
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:macro name="usv_buoyancy_gazebo" params="name width:=2.4 length:=4.9">
+    <!--Gazebo Plugin for simulating WAM-V buoyancy-->
+    <gazebo>
+      <plugin name="usv_buoyancy_${name}_hull_left" filename="libbuoyancy_gazebo_plugin.so">
+        <!-- Wave model -->
+        <wave_model>ocean_waves</wave_model>
+        <fluid_density>997.8</fluid_density>
+        <fluid_level>0</fluid_level>
+
+        <linear_drag>0</linear_drag>
+        <angular_drag>0</angular_drag>
+
+        <buoyancy>
+          <link_name>${namespace}/base_link</link_name>
+          <!-- pose info from wamv_base.urdf.xacro/${prefix}_float-->
+          <pose>0 -1.03 0.2 0 1.57 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.213</radius>
+              <length>${length}</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+      </plugin>
+
+      <plugin name="usv_buoyancy_${name}_hull_right" filename="libbuoyancy_gazebo_plugin.so">
+        <!-- Wave model -->
+        <wave_model>ocean_waves</wave_model>
+        <fluid_density>997.8</fluid_density>
+        <fluid_level>0</fluid_level>
+
+        <linear_drag>0</linear_drag>
+        <angular_drag>0</angular_drag>
+
+        <buoyancy>
+          <link_name>${namespace}/base_link</link_name>
+          <!-- pose info from wamv_base.urdf.xacro/${prefix}_float-->
+          <pose>0 1.03 0.2 0 1.57 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.213</radius>
+              <length>${length}</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+      </plugin>
+
+    </gazebo>
+  </xacro:macro>
+</robot>

--- a/wamv_gazebo/urdf/buoyancy/wamv_buoyancy_plugin.xacro
+++ b/wamv_gazebo/urdf/buoyancy/wamv_buoyancy_plugin.xacro
@@ -3,7 +3,7 @@
   <xacro:macro name="usv_buoyancy_gazebo" params="name width:=2.4 length:=4.9">
     <!--Gazebo Plugin for simulating WAM-V buoyancy-->
     <gazebo>
-      <plugin name="usv_buoyancy_${name}_hull_left" filename="libbuoyancy_gazebo_plugin.so">
+      <plugin name="usv_buoyancy_${name}" filename="libbuoyancy_gazebo_plugin.so">
         <!-- Wave model -->
         <wave_model>ocean_waves</wave_model>
         <fluid_density>997.8</fluid_density>
@@ -14,39 +14,12 @@
 
         <buoyancy>
           <link_name>${namespace}/base_link</link_name>
-          <!-- pose info from wamv_base.urdf.xacro/${prefix}_float-->
-          <pose>0 -1.03 0.2 0 1.57 0</pose>
           <geometry>
-            <cylinder>
-              <radius>0.213</radius>
-              <length>${length}</length>
-            </cylinder>
+            <!-- mesh from wamv_base.urdf.xacro/${namespace}/dummy_link -->
+            <mesh filename="package://wamv_description/models/WAM-V-Base/mesh/WAM-V-Base.dae"/>
           </geometry>
         </buoyancy>
       </plugin>
-
-      <plugin name="usv_buoyancy_${name}_hull_right" filename="libbuoyancy_gazebo_plugin.so">
-        <!-- Wave model -->
-        <wave_model>ocean_waves</wave_model>
-        <fluid_density>997.8</fluid_density>
-        <fluid_level>0</fluid_level>
-
-        <linear_drag>0</linear_drag>
-        <angular_drag>0</angular_drag>
-
-        <buoyancy>
-          <link_name>${namespace}/base_link</link_name>
-          <!-- pose info from wamv_base.urdf.xacro/${prefix}_float-->
-          <pose>0 1.03 0.2 0 1.57 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.213</radius>
-              <length>${length}</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-      </plugin>
-
     </gazebo>
   </xacro:macro>
 </robot>

--- a/wamv_gazebo/urdf/macros.xacro
+++ b/wamv_gazebo/urdf/macros.xacro
@@ -4,6 +4,8 @@
        name="WAM-V">
   <!-- Include dynamics macros -->
   <xacro:include filename="$(find wamv_gazebo)/urdf/dynamics/wamv_gazebo_dynamics_plugin.xacro" />
+  <!-- Include buoyancy macros -->
+  <xacro:include filename="$(find wamv_gazebo)/urdf/buoyancy/wamv_buoyancy_plugin.xacro" />
 
   <!-- Include sensor macros -->
   <xacro:include filename="$(find wamv_gazebo)/urdf/components/wamv_camera.xacro" />

--- a/wamv_gazebo/urdf/wamv_gazebo.xacro
+++ b/wamv_gazebo/urdf/wamv_gazebo.xacro
@@ -10,5 +10,7 @@
     <xacro:include filename="${thruster_layout}"/>
     <!-- Attach hydrodynamics plugin -->
     <xacro:usv_dynamics_gazebo name="wamv_dynamics_plugin"/>
+    <!-- Attach buoyancy plugin -->
+    <xacro:usv_buoyancy_gazebo name="wamv_buoyancy_plugin"/>
   </xacro:macro>
 </robot>

--- a/wave_gazebo_plugins/CMakeLists.txt
+++ b/wave_gazebo_plugins/CMakeLists.txt
@@ -2,21 +2,13 @@ cmake_minimum_required(VERSION 2.8.3)
 project(wave_gazebo_plugins)
 
 ###############################################################################
-# Compile as C++11, supported in ROS Kinetic and newer
 
-#set(CMAKE_CXX_STANDARD 11)
-#set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-# For this package set as C++14
 include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX14)
-    set(CMAKE_CXX_FLAGS "-std=c++14")
-elseif(COMPILER_SUPPORTS_CXX0X)
-    set(CMAKE_CXX_FLAGS "-std=c++0x")
+CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
+if(COMPILER_SUPPORTS_CXX17)
+    add_compile_options(-std=c++17)
 else()
-    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++14 support. Please use a different C++ compiler.")
+    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++17 support. Please use a different C++ compiler.")
 endif()
 
 # Set policy for CMake 3.1+. Use OLD policy to let FindBoost.cmake, dependency


### PR DESCRIPTION
This allows the support for using a mesh file as the geometry used in the buoyancy computations. The buoyancy force computed from this PR is verified within 100N of the original buoyancy code. Which is close enough, to believe that this PR provides a more accurate buoyancy computation than the existing code.

Closes #488 