### PR TITLE
[Garden] Fix bridging Gz to ROS2 topics

### DIFF
--- a/vrx_gz/src/vrx_gz/bridges.py
+++ b/vrx_gz/src/vrx_gz/bridges.py
@@ -10,7 +10,7 @@ def imu(world_name, model_name, link_name='base_link'):
     return Bridge(
         gz_topic=f'{sensor_prefix}/imu_sensor/imu',
         ros_topic='imu/data',
-        gz_type='gz.msgs.IMU',
+        gz_type='ignition.msgs.IMU',
         ros_type='sensor_msgs/msg/Imu',
         direction=BridgeDirection.GZ_TO_ROS)
 
@@ -20,7 +20,7 @@ def magnetometer(world_name, model_name, link_name='base_link'):
     return Bridge(
         gz_topic=f'{sensor_prefix}/magnetometer/magnetometer',
         ros_topic='magnetic_field',
-        gz_type='gz.msgs.Magnetometer',
+        gz_type='ignition.msgs.Magnetometer',
         ros_type='sensor_msgs/msg/MagneticField',
         direction=BridgeDirection.GZ_TO_ROS)
 
@@ -30,7 +30,7 @@ def air_pressure(world_name, model_name, link_name='base_link'):
     return Bridge(
         gz_topic=f'{sensor_prefix}/air_pressure/air_pressure',
         ros_topic='air_pressure',
-        gz_type='gz.msgs.FluidPressure',
+        gz_type='ignition.msgs.FluidPressure',
         ros_type='sensor_msgs/msg/FluidPressure',
         direction=BridgeDirection.GZ_TO_ROS)
 
@@ -39,7 +39,7 @@ def pose(model_name):
     return Bridge(
         gz_topic=f'/model/{model_name}/pose',
         ros_topic='pose',
-        gz_type='gz.msgs.Pose_V',
+        gz_type='ignition.msgs.Pose_V',
         ros_type='tf2_msgs/msg/TFMessage',
         direction=BridgeDirection.GZ_TO_ROS)
 
@@ -48,7 +48,7 @@ def pose_static(model_name):
     return Bridge(
         gz_topic=f'/model/{model_name}/pose_static',
         ros_topic='pose_static',
-        gz_type='gz.msgs.Pose_V',
+        gz_type='ignition.msgs.Pose_V',
         ros_type='tf2_msgs/msg/TFMessage',
         direction=BridgeDirection.GZ_TO_ROS)
 
@@ -57,7 +57,7 @@ def cmd_vel(model_name):
     return Bridge(
         gz_topic=f'/model/{model_name}/cmd_vel',
         ros_topic='cmd_vel',
-        gz_type='gz.msgs.Twist',
+        gz_type='ignition.msgs.Twist',
         ros_type='geometry_msgs/msg/Twist',
         direction=BridgeDirection.ROS_TO_GZ)
 
@@ -65,7 +65,7 @@ def thrust(model_name, side):
     return Bridge(
         gz_topic=f'{model_name}/thrusters/{side}/thrust',
         ros_topic=f'thrusters/{side}/thrust',
-        gz_type='gz.msgs.Double',
+        gz_type='ignition.msgs.Double',
         ros_type='std_msgs/msg/Float64',
         direction=BridgeDirection.ROS_TO_GZ)
 
@@ -80,7 +80,7 @@ def thrust_joint_pos(model_name, side):
     return Bridge(
         gz_topic=f'{model_name}/thrusters/{side}/pos',
         ros_topic=f'thrusters/{side}/pos',
-        gz_type='gz.msgs.Double',
+        gz_type='ignition.msgs.Double',
         ros_type='std_msgs/msg/Float64',
         direction=BridgeDirection.ROS_TO_GZ)
 
@@ -88,7 +88,7 @@ def comms_tx(model_name):
     return Bridge(
         gz_topic='/broker/msgs',
         ros_topic='tx',
-        gz_type='gz.msgs.Dataframe',
+        gz_type='ignition.msgs.Dataframe',
         ros_type='ros_gz_interfaces/msg/Dataframe',
         direction=BridgeDirection.ROS_TO_GZ)
 
