### PR TITLE
Working minimal ScoringPlugin example

### DIFF
--- a/vrx_ign/CMakeLists.txt
+++ b/vrx_ign/CMakeLists.txt
@@ -47,12 +47,26 @@ install(
   TARGETS Waves
   DESTINATION lib)
 
+# Base scoring plugin
+add_library(ScoringPlugin SHARED
+  src/ScoringPlugin.cc
+)
+target_link_libraries(ScoringPlugin PUBLIC
+ignition-gazebo${IGN_GAZEBO_VER}::core
+ignition-plugin${IGN_PLUGIN_VER}::ignition-plugin${IGN_PLUGIN_VER}
+ignition-rendering${IGN_RENDERING_VER}::ignition-rendering${IGN_RENDERING_VER}
+ignition-physics${IGN_PHYSICS_VER}::ignition-physics${IGN_PHYSICS_VER}
+Waves
+)
+install(
+  TARGETS ScoringPlugin
+  DESTINATION lib)
+
 # Plugins
 list(APPEND VRX_IGN_PLUGINS
   SimpleHydrodynamics
   Surface
   WaveVisual
-  ScoringPlugin
 )
 
 foreach(PLUGIN ${VRX_IGN_PLUGINS})
@@ -63,6 +77,7 @@ foreach(PLUGIN ${VRX_IGN_PLUGINS})
     ignition-rendering${IGN_RENDERING_VER}::ignition-rendering${IGN_RENDERING_VER}
     ignition-physics${IGN_PHYSICS_VER}::ignition-physics${IGN_PHYSICS_VER}
     Waves
+    ScoringPlugin
   )
 endforeach()
 

--- a/vrx_ign/CMakeLists.txt
+++ b/vrx_ign/CMakeLists.txt
@@ -4,7 +4,6 @@ project(vrx_ign)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
-find_package(rclcpp REQUIRED)
 
 find_package(ignition-gazebo6 REQUIRED)
 set(IGN_GAZEBO_VER ${ignition-gazebo6_VERSION_MAJOR})
