### PR TITLE
Utilize proper pms coefficients

### DIFF
--- a/usv_gazebo_plugins/CMakeLists.txt
+++ b/usv_gazebo_plugins/CMakeLists.txt
@@ -19,8 +19,8 @@ catkin_package(
   CATKIN_DEPENDS message_runtime gazebo_dev roscpp wave_gazebo_plugins
 )
 
-# Plugins require c++11
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+# Plugins require c++17
+set(CMAKE_CXX_FLAGS "-std=c++17 ${CMAKE_CXX_FLAGS}")
 
 include_directories( include
   ${catkin_INCLUDE_DIRS}

--- a/wave_gazebo_plugins/CMakeLists.txt
+++ b/wave_gazebo_plugins/CMakeLists.txt
@@ -2,21 +2,13 @@ cmake_minimum_required(VERSION 2.8.3)
 project(wave_gazebo_plugins)
 
 ###############################################################################
-# Compile as C++11, supported in ROS Kinetic and newer
 
-#set(CMAKE_CXX_STANDARD 11)
-#set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-# For this package set as C++14
 include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX14)
-    set(CMAKE_CXX_FLAGS "-std=c++14")
-elseif(COMPILER_SUPPORTS_CXX0X)
-    set(CMAKE_CXX_FLAGS "-std=c++0x")
+CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
+if(COMPILER_SUPPORTS_CXX17)
+    add_compile_options(-std=c++17)
 else()
-    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++14 support. Please use a different C++ compiler.")
+    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++17 support. Please use a different C++ compiler.")
 endif()
 
 # Set policy for CMake 3.1+. Use OLD policy to let FindBoost.cmake, dependency

--- a/wave_gazebo_plugins/src/Wavefield.cc
+++ b/wave_gazebo_plugins/src/Wavefield.cc
@@ -192,9 +192,10 @@ namespace asv
     public: double pm(double omega, double omega_p)
     {
       double alpha = 0.0081;
+      double beta = 0.74;
       double g = 9.81;
       return alpha*std::pow(g, 2.0)/std::pow(omega, 5.0)* \
-        std::exp(-(5.0/4.0)*std::pow(omega_p/omega, 4.0));
+        std::exp(-beta*std::pow(omega_p/omega, 4.0));
     }
 
     /// \brief Recalculate for Pierson-Moskowitz spectrum sampling model


### PR DESCRIPTION
The Pierson-Moskowitz uses a coefficient called $\beta$, which is defined as 0.74.
Source: https://wikiwaves.org/Ocean-Wave_Spectra

In our code, we have $\beta$ hardcoded as 5.0/4.0 = 1.25. This is incorrect.

This PR updates the Wavefield code to use the correct parameter.

Full equation: 

$$ S(\omega) = \dfrac{\alpha g^2}{\omega^5} \exp \left( - \beta * \left(\dfrac{\omega_0}{\omega}\right)^4 \right)$$

with $\alpha = 0.0081$ (correct in our code) and $\beta = 0.74$ (not correct in our code).

cc: @bsb808 @jeastnswc