@@ -97,17 +97,8 @@ def comms_rx(model_name):
     return Bridge(
         gz_topic=f'/model/{model_name}/rx',
         ros_topic='rx',
-        gz_type='gz.msgs.Dataframe',
+        gz_type='ignition.msgs.Dataframe',
         ros_type='ros_gz_interfaces/msg/Dataframe',
-        direction=BridgeDirection.GZ_TO_ROS)
-
-
-def score():
-    return Bridge(
-        gz_topic='/vrx/score',
-        ros_topic='/vrx/score',
-        gz_type='gz.msgs.Float',
-        ros_type='std_msgs/msg/Float32',
         direction=BridgeDirection.GZ_TO_ROS)
 
 
@@ -115,24 +106,6 @@ def clock():
     return Bridge(
         gz_topic='/clock',
         ros_topic='/clock',
-        gz_type='gz.msgs.Clock',
+        gz_type='ignition.msgs.Clock',
         ros_type='rosgraph_msgs/msg/Clock',
-        direction=BridgeDirection.GZ_TO_ROS)
-
-
-def run_clock():
-    return Bridge(
-        gz_topic='/vrx/run_clock',
-        ros_topic='/vrx/run_clock',
-        gz_type='gz.msgs.Clock',
-        ros_type='rosgraph_msgs/msg/Clock',
-        direction=BridgeDirection.GZ_TO_ROS)
-
-
-def phase():
-    return Bridge(
-        gz_topic='/vrx/phase',
-        ros_topic='/vrx/phase',
-        gz_type='gz.msgs.StringMsg',
-        ros_type='std_msgs/msg/String',
         direction=BridgeDirection.GZ_TO_ROS)

--- a/vrx_gz/src/vrx_gz/launch.py
+++ b/vrx_gz/src/vrx_gz/launch.py
@@ -44,10 +44,7 @@ def simulation(world_name, headless=False):
 
 def competition_bridges():
     bridges = [
-        vrx_gz.bridges.score(),
         vrx_gz.bridges.clock(),
-        vrx_gz.bridges.run_clock(),
-        vrx_gz.bridges.phase(),
     ]
     nodes = []
     nodes.append(Node(

--- a/vrx_gz/src/vrx_gz/model.py
+++ b/vrx_gz/src/vrx_gz/model.py
@@ -64,15 +64,15 @@ class Model:
         nodes = []
         bridges = [
             # IMU
-            vrx_gz.bridges.imu(world_name, self.model_name),
+            # vrx_gz.bridges.imu(world_name, self.model_name),
             # pose
             vrx_gz.bridges.pose(self.model_name),
             # pose static
             vrx_gz.bridges.pose_static(self.model_name),
             # comms tx
-            vrx_gz.bridges.comms_tx(self.model_name),
+            # vrx_gz.bridges.comms_tx(self.model_name),
             # comms rx
-            vrx_gz.bridges.comms_rx(self.model_name),
+            # vrx_gz.bridges.comms_rx(self.model_name),
         ]
         if self.is_UAV():
             bridges.extend([

--- a/vrx_ros/launch/competition_local.launch.py
+++ b/vrx_ros/launch/competition_local.launch.py
@@ -65,10 +65,7 @@ def generate_launch_description():
     )
 
     bridges = [
-      vrx_gz.bridges.score(),
       vrx_gz.bridges.clock(),
-      vrx_gz.bridges.run_clock(),
-      vrx_gz.bridges.phase(),
     ]
 
     bridge_node = Node(


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@openrobotics.org>

Follow up to #519, this PR fixes the ROS2 topics for the wamv. The problem was that the [ros_ign_bridge](https://github.com/gazebosim/ros_gz/tree/humble/ros_gz_bridge) is still using the `ignition.msgs.*` msg types instead of `gz.msgs` (see msg type table `README.md`) , presumably to keep compability with Fortress. 

All ROS2 topics should be working except the thruster cmd topic. It requires this https://github.com/gazebosim/gz-sim/pull/1681 to be forward ported from Fortress to Garden

The thrusters joint pos topic should work. 
```
ros2 topic pub': ros2 topic pub --once wamv/thrusters/right/pos std_msgs/msg/Float64 'data: -1
```
I removed more topic bridges that are not needed / used:
* `/wamv/imu/data` - commented out as there is no imu sensor on the wamv yet
* `/wamv/rx` and `/wamv/tx` - commented out as RFComms is not being used yet
* `/vrx/score`, `/vrx/run_clock`, `/vrx/phase`: removed as these are also MBZIRC-specific. From looking at the vrx [technical guide](file:///home/ian/Desktop/VRX2022_Technical-Guide_v1.1.pdf), I think there is a `/vrx/task/info` topic with custom message type that captures these status data instead.