@@ -22,8 +21,8 @@ set(IGN_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
 find_package(ignition-rendering6 REQUIRED)
 set(IGN_RENDERING_VER ${ignition-rendering6_VERSION_MAJOR})
 find_package(sdformat12 REQUIRED)
-find_package(ignition-physics4 REQUIRED)
-set(IGN_PHYSICS_VER ${ignition-physics4_VERSION_MAJOR})
+find_package(ignition-physics5 REQUIRED)
+set(IGN_PHYSICS_VER ${ignition-physics5_VERSION_MAJOR})
 
 find_package(std_msgs REQUIRED)
 

--- a/vrx_ign/CMakeLists.txt
+++ b/vrx_ign/CMakeLists.txt
@@ -4,6 +4,7 @@ project(vrx_ign)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
+find_package(rclcpp REQUIRED)
 
 find_package(ignition-gazebo6 REQUIRED)
 set(IGN_GAZEBO_VER ${ignition-gazebo6_VERSION_MAJOR})
@@ -21,8 +22,11 @@ set(IGN_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
 find_package(ignition-rendering6 REQUIRED)
 set(IGN_RENDERING_VER ${ignition-rendering6_VERSION_MAJOR})
 find_package(sdformat12 REQUIRED)
+find_package(ignition-physics4 REQUIRED)
+set(IGN_PHYSICS_VER ${ignition-physics4_VERSION_MAJOR})
 
 find_package(std_msgs REQUIRED)
+
 
 #============================================================================
 # Hooks
@@ -49,6 +53,7 @@ list(APPEND VRX_IGN_PLUGINS
   SimpleHydrodynamics
   Surface
   WaveVisual
+  ScoringPlugin
 )
 
 foreach(PLUGIN ${VRX_IGN_PLUGINS})
@@ -57,9 +62,12 @@ foreach(PLUGIN ${VRX_IGN_PLUGINS})
     ignition-gazebo${IGN_GAZEBO_VER}::core
     ignition-plugin${IGN_PLUGIN_VER}::ignition-plugin${IGN_PLUGIN_VER}
     ignition-rendering${IGN_RENDERING_VER}::ignition-rendering${IGN_RENDERING_VER}
+    ignition-physics${IGN_PHYSICS_VER}::ignition-physics${IGN_PHYSICS_VER}
     Waves
   )
 endforeach()
+
+
 
 install(
   TARGETS ${VRX_IGN_PLUGINS}
@@ -69,6 +77,8 @@ ament_python_install_package(
   vrx_ign
   PACKAGE_DIR src/vrx_ign
 )
+
+
 
 #============================================================================
 # Resources

--- a/vrx_ign/src/ScoringPlugin.cc
+++ b/vrx_ign/src/ScoringPlugin.cc
@@ -1,0 +1,409 @@
+#include <ignition/common/Console.hh>
+#include <ignition/physics/Joint.hh>
+#include <ignition/plugin/Register.hh>
+#include <ignition/gazebo/components/World.hh>
+#include <ignition/gazebo/EntityComponentManager.hh>
+#include <ignition/gazebo/Events.hh>
+#include <ignition/gazebo/SdfEntityCreator.hh>
+#include "ScoringPlugin.hh"
+
+void cb(const ignition::msgs::Contacts &_contacts){return;}
+
+ScoringPlugin::ScoringPlugin()
+
+{
+}
+
+void ScoringPlugin::Configure(const ignition::gazebo::Entity &_entity,
+                           const std::shared_ptr<const sdf::Element> &_sdf,
+                           ignition::gazebo::EntityComponentManager &_ecm,
+                           ignition::gazebo::EventManager &_eventMgr)
+{
+
+    this->creator = std::make_unique<ignition::gazebo::SdfEntityCreator>(_ecm, _eventMgr);
+    this->worldEntity = _ecm.EntityByComponents(ignition::gazebo::components::World());
+    this->eventManager = &_eventMgr;
+    this->sdf = _sdf;
+    //this->forceReturn = true; // Turns off update function!  Remove before use.
+    // SDF.
+    if (!this->ParseSDFParameters())
+    {
+        ignerr << "Scoring disabled" << std::endl;
+
+        return;
+    }
+
+    this->readyTime = std::chrono::duration<double>(this->initialStateDuration);
+    this->runningTime = this->readyTime +  std::chrono::duration<double>(this->readyStateDuration);
+    this->finishTime = this->runningTime + std::chrono::duration<double>(this->runningStateDuration);
+
+    // Prepopulate the task msg.
+
+    taskMessage.set_data(this->taskState);
+
+    this->taskPub = this->node.Advertise<ignition::msgs::StringMsg>(this->taskInfoTopic);
+    this->contactPub = this->node.Advertise<ignition::msgs::Contact>(this->contactDebugTopic);
+
+    std::string worldName = "sydney_regatta"; //hard code for testing
+    
+    std::string collisionTopic =
+        std::string("/gazebosim/") + worldName + std::string("/physics/contacts");
+             if (!gzNode->Subscribe(collisionTopic, &ScoringPlugin::OnCollisionMsg, this))
+    {
+        std::cerr << "Error subscribing to [" << collisionTopic << "]" << std::endl;
+        ignerr << "Error subscribing to [" << collisionTopic << "]" << std::endl;
+    }
+
+    this->serverControlPub = std::make_unique<ignition::transport::Node::Publisher>
+        (gzNode->Advertise<ignition::msgs::ServerControl>
+        ("/gazebosim/server/control")); */
+}
+
+//////////////////////////////////////////////////
+double ScoringPlugin::Score() const
+{
+  return this->score;
+}
+
+//////////////////////////////////////////////////
+void ScoringPlugin::SetScore(double _newScore)
+{
+  if (this->TaskState() == "running")
+    this->score = _newScore;
+}
+
+//////////////////////////////////////////////////
+std::string ScoringPlugin::TaskName() const
+{
+  return this->taskName;
+}
+
+//////////////////////////////////////////////////
+std::string ScoringPlugin::TaskState() const
+{
+  return this->taskState;
+}
+
+//////////////////////////////////////////////////
+std::chrono::duration<double> ScoringPlugin::ElapsedTime() const
+{
+  return this->elapsedTime;
+}
+
+//////////////////////////////////////////////////
+std::chrono::duration<double> ScoringPlugin::RemainingTime() const
+{
+  return this->remainingTime;
+}
+
+//////////////////////////////////////////////////
+void ScoringPlugin::Finish()
+{
+  if (this->taskState == "finished")
+    return;
+
+  this->taskState = "finished";
+  this->OnFinished();
+}
+
+//////////////////////////////////////////////////
+void ScoringPlugin::PostUpdate(const ignition::gazebo::UpdateInfo &_info,
+                const ignition::gazebo::EntityComponentManager &_ecm)
+{
+    // Placeholder for testing
+    if (this->forceReturn)
+    {
+      return;
+    }
+
+    this->simTime = _info.simTime;
+    this->UpdateTime(simTime);
+    this->UpdateTaskState();
+    this->PublishStats();
+}
+
+//////////////////////////////////////////////////
+void ScoringPlugin::UpdateTime(const std::chrono::duration<double> _simTime)
+{
+    this->currentTime = _simTime;
+    this->elapsedTime = this->currentTime - this->runningTime;
+    this->remainingTime = this->finishTime - this->currentTime;
+    this->timedOut = this->remainingTime <= std::chrono::duration<double>(0.0);
+}
+
+//////////////////////////////////////////////////
+void ScoringPlugin::UpdateTaskState()
+{
+  if (this->taskState == "initial" &&
+      this->currentTime >= this->readyTime)
+  {
+    this->taskState = "ready";
+    this->ReleaseVehicle();
+    this->OnReady();
+    return;
+  }
+
+  if (this->taskState == "ready" &&
+      this->currentTime >= this->runningTime)
+  {
+    this->taskState = "running";
+    this->OnRunning();
+    return;
+  }
+
+  if (this->taskState == "running" && this->timedOut)
+  {
+    this->taskState = "finished";
+    this->OnFinished();
+    return;
+  }
+}
+
+//////////////////////////////////////////////////
+
+void ScoringPlugin::UpdateTaskMessage() //My simplified version
+{
+    this->taskMessage.set_data(this->taskState);
+}
+//////////////////////////////////////////////////
+void ScoringPlugin::PublishStats()
+{
+  this->UpdateTaskMessage();
+
+  // We publish stats at 1Hz.
+  if (this->currentTime - this->lastStatsSent >= std::chrono::duration<double>(1.0))
+  {
+    this->taskPub.Publish(this->taskMessage);
+    this->lastStatsSent = this->currentTime;
+  }
+}
+//////////////////////////////////////////////////
+void ScoringPlugin::ReleaseVehicle()
+{
+    ignmsg << "Scoring Plugin Released WAMV" << std::endl;
+}
+
+void ScoringPlugin::OnReady()
+{
+  if (!this->silent)
+    ignmsg << "ScoringPlugin::OnReady" << std::endl;
+}
+
+//////////////////////////////////////////////////
+void ScoringPlugin::OnRunning()
+{
+  if (!this->silent)
+    ignmsg << "ScoringPlugin::OnRunning" << std::endl;
+}
+
+//////////////////////////////////////////////////
+void ScoringPlugin::OnFinished()
+{
+  if (!this->silent)
+    ignmsg << this->simTime.count() << "  OnFinished" << std::endl;
+
+  // If a timeoutScore was specified, use it.
+  if (this->timedOut && this->timeoutScore > 0.0)
+  {
+    this->score = this->timeoutScore;
+  }
+  this->UpdateTaskMessage();
+  this->taskPub.Publish(this->taskMessage);
+  this->Exit();
+}
+
+//////////////////////////////////////////////////
+void ScoringPlugin::OnCollision()
+{
+  ++this->numCollisions;
+}
+
+
+//////////////////////////////////////////////////
+void ScoringPlugin::OnCollisionMsg(const ignition::msgs::Contacts &_contacts)
+{
+    // loop through collisions, if any include the wamv, increment collision
+    // counter
+  ignmsg << "Collision Message" << std::endl;
+
+}
+
+//////////////////////////////////////////////////
+bool ScoringPlugin::ParseSDFParameters()
+{
+  // This is a required element.
+  if (!this->sdf->HasElement("vehicle"))
+  {
+    ignerr << "Unable to find <vehicle> element in SDF." << std::endl;
+    return false;
+  }
+  this->vehicleName = this->sdf->Get<std::string>("vehicle");
+
+  // This is a required element.
+  if (!this->sdf->HasElement("task_name"))
+  {
+    ignerr << "Unable to find <task_name> element in SDF." << std::endl;
+    return false;
+  }
+  this->taskName = this->sdf->Get<std::string>("task_name");
+
+  // This is an optional element.
+  if (this->sdf->HasElement("task_info_topic"))
+    this->taskInfoTopic = this->sdf->Get<std::string>("task_info_topic");
+
+  // This is an optional element.
+  if (this->sdf->HasElement("contact_debug_topic"))
+    this->contactDebugTopic = this->sdf->Get<std::string>
+      ("contact_debug_topic");
+
+  // This is an optional element.
+  if (this->sdf->HasElement("per_plugin_exit_on_completion"))
+    this->perPluginExitOnCompletion = this->sdf->Get<bool>(
+      "per_plugin_exit_on_completion");
+
+  // This is an optional element.
+  if (this->sdf->HasElement("initial_state_duration"))
+  {
+    double value = this->sdf->Get<double>("initial_state_duration");
+    if (value < 0)
+    {
+      ignerr << "<initial_state_duration> value should not be negative."
+            << std::endl;
+      return false;
+    }
+    this->initialStateDuration = value;
+  }
+
+  // This is an optional element.
+  if (this->sdf->HasElement("ready_state_duration"))
+  {
+    double value = this->sdf->Get<double>("ready_state_duration");
+    if (value < 0)
+    {
+      ignerr << "<ready_state_duration> value should not be negative."
+            << std::endl;
+      return false;
+    }
+
+    this->readyStateDuration = value;
+  }
+
+  // This is an optional element.
+  if (this->sdf->HasElement("running_state_duration"))
+  {
+    double value = this->sdf->Get<double>("running_state_duration");
+    if (value < 0)
+    {
+      ignerr << "<running_state_duration> value should not be negative."
+            << std::endl;
+      return false;
+    }
+    this->runningStateDuration = value;
+  }
+
+  // This is an optional element.
+  if (this->sdf->HasElement("collision_buffer"))
+  {
+    this->collisionBuffer = this->sdf->Get<float>("collision_buffer");
+  }
+
+  // This is an optional element.
+  if (this->sdf->HasElement("silent"))
+  {
+    this->silent = this->sdf->Get<bool>("silent");
+  }
+
+  return this->ParseJoints();
+}
+
+//////////////////////////////////////////////////
+bool ScoringPlugin::ParseJoints()
+{   
+  auto sdf = const_cast<sdf::Element *>(this->sdf.get());
+  // Optional element.
+  if (this->sdf->HasElement("release_joints"))
+  {
+    const sdf::ElementPtr releaseJointsElem = sdf->GetElement("release_joints");
+
+    // We need at least one joint.
+    if (!releaseJointsElem->HasElement("joint"))
+    {
+      ignerr << "Unable to find <joint> element in SDF." << std::endl;
+      return false;
+    }
+
+    auto jointElem = releaseJointsElem->GetElement("joint");
+
+    // Parse a new joint to be released.
+    while (jointElem)
+    {
+      // The joint's name.
+      if (!jointElem->HasElement("name"))
+      {
+        ignerr << "Unable to find <name> element in SDF." << std::endl;
+        return false;
+      }
+
+      const std::string jointName = jointElem->Get<std::string>("name");
+      this->lockJointNames.push_back(jointName);
+
+      // Parse the next joint.
+      jointElem = jointElem->GetNextElement("joint");
+    }
+  }
+
+  return true;
+}
+
+void ScoringPlugin::Exit()
+{
+  bool exit = this->perPluginExitOnCompletion;
+
+  char* env = std::getenv("VRX_EXIT_ON_COMPLETION");
+  if (env != nullptr && std::string(env) == "true")
+  {
+    // Overwrite class variable if environment variable is specified
+    exit = true;
+  }
+
+  if (exit)
+  {
+    // shutdown gazebo
+    ignition::msgs::ServerControl msg;
+    msg.set_stop(true);
+    this->serverControlPub->Publish(msg);
+  }
+  else
+  {
+    ignerr << "VRX_EXIT_ON_COMPLETION and <per_plugin_exit_on_completion> "
+      << "both not set, will not shutdown on ScoringPlugin::Exit()"
+      << std::endl;
+  }
+  return;
+}
+
+void ScoringPlugin::SetTimeoutScore(double _timeoutScore)
+{
+  this->timeoutScore = _timeoutScore;
+}
+
+double ScoringPlugin::GetTimeoutScore() const
+{
+  return this->timeoutScore;
+}
+
+double ScoringPlugin::GetRunningStateDuration() const
+{
+  return this->runningStateDuration;
+}
+
+unsigned int ScoringPlugin::GetNumCollisions() const
+{
+  return this->numCollisions;
+}
+
+
+IGNITION_ADD_PLUGIN(ScoringPlugin,
+                    ignition::gazebo::System,
+                    ScoringPlugin::ISystemConfigure,
+                    ScoringPlugin::ISystemPostUpdate)

--- a/vrx_ign/src/ScoringPlugin.cc
+++ b/vrx_ign/src/ScoringPlugin.cc
@@ -50,20 +50,7 @@ void ScoringPlugin::Configure(const ignition::gazebo::Entity &_entity,
   this->contactPub = 
         this->node.Advertise<ignition::msgs::Contact>(this->contactDebugTopic);
 
-  std::string worldName = "sydney_regatta"; //hard code for testing
-    
-  std::string collisionTopic =
-        std::string("/gazebosim/") + worldName + std::string("/physics/contacts");
-  if (!gzNode->Subscribe(collisionTopic, &ScoringPlugin::OnCollisionMsg, this))
-    {
-      std::cerr << "Error subscribing to [" << collisionTopic << "]" 
-            << std::endl;
-      ignerr << "Error subscribing to [" << collisionTopic << "]" << std::endl;
-    }
 
-  this->serverControlPub = std::make_unique<ignition::transport::Node::Publisher>
-        (gzNode->Advertise<ignition::msgs::ServerControl>
-        ("/gazebosim/server/control")); */
 }
 
 //////////////////////////////////////////////////

--- a/vrx_ign/src/ScoringPlugin.cc
+++ b/vrx_ign/src/ScoringPlugin.cc
@@ -20,11 +20,13 @@ void ScoringPlugin::Configure(const ignition::gazebo::Entity &_entity,
                            ignition::gazebo::EventManager &_eventMgr)
 {
 
-    this->creator = std::make_unique<ignition::gazebo::SdfEntityCreator>(_ecm, _eventMgr);
-    this->worldEntity = _ecm.EntityByComponents(ignition::gazebo::components::World());
+    this->creator = 
+        std::make_unique<ignition::gazebo::SdfEntityCreator>(_ecm, _eventMgr);
+    this->worldEntity = 
+        _ecm.EntityByComponents(ignition::gazebo::components::World());
     this->eventManager = &_eventMgr;
     this->sdf = _sdf;
-    //this->forceReturn = true; // Turns off update function!  Remove before use.
+    //this->forceReturn = true; // Turns off update function! Remove before use.
     // SDF.
     if (!this->ParseSDFParameters())
     {
@@ -34,27 +36,32 @@ void ScoringPlugin::Configure(const ignition::gazebo::Entity &_entity,
     }
 
     this->readyTime = std::chrono::duration<double>(this->initialStateDuration);
-    this->runningTime = this->readyTime +  std::chrono::duration<double>(this->readyStateDuration);
-    this->finishTime = this->runningTime + std::chrono::duration<double>(this->runningStateDuration);
+    this->runningTime = this->readyTime +  
+        std::chrono::duration<double>(this->readyStateDuration);
+    this->finishTime = this->runningTime + 
+        std::chrono::duration<double>(this->runningStateDuration);
 
     // Prepopulate the task msg.
 
-    taskMessage.set_data(this->taskState);
+  taskMessage.set_data(this->taskState);
 
-    this->taskPub = this->node.Advertise<ignition::msgs::StringMsg>(this->taskInfoTopic);
-    this->contactPub = this->node.Advertise<ignition::msgs::Contact>(this->contactDebugTopic);
+  this->taskPub = 
+        this->node.Advertise<ignition::msgs::StringMsg>(this->taskInfoTopic);
+  this->contactPub = 
+        this->node.Advertise<ignition::msgs::Contact>(this->contactDebugTopic);
 
-    std::string worldName = "sydney_regatta"; //hard code for testing
+  std::string worldName = "sydney_regatta"; //hard code for testing
     
-    std::string collisionTopic =
+  std::string collisionTopic =
         std::string("/gazebosim/") + worldName + std::string("/physics/contacts");
-             if (!gzNode->Subscribe(collisionTopic, &ScoringPlugin::OnCollisionMsg, this))
+  if (!gzNode->Subscribe(collisionTopic, &ScoringPlugin::OnCollisionMsg, this))
     {
-        std::cerr << "Error subscribing to [" << collisionTopic << "]" << std::endl;
-        ignerr << "Error subscribing to [" << collisionTopic << "]" << std::endl;
+      std::cerr << "Error subscribing to [" << collisionTopic << "]" 
+            << std::endl;
+      ignerr << "Error subscribing to [" << collisionTopic << "]" << std::endl;
     }
 
-    this->serverControlPub = std::make_unique<ignition::transport::Node::Publisher>
+  this->serverControlPub = std::make_unique<ignition::transport::Node::Publisher>
         (gzNode->Advertise<ignition::msgs::ServerControl>
         ("/gazebosim/server/control")); */
 }
@@ -171,7 +178,8 @@ void ScoringPlugin::PublishStats()
   this->UpdateTaskMessage();
 
   // We publish stats at 1Hz.
-  if (this->currentTime - this->lastStatsSent >= std::chrono::duration<double>(1.0))
+  if (this->currentTime - this->lastStatsSent >= 
+      std::chrono::duration<double>(1.0))
   {
     this->taskPub.Publish(this->taskMessage);
     this->lastStatsSent = this->currentTime;

--- a/vrx_ign/src/ScoringPlugin.cc
+++ b/vrx_ign/src/ScoringPlugin.cc
@@ -7,6 +7,8 @@
 #include <ignition/gazebo/SdfEntityCreator.hh>
 #include "ScoringPlugin.hh"
 
+using namespace vrx;
+
 void cb(const ignition::msgs::Contacts &_contacts){return;}
 
 ScoringPlugin::ScoringPlugin()
@@ -14,6 +16,7 @@ ScoringPlugin::ScoringPlugin()
 {
 }
 
+//////////////////////////////////////////////////
 void ScoringPlugin::Configure(const ignition::gazebo::Entity &_entity,
                            const std::shared_ptr<const sdf::Element> &_sdf,
                            ignition::gazebo::EntityComponentManager &_ecm,
@@ -350,6 +353,7 @@ bool ScoringPlugin::ParseJoints()
   return true;
 }
 
+//////////////////////////////////////////////////
 void ScoringPlugin::Exit()
 {
   bool exit = this->perPluginExitOnCompletion;
@@ -377,28 +381,32 @@ void ScoringPlugin::Exit()
   return;
 }
 
+//////////////////////////////////////////////////
 void ScoringPlugin::SetTimeoutScore(double _timeoutScore)
 {
   this->timeoutScore = _timeoutScore;
 }
 
+//////////////////////////////////////////////////
 double ScoringPlugin::GetTimeoutScore() const
 {
   return this->timeoutScore;
 }
 
+//////////////////////////////////////////////////
 double ScoringPlugin::GetRunningStateDuration() const
 {
   return this->runningStateDuration;
 }
 
+//////////////////////////////////////////////////
 unsigned int ScoringPlugin::GetNumCollisions() const
 {
   return this->numCollisions;
 }
 
 
-IGNITION_ADD_PLUGIN(ScoringPlugin,
+IGNITION_ADD_PLUGIN(vrx::ScoringPlugin,
                     ignition::gazebo::System,
-                    ScoringPlugin::ISystemConfigure,
-                    ScoringPlugin::ISystemPostUpdate)
+                    vrx::ScoringPlugin::ISystemConfigure,
+                    vrx::ScoringPlugin::ISystemPostUpdate)

--- a/vrx_ign/src/ScoringPlugin.hh
+++ b/vrx_ign/src/ScoringPlugin.hh
@@ -1,0 +1,299 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef VRX_GAZEBO_SCORING_PLUGIN_HH_
+#define VRX_GAZEBO_SCORING_PLUGIN_HH_
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <ignition/gazebo/System.hh>
+#include <ignition/common.hh>
+#include <ignition/transport.hh>
+#include <ignition/msgs.hh>
+#include <ignition/physics.hh>
+#include <ignition/math/SphericalCoordinates.hh>
+#include <ignition/gazebo/components/SphericalCoordinates.hh>
+#include <ignition/gazebo/components/Name.hh>
+#include <ignition/gazebo/World.hh>
+#include <sdf/sdf.hh>
+#include <ignition/msgs/any.pb.h>
+#include <ignition/msgs/param.pb.h>
+#include <ignition/msgs/param_v.pb.h>
+#include <ignition/msgs/stringmsg.pb.h>
+#include "ignition/gazebo/Util.hh"
+#include <ignition/transport/Node.hh>
+
+
+class ScoringPlugin 
+        : public ignition::gazebo::System,
+          public ignition::gazebo::ISystemConfigure,
+          public ignition::gazebo::ISystemPostUpdate 
+    {
+        /// \brief Class constructor
+        public: ScoringPlugin();
+
+        /// \brief Shutdown Gazebo and ROS
+        public: void Exit();
+
+        // Documentation inherited
+        public: void Configure(const ignition::gazebo::Entity &_entity,
+                           const std::shared_ptr<const sdf::Element> &_sdf,
+                           ignition::gazebo::EntityComponentManager &_ecm,
+                           ignition::gazebo::EventManager &_eventMgr) override;
+
+        /// \brief Get the current score.
+        /// \return The current score.
+        protected: double Score() const;
+
+        /// \brief Set the score.
+        /// \param[in] _newScore The new score.
+        protected: void SetScore(double _newScore);
+
+        /// \brief Get the task name.
+        /// \return Task name.
+        protected: std::string TaskName() const;
+
+        /// \brief Get the task state.
+        /// \return Task state.
+        protected: std::string TaskState() const;
+
+        /// \brief Elapsed time in the running state.
+        /// \return The elapsed time in the running state.
+        protected: std::chrono::duration<double> ElapsedTime() const;
+
+        /// \brief Remaining time in the running state.
+        /// \return The remaining time in the running state.
+        protected: std::chrono::duration<double> RemainingTime() const;
+
+        /// \brief Finish the current task.
+        /// This will set the "finished" flag in the task message to true.
+        protected: void Finish();
+
+        /// \brief Tries to release the vehicle in case is locked.
+        protected: virtual void ReleaseVehicle();
+
+        /// \brief Set the score in case of timeout
+        protected: void SetTimeoutScore(double _timeoutScore);
+
+        /// \brief Get the timeoutScore
+        protected: double GetTimeoutScore() const;
+
+        /// \brief Get running duration
+        protected: double GetRunningStateDuration() const;
+
+        /// \brief Get the number of WAM-V collisions.
+        protected: unsigned int GetNumCollisions() const;
+
+        /// \brief Callback executed at every world update.
+        public: void PostUpdate(
+                    const ignition::gazebo::UpdateInfo &_info,
+                    const ignition::gazebo::EntityComponentManager &_ecm) override;
+
+        /// \brief Update all time-related variables.
+        std::chrono::duration<double> simTime;
+        private: void UpdateTime(const std::chrono::duration<double> _simTime);
+
+        /// \brief Update the state of the current task.
+        private: void UpdateTaskState();
+
+        /// \brief Update the task stats message.
+        private: void UpdateTaskMessage();
+
+        /// \brief Publish the task stats over a ROS topic.
+        private: void PublishStats();
+
+        /// \brief Callback executed when the task state transition into "ready".
+        private: virtual void OnReady();
+
+        /// \brief Callback executed when the task state transition into "running".
+        private: virtual void OnRunning();
+
+        /// \brief Callback executed when the task state transition into "finished".
+        protected: virtual void OnFinished();
+
+        /// \brief Callback executed when a collision is detected for the WAMV.
+        private: virtual void OnCollision();
+
+        /// \brief Callback function when collision occurs in the world.
+        /// \param[in] _contacts List of all collisions from last simulation iteration
+        private: void OnCollisionMsg(const ignition::msgs::Contacts &_contacts);
+
+        /// \brief Parse all SDF parameters.
+        /// \return True when all parameters were successfully parsed or false
+        /// otherwise.
+        private: bool ParseSDFParameters();
+
+        /// \brief Parse the joints section of the SDF block.
+        /// \return True when all parameters were successfully parsed or false
+        /// otherwise.
+        private: bool ParseJoints();
+
+        /// \brief A world pointer.
+        //TODO: How to define world ptr?
+        // protected: std::shared_ptr<World::World> world;
+        //protected: World world;
+
+          /// \brief Creator interface 
+        protected: std::unique_ptr<ignition::gazebo::SdfEntityCreator> creator{nullptr};
+
+        /// \brief World entity
+        protected: ignition::gazebo::Entity worldEntity{ignition::gazebo::kNullEntity};
+
+        /// \brief Event manager for pausing simulation 
+        public: ignition::gazebo::EventManager *eventManager{nullptr};
+
+        /// \brief The name of the task.
+        protected: std::string taskName = "undefined";
+
+        /// \brief The name of the vehicle to score.
+        protected: std::string vehicleName;
+
+        /// \brief Pointer to the vehicle to score.
+        //TODO: How to define model ptr?
+        // protected: ignition::physics::Model3dPtr vehicleModel;
+        protected: std::unique_ptr<ignition::gazebo::Entity> vehicleModel;
+
+        /// \brief Last collision time.
+        protected: std::chrono::duration<double> lastCollisionTime;
+
+        /// \brief Silent mode enabled?
+        protected: bool silent = false;
+
+        /// \brief Spherical coordinates conversions.
+        protected: ignition::math::SphericalCoordinates sc;
+
+        /// \brief Ignition Transport node.
+        public: ignition::transport::Node node;
+
+        /// \brief Collision detection node subscriber
+        // TODO - Verify if ignition requires a subscriber object
+        
+        /// \brief gazebo server control publisher
+        std::unique_ptr<ignition::transport::Node::Publisher> serverControlPub;
+
+        /// \brief Topic where the task stats are published.
+        private: std::string taskInfoTopic = "/vrx/task/info";
+
+        /// \brief Bool flag for debug.
+        private: bool debug = true;
+
+        /// \brief Topic where debug collision is published.
+        private: std::string contactDebugTopic = "/vrx/debug/contact";
+
+        /// \brief The score.
+        private: double score = 0.0;
+
+        /// \brief Pointer to the SDF plugin element.
+        private: std::shared_ptr<const sdf::Element> sdf; 
+
+        /// \brief Duration (seconds) of the initial state.
+        private: double initialStateDuration = 30.0;
+
+        /// \brief Duration (seconds) of the ready state.
+        private: double readyStateDuration = 60.0;
+
+        /// \brief Duration (seconds) of the running state (max task time).
+        protected: double runningStateDuration = 300.0;
+
+        /// \brief Absolute time specifying the start of the ready state.
+        private: std::chrono::duration<double> readyTime;
+
+        /// \brief Absolute time specifying the start of the running state.
+        private: std::chrono::duration<double> runningTime;
+
+        /// \brief Absolute time specifying the start of the finish state.
+        private: std::chrono::duration<double> finishTime;
+
+        /// \brief Current time (simulation).
+        private: std::chrono::duration<double> currentTime;
+
+        // \brief Elapsed time since the start of the task (running state).
+        private: std::chrono::duration<double> elapsedTime;
+
+        /// \brief Remaining time since the start of the task (running state).
+        private: std::chrono::duration<double> remainingTime;
+
+        /// \brief Collision buffer.
+        private: float collisionBuffer = 3.0;
+
+        /// \brief Collisions counter.
+        private: int collisionCounter = 0;
+
+        /// \brief Collision list.
+        private: std::vector<std::string> collisionList;
+
+        /// \brief Collisions timestamps.
+        private: std::vector<std::chrono::duration<double> > collisionTimestamps;
+
+        /// \brief Whether the current task has timed out or not.
+        private: bool timedOut = false;
+
+        /// \brief Time at which the last message was sent.
+        private: std::chrono::duration<double> lastStatsSent;
+
+        /// \brief The task state.
+        private: std::string taskState = "initial";
+        
+        /// \brief The next task message to be published.
+        // ignition::msgs::Param_V taskMsg;
+        // ignition::msgs::Any taskMsgName, taskMsgState, 
+        //         taskMsgReadyTime, taskMsgRunningTime, taskMsgElapsedTime, taskMsgRemainingTime,
+        //         taskMsgTimedOut, taskMsgNumCollisions, taskMsgScore;
+        
+        // google::protobuf::Map< std::string, ignition::msgs::Any>* taskMsgParam;
+
+        /// \brief Simplified task message (pending protobuf investigation)
+        ignition::msgs::StringMsg taskMessage;
+
+        /// \brief ROS Contact Msg.
+        // private: vrx_ros::msg::Contact contactMsg; //Replaced with ignition messages
+        private: ignition::msgs::Contact contactMsg;
+
+        /// \brief The name of the joints to be dettached during ReleaseVehicle().
+        private: std::vector<std::string> lockJointNames;
+
+        /// \brief Publisher for the task state.
+        //Replaced with ignition messages
+       // protected: std::unique_ptr<ignition::transport::Node::Publisher> taskPub;
+       private: ignition::transport::Node::Publisher taskPub;
+        // protected: rclcpp::Publisher<vrx_ros::msg::Task>::SharedPtr taskPub;
+        // protected: ros::Publisher taskPub;
+
+        /// \brief Publisher for the collision.
+        //Replaced with ignition messages
+        //private: std::unique_ptr<ignition::transport::Node::Publisher> contactPub;
+        private: ignition::transport::Node::Publisher contactPub;
+        // private: rclcpp::Publisher<vrx_ros::msg::Contact>::SharedPtr contactPub;
+        // private: ros::Publisher contactPub;
+
+
+        /// \brief Score in case of timeout - added for Navigation task
+        private: double timeoutScore = -1;
+
+        /// \brief Whether to shut down after last gate is crossed.
+        private: bool perPluginExitOnCompletion = true;
+
+        /// \brief Number of WAM-V collisions.
+        private: unsigned int numCollisions = 0u;
+
+        // For testing
+        private: bool forceReturn = false;
+
+        };
+
+#endif

--- a/vrx_ign/src/ScoringPlugin.hh
+++ b/vrx_ign/src/ScoringPlugin.hh
@@ -101,8 +101,8 @@ class ScoringPlugin
 
         /// \brief Callback executed at every world update.
         public: void PostUpdate(
-                    const ignition::gazebo::UpdateInfo &_info,
-                    const ignition::gazebo::EntityComponentManager &_ecm) override;
+                const ignition::gazebo::UpdateInfo &_info,
+                const ignition::gazebo::EntityComponentManager &_ecm) override;
 
         /// \brief Update all time-related variables.
         std::chrono::duration<double> simTime;
@@ -117,20 +117,20 @@ class ScoringPlugin
         /// \brief Publish the task stats over a ROS topic.
         private: void PublishStats();
 
-        /// \brief Callback executed when the task state transition into "ready".
+        /// \brief Callback executed when the state transitions to "ready".
         private: virtual void OnReady();
 
-        /// \brief Callback executed when the task state transition into "running".
+        /// \brief Callback executed when the state transitions to "running".
         private: virtual void OnRunning();
 
-        /// \brief Callback executed when the task state transition into "finished".
+        /// \brief Callback executed when the state transitions to "finished".
         protected: virtual void OnFinished();
 
         /// \brief Callback executed when a collision is detected for the WAMV.
         private: virtual void OnCollision();
 
         /// \brief Callback function when collision occurs in the world.
-        /// \param[in] _contacts List of all collisions from last simulation iteration
+        /// \param[in] _contacts List of all collisions from last sim iteration
         private: void OnCollisionMsg(const ignition::msgs::Contacts &_contacts);
 
         /// \brief Parse all SDF parameters.
@@ -149,10 +149,12 @@ class ScoringPlugin
         //protected: World world;
 
           /// \brief Creator interface 
-        protected: std::unique_ptr<ignition::gazebo::SdfEntityCreator> creator{nullptr};
+        protected: 
+          std::unique_ptr<ignition::gazebo::SdfEntityCreator> creator{nullptr};
 
         /// \brief World entity
-        protected: ignition::gazebo::Entity worldEntity{ignition::gazebo::kNullEntity};
+        protected: 
+          ignition::gazebo::Entity worldEntity{ignition::gazebo::kNullEntity};
 
         /// \brief Event manager for pausing simulation 
         public: ignition::gazebo::EventManager *eventManager{nullptr};
@@ -238,7 +240,7 @@ class ScoringPlugin
         private: std::vector<std::string> collisionList;
 
         /// \brief Collisions timestamps.
-        private: std::vector<std::chrono::duration<double> > collisionTimestamps;
+        private: std::vector<std::chrono::duration<double>> collisionTimestamps;
 
         /// \brief Whether the current task has timed out or not.
         private: bool timedOut = false;
@@ -249,38 +251,21 @@ class ScoringPlugin
         /// \brief The task state.
         private: std::string taskState = "initial";
         
-        /// \brief The next task message to be published.
-        // ignition::msgs::Param_V taskMsg;
-        // ignition::msgs::Any taskMsgName, taskMsgState, 
-        //         taskMsgReadyTime, taskMsgRunningTime, taskMsgElapsedTime, taskMsgRemainingTime,
-        //         taskMsgTimedOut, taskMsgNumCollisions, taskMsgScore;
-        
-        // google::protobuf::Map< std::string, ignition::msgs::Any>* taskMsgParam;
-
         /// \brief Simplified task message (pending protobuf investigation)
         ignition::msgs::StringMsg taskMessage;
 
-        /// \brief ROS Contact Msg.
-        // private: vrx_ros::msg::Contact contactMsg; //Replaced with ignition messages
+        /// \brief Ignition Contact Msg.
+
         private: ignition::msgs::Contact contactMsg;
 
-        /// \brief The name of the joints to be dettached during ReleaseVehicle().
+        /// \brief The name of the joints to detach during ReleaseVehicle().
         private: std::vector<std::string> lockJointNames;
 
         /// \brief Publisher for the task state.
-        //Replaced with ignition messages
-       // protected: std::unique_ptr<ignition::transport::Node::Publisher> taskPub;
-       private: ignition::transport::Node::Publisher taskPub;
-        // protected: rclcpp::Publisher<vrx_ros::msg::Task>::SharedPtr taskPub;
-        // protected: ros::Publisher taskPub;
+        private: ignition::transport::Node::Publisher taskPub;
 
         /// \brief Publisher for the collision.
-        //Replaced with ignition messages
-        //private: std::unique_ptr<ignition::transport::Node::Publisher> contactPub;
         private: ignition::transport::Node::Publisher contactPub;
-        // private: rclcpp::Publisher<vrx_ros::msg::Contact>::SharedPtr contactPub;
-        // private: ros::Publisher contactPub;
-
 
         /// \brief Score in case of timeout - added for Navigation task
         private: double timeoutScore = -1;

--- a/vrx_ign/src/ScoringPlugin.hh
+++ b/vrx_ign/src/ScoringPlugin.hh
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
+ */
 
 #ifndef VRX_GAZEBO_SCORING_PLUGIN_HH_
 #define VRX_GAZEBO_SCORING_PLUGIN_HH_
@@ -37,249 +37,310 @@
 #include <ignition/msgs/stringmsg.pb.h>
 #include "ignition/gazebo/Util.hh"
 #include <ignition/transport/Node.hh>
-
+#include <ignition/gazebo/SdfEntityCreator.hh>
 namespace vrx
 {
-class ScoringPlugin 
-        : public ignition::gazebo::System,
-          public ignition::gazebo::ISystemConfigure,
-          public ignition::gazebo::ISystemPostUpdate 
-    {
-        /// \brief Class constructor
-        public: ScoringPlugin();
-
-        /// \brief Shutdown Gazebo and ROS
-        public: void Exit();
-
-        // Documentation inherited
-        public: void Configure(const ignition::gazebo::Entity &_entity,
-                           const std::shared_ptr<const sdf::Element> &_sdf,
-                           ignition::gazebo::EntityComponentManager &_ecm,
-                           ignition::gazebo::EventManager &_eventMgr) override;
-
-        /// \brief Get the current score.
-        /// \return The current score.
-        protected: double Score() const;
-
-        /// \brief Set the score.
-        /// \param[in] _newScore The new score.
-        protected: void SetScore(double _newScore);
-
-        /// \brief Get the task name.
-        /// \return Task name.
-        protected: std::string TaskName() const;
-
-        /// \brief Get the task state.
-        /// \return Task state.
-        protected: std::string TaskState() const;
-
-        /// \brief Elapsed time in the running state.
-        /// \return The elapsed time in the running state.
-        protected: std::chrono::duration<double> ElapsedTime() const;
-
-        /// \brief Remaining time in the running state.
-        /// \return The remaining time in the running state.
-        protected: std::chrono::duration<double> RemainingTime() const;
-
-        /// \brief Finish the current task.
-        /// This will set the "finished" flag in the task message to true.
-        protected: void Finish();
-
-        /// \brief Tries to release the vehicle in case is locked.
-        protected: virtual void ReleaseVehicle();
-
-        /// \brief Set the score in case of timeout
-        protected: void SetTimeoutScore(double _timeoutScore);
-
-        /// \brief Get the timeoutScore
-        protected: double GetTimeoutScore() const;
-
-        /// \brief Get running duration
-        protected: double GetRunningStateDuration() const;
-
-        /// \brief Get the number of WAM-V collisions.
-        protected: unsigned int GetNumCollisions() const;
-
-        /// \brief Callback executed at every world update.
-        public: void PostUpdate(
-                const ignition::gazebo::UpdateInfo &_info,
-                const ignition::gazebo::EntityComponentManager &_ecm) override;
-
-        /// \brief Update all time-related variables.
-        std::chrono::duration<double> simTime;
-        private: void UpdateTime(const std::chrono::duration<double> _simTime);
-
-        /// \brief Update the state of the current task.
-        private: void UpdateTaskState();
-
-        /// \brief Update the task stats message.
-        private: void UpdateTaskMessage();
-
-        /// \brief Publish the task stats over a ROS topic.
-        private: void PublishStats();
-
-        /// \brief Callback executed when the state transitions to "ready".
-        private: virtual void OnReady();
-
-        /// \brief Callback executed when the state transitions to "running".
-        private: virtual void OnRunning();
-
-        /// \brief Callback executed when the state transitions to "finished".
-        protected: virtual void OnFinished();
-
-        /// \brief Callback executed when a collision is detected for the WAMV.
-        private: virtual void OnCollision();
-
-        /// \brief Callback function when collision occurs in the world.
-        /// \param[in] _contacts List of all collisions from last sim iteration
-        private: void OnCollisionMsg(const ignition::msgs::Contacts &_contacts);
-
-        /// \brief Parse all SDF parameters.
-        /// \return True when all parameters were successfully parsed or false
-        /// otherwise.
-        private: bool ParseSDFParameters();
-
-        /// \brief Parse the joints section of the SDF block.
-        /// \return True when all parameters were successfully parsed or false
-        /// otherwise.
-        private: bool ParseJoints();
-
-        /// \brief A world pointer.
-        //TODO: How to define world ptr?
-        // protected: std::shared_ptr<World::World> world;
-        //protected: World world;
-
-          /// \brief Creator interface 
-        protected: 
-          std::unique_ptr<ignition::gazebo::SdfEntityCreator> creator{nullptr};
-
-        /// \brief World entity
-        protected: 
-          ignition::gazebo::Entity worldEntity{ignition::gazebo::kNullEntity};
-
-        /// \brief Event manager for pausing simulation 
-        public: ignition::gazebo::EventManager *eventManager{nullptr};
-
-        /// \brief The name of the task.
-        protected: std::string taskName = "undefined";
-
-        /// \brief The name of the vehicle to score.
-        protected: std::string vehicleName;
-
-        /// \brief Pointer to the vehicle to score.
-        //TODO: How to define model ptr?
-        // protected: ignition::physics::Model3dPtr vehicleModel;
-        protected: std::unique_ptr<ignition::gazebo::Entity> vehicleModel;
-
-        /// \brief Last collision time.
-        protected: std::chrono::duration<double> lastCollisionTime;
-
-        /// \brief Silent mode enabled?
-        protected: bool silent = false;
-
-        /// \brief Spherical coordinates conversions.
-        protected: ignition::math::SphericalCoordinates sc;
-
-        /// \brief Ignition Transport node.
-        public: ignition::transport::Node node;
-
-        /// \brief Collision detection node subscriber
-        // TODO - Verify if ignition requires a subscriber object
-        
-        /// \brief gazebo server control publisher
-        std::unique_ptr<ignition::transport::Node::Publisher> serverControlPub;
-
-        /// \brief Topic where the task stats are published.
-        private: std::string taskInfoTopic = "/vrx/task/info";
-
-        /// \brief Bool flag for debug.
-        private: bool debug = true;
-
-        /// \brief Topic where debug collision is published.
-        private: std::string contactDebugTopic = "/vrx/debug/contact";
-
-        /// \brief The score.
-        private: double score = 0.0;
-
-        /// \brief Pointer to the SDF plugin element.
-        private: std::shared_ptr<const sdf::Element> sdf; 
-
-        /// \brief Duration (seconds) of the initial state.
-        private: double initialStateDuration = 30.0;
-
-        /// \brief Duration (seconds) of the ready state.
-        private: double readyStateDuration = 60.0;
-
-        /// \brief Duration (seconds) of the running state (max task time).
-        protected: double runningStateDuration = 300.0;
-
-        /// \brief Absolute time specifying the start of the ready state.
-        private: std::chrono::duration<double> readyTime;
-
-        /// \brief Absolute time specifying the start of the running state.
-        private: std::chrono::duration<double> runningTime;
-
-        /// \brief Absolute time specifying the start of the finish state.
-        private: std::chrono::duration<double> finishTime;
-
-        /// \brief Current time (simulation).
-        private: std::chrono::duration<double> currentTime;
-
-        // \brief Elapsed time since the start of the task (running state).
-        private: std::chrono::duration<double> elapsedTime;
-
-        /// \brief Remaining time since the start of the task (running state).
-        private: std::chrono::duration<double> remainingTime;
-
-        /// \brief Collision buffer.
-        private: float collisionBuffer = 3.0;
-
-        /// \brief Collisions counter.
-        private: int collisionCounter = 0;
-
-        /// \brief Collision list.
-        private: std::vector<std::string> collisionList;
-
-        /// \brief Collisions timestamps.
-        private: std::vector<std::chrono::duration<double>> collisionTimestamps;
-
-        /// \brief Whether the current task has timed out or not.
-        private: bool timedOut = false;
-
-        /// \brief Time at which the last message was sent.
-        private: std::chrono::duration<double> lastStatsSent;
-
-        /// \brief The task state.
-        private: std::string taskState = "initial";
-        
-        /// \brief Simplified task message (pending protobuf investigation)
-        ignition::msgs::StringMsg taskMessage;
-
-        /// \brief Ignition Contact Msg.
-
-        private: ignition::msgs::Contact contactMsg;
-
-        /// \brief The name of the joints to detach during ReleaseVehicle().
-        private: std::vector<std::string> lockJointNames;
-
-        /// \brief Publisher for the task state.
-        private: ignition::transport::Node::Publisher taskPub;
-
-        /// \brief Publisher for the collision.
-        private: ignition::transport::Node::Publisher contactPub;
-
-        /// \brief Score in case of timeout - added for Navigation task
-        private: double timeoutScore = -1;
-
-        /// \brief Whether to shut down after last gate is crossed.
-        private: bool perPluginExitOnCompletion = true;
-
-        /// \brief Number of WAM-V collisions.
-        private: unsigned int numCollisions = 0u;
-
-        // For testing
-        private: bool forceReturn = false;
-
-        };
+  class ScoringPlugin
+      : public ignition::gazebo::System,
+        public ignition::gazebo::ISystemConfigure,
+        public ignition::gazebo::ISystemPostUpdate
+  {
+    /// \brief Class constructor
+  public:
+    ScoringPlugin();
+
+    /// \brief Shutdown Gazebo and ROS
+  public:
+    void Exit();
+
+    // Documentation inherited
+  public:
+    void Configure(const ignition::gazebo::Entity &_entity,
+                   const std::shared_ptr<const sdf::Element> &_sdf,
+                   ignition::gazebo::EntityComponentManager &_ecm,
+                   ignition::gazebo::EventManager &_eventMgr) override;
+
+    /// \brief Get the current score.
+    /// \return The current score.
+  protected:
+    double Score() const;
+
+    /// \brief Set the score.
+    /// \param[in] _newScore The new score.
+  protected:
+    void SetScore(double _newScore);
+
+    /// \brief Get the task name.
+    /// \return Task name.
+  protected:
+    std::string TaskName() const;
+
+    /// \brief Get the task state.
+    /// \return Task state.
+  protected:
+    std::string TaskState() const;
+
+    /// \brief Elapsed time in the running state.
+    /// \return The elapsed time in the running state.
+  protected:
+    std::chrono::duration<double> ElapsedTime() const;
+
+    /// \brief Remaining time in the running state.
+    /// \return The remaining time in the running state.
+  protected:
+    std::chrono::duration<double> RemainingTime() const;
+
+    /// \brief Finish the current task.
+    /// This will set the "finished" flag in the task message to true.
+  protected:
+    void Finish();
+
+    /// \brief Tries to release the vehicle in case is locked.
+    // protected: virtual void ReleaseVehicle();
+  protected:
+    void ReleaseVehicle();
+    /// \brief Set the score in case of timeout
+  protected:
+    void SetTimeoutScore(double _timeoutScore);
+
+    /// \brief Get the timeoutScore
+  protected:
+    double GetTimeoutScore() const;
+
+    /// \brief Get running duration
+  protected:
+    double GetRunningStateDuration() const;
+
+    /// \brief Get the number of WAM-V collisions.
+  protected:
+    unsigned int GetNumCollisions() const;
+
+    /// \brief Callback executed at every world update.
+  public:
+    void PostUpdate(
+        const ignition::gazebo::UpdateInfo &_info,
+        const ignition::gazebo::EntityComponentManager &_ecm) override;
+
+    /// \brief Update all time-related variables.
+    std::chrono::duration<double> simTime;
+
+  private:
+    void UpdateTime(const std::chrono::duration<double> _simTime);
+
+    /// \brief Update the state of the current task.
+  private:
+    void UpdateTaskState();
+
+    /// \brief Update the task stats message.
+  private:
+    void UpdateTaskMessage();
+
+    /// \brief Publish the task stats over a ROS topic.
+  private:
+    void PublishStats();
+
+    /// \brief Callback executed when the state transitions to "ready".
+  private:
+    virtual void OnReady();
+
+    /// \brief Callback executed when the state transitions to "running".
+  private:
+    virtual void OnRunning();
+
+    /// \brief Callback executed when the state transitions to "finished".
+  protected:
+    virtual void OnFinished();
+
+    /// \brief Callback executed when a collision is detected for the WAMV.
+  private:
+    void OnCollision();
+
+    /// \brief Callback function when collision occurs in the world.
+    /// \param[in] _contacts List of all collisions from last sim iteration
+  private:
+    void OnCollisionMsg(const ignition::msgs::Contacts &_contacts);
+
+    /// \brief Parse all SDF parameters.
+    /// \return True when all parameters were successfully parsed or false
+    /// otherwise.
+  private:
+    bool ParseSDFParameters();
+
+    /// \brief Parse the joints section of the SDF block.
+    /// \return True when all parameters were successfully parsed or false
+    /// otherwise.
+  private:
+    bool ParseJoints();
+
+    /// \brief A world pointer.
+    // TODO: How to define world ptr?
+    //  protected: std::shared_ptr<World::World> world;
+    // protected: World world;
+
+    /// \brief Creator interface
+  protected:
+    std::unique_ptr<ignition::gazebo::SdfEntityCreator> creator{nullptr};
+
+    /// \brief World entity
+  protected:
+    ignition::gazebo::Entity worldEntity{ignition::gazebo::kNullEntity};
+
+    /// \brief Event manager for pausing simulation
+  public:
+    ignition::gazebo::EventManager *eventManager{nullptr};
+
+    /// \brief The name of the task.
+  protected:
+    std::string taskName = "undefined";
+
+    /// \brief The name of the vehicle to score.
+  protected:
+    std::string vehicleName;
+
+    /// \brief Pointer to the vehicle to score.
+    // TODO: How to define model ptr?
+    //  protected: ignition::physics::Model3dPtr vehicleModel;
+  protected:
+    std::unique_ptr<ignition::gazebo::Entity> vehicleModel;
+
+    /// \brief Last collision time.
+  protected:
+    std::chrono::duration<double> lastCollisionTime;
+
+    /// \brief Silent mode enabled?
+  protected:
+    bool silent = false;
+
+    /// \brief Spherical coordinates conversions.
+    // protected: std::optional<ignition::math::SphericalCoordinates> sc;
+  protected:
+    ignition::math::SphericalCoordinates sc;
+
+    /// \brief Ignition Transport node.
+  public:
+    ignition::transport::Node node;
+
+    /// \brief Collision detection node subscriber
+    // TODO - Verify if ignition requires a subscriber object
+
+    /// \brief gazebo server control publisher
+    std::unique_ptr<ignition::transport::Node::Publisher> serverControlPub;
+
+    /// \brief Topic where the task stats are published.
+  private:
+    std::string taskInfoTopic = "/vrx/task/info";
+
+    /// \brief Bool flag for debug.
+  private:
+    bool debug = true;
+
+    /// \brief Topic where debug collision is published.
+  private:
+    std::string contactDebugTopic = "/vrx/debug/contact";
+
+    /// \brief The score.
+  private:
+    double score = 0.0;
+
+    /// \brief Pointer to the SDF plugin element.
+  private:
+    std::shared_ptr<const sdf::Element> sdf;
+
+    /// \brief Duration (seconds) of the initial state.
+  private:
+    double initialStateDuration = 30.0;
+
+    /// \brief Duration (seconds) of the ready state.
+  private:
+    double readyStateDuration = 60.0;
+
+    /// \brief Duration (seconds) of the running state (max task time).
+  protected:
+    double runningStateDuration = 300.0;
+
+    /// \brief Absolute time specifying the start of the ready state.
+  private:
+    std::chrono::duration<double> readyTime;
+
+    /// \brief Absolute time specifying the start of the running state.
+  private:
+    std::chrono::duration<double> runningTime;
+
+    /// \brief Absolute time specifying the start of the finish state.
+  private:
+    std::chrono::duration<double> finishTime;
+
+    /// \brief Current time (simulation).
+  private:
+    std::chrono::duration<double> currentTime;
+
+    // \brief Elapsed time since the start of the task (running state).
+  private:
+    std::chrono::duration<double> elapsedTime;
+
+    /// \brief Remaining time since the start of the task (running state).
+  private:
+    std::chrono::duration<double> remainingTime;
+
+    /// \brief Collision buffer.
+  private:
+    float collisionBuffer = 3.0;
+
+    /// \brief Collisions counter.
+  private:
+    int collisionCounter = 0;
+
+    /// \brief Collision list.
+  private:
+    std::vector<std::string> collisionList;
+
+    /// \brief Collisions timestamps.
+  private:
+    std::vector<std::chrono::duration<double>> collisionTimestamps;
+
+    /// \brief Whether the current task has timed out or not.
+  private:
+    bool timedOut = false;
+
+    /// \brief Time at which the last message was sent.
+  private:
+    std::chrono::duration<double> lastStatsSent;
+
+    /// \brief The task state.
+  private:
+    std::string taskState = "initial";
+
+    /// \brief Simplified task message (pending protobuf investigation)
+    ignition::msgs::StringMsg taskMessage;
+
+    /// \brief Ignition Contact Msg.
+
+  private:
+    ignition::msgs::Contact contactMsg;
+
+    /// \brief The name of the joints to detach during ReleaseVehicle().
+  private:
+    std::vector<std::string> lockJointNames;
+
+    /// \brief Publisher for the task state.
+  private:
+    ignition::transport::Node::Publisher taskPub;
+
+    /// \brief Publisher for the collision.
+  private:
+    ignition::transport::Node::Publisher contactPub;
+
+    /// \brief Score in case of timeout - added for Navigation task
+  private:
+    double timeoutScore = -1;
+
+    /// \brief Whether to shut down after last gate is crossed.
+  private:
+    bool perPluginExitOnCompletion = true;
+
+    /// \brief Number of WAM-V collisions.
+  private:
+    unsigned int numCollisions = 0u;
+  };
 }
 #endif

--- a/vrx_ign/src/ScoringPlugin.hh
+++ b/vrx_ign/src/ScoringPlugin.hh
@@ -38,7 +38,8 @@
 #include "ignition/gazebo/Util.hh"
 #include <ignition/transport/Node.hh>
 
-
+namespace vrx
+{
 class ScoringPlugin 
         : public ignition::gazebo::System,
           public ignition::gazebo::ISystemConfigure,
@@ -280,5 +281,5 @@ class ScoringPlugin
         private: bool forceReturn = false;
 
         };
-
+}
 #endif

--- a/vrx_ign/worlds/sydney_regatta.sdf
+++ b/vrx_ign/worlds/sydney_regatta.sdf
@@ -438,7 +438,7 @@
     </plugin>
     <plugin
       filename="libScoringPlugin.so"
-      name="ScoringPlugin">
+      name="vrx::ScoringPlugin">
       <vehicle>wamv</vehicle>
       <task_name>station_keeping</task_name>
     </plugin>

--- a/vrx_ign/worlds/sydney_regatta.sdf
+++ b/vrx_ign/worlds/sydney_regatta.sdf
@@ -436,6 +436,11 @@
         </noise>
       </vertical>
     </plugin>
-
+    <plugin
+      filename="libScoringPlugin.so"
+      name="ScoringPlugin">
+      <vehicle>wamv</vehicle>
+      <task_name>station_keeping</task_name>
+    </plugin>
   </world>
 </sdf>


### PR DESCRIPTION
This PR does not need to be merged - if you prefer, we can leave the branch as-is for reference.

This code implements a very basic version of the ScoringPlugin.  It loads the plugin, keeps track of the task time, and publishes changes in state (initial/ready/running/finished) to the /vrx/task/info topic.  Timing and some of messaging is stolen from Rishikesh's in-progress branch.  The goal is to provide some capability for testing new code segments in plugins that will derive from the base ScoringPlugin while full functionality is pending.

To test: start the simulation via `ros2 launch vrx_ros competition_local.launch.py ign_args:="-v 4 -r sydney_regatta.sdf"`
You should be able to see the ScoringPlugin listed under System Plugin info in the Component Inspector.
In a separate terminal window, echo the task topic via `ign topic --echo -t /vrx/task/info`
You should see the state message updating at 1Hz.  It will cycle through from initial to ready to running.  Finally, it will print "finished" once, and the simulation will exit.

Next steps: Ran into significant cmake problems trying to incorporate protobuf custom messages, and so the task message in this example is minimal.  Next major effort will be to resolve that issue.  