### PR TITLE
[Garden] Port Ball Shooter plugin

### DIFF
--- a/vrx_gz/CMakeLists.txt
+++ b/vrx_gz/CMakeLists.txt
@@ -96,6 +96,7 @@ install(
 
 # Plugins
 list(APPEND VRX_GZ_PLUGINS
+  BallShooterPlugin
   PerceptionScoringPlugin
   SimpleHydrodynamics
   StationkeepingScoringPlugin

--- a/vrx_gz/src/BallShooterPlugin.cc
+++ b/vrx_gz/src/BallShooterPlugin.cc
@@ -196,7 +196,10 @@ void BallShooterPlugin::Configure(const sim::Entity &_entity,
 
   // Parse <num_shots> if available.
   if (sdf->HasElement("num_shots"))
-    this->dataPtr->remainingShots = sdf->GetElement("num_shots")->Get<unsigned int>();
+  {
+    this->dataPtr->remainingShots =
+        sdf->GetElement("num_shots")->Get<unsigned int>();
+  }
 
   // Parse <shot_force> if available.
   if (sdf->HasElement("shot_force"))

--- a/vrx_gz/src/BallShooterPlugin.cc
+++ b/vrx_gz/src/BallShooterPlugin.cc
@@ -23,15 +23,14 @@
 
 #include <gz/sim/Link.hh>
 #include <gz/sim/Model.hh>
+#include <gz/sim/components/AngularVelocityCmd.hh>
+#include <gz/sim/components/LinearVelocityCmd.hh>
 #include <gz/sim/components/Link.hh>
 #include <gz/sim/components/Model.hh>
 #include <gz/sim/components/Name.hh>
 #include <gz/sim/components/ParentEntity.hh>
 #include <gz/sim/components/Pose.hh>
 #include <gz/sim/components/PoseCmd.hh>
-
-#include <gz/sim/components/AngularVelocityCmd.hh>
-#include <gz/sim/components/LinearVelocityCmd.hh>
 
 #include <gz/transport/Node.hh>
 

--- a/vrx_gz/src/BallShooterPlugin.cc
+++ b/vrx_gz/src/BallShooterPlugin.cc
@@ -1,0 +1,308 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <mutex>
+#include <string>
+
+#include <gz/math/Matrix4.hh>
+#include <gz/plugin/Register.hh>
+
+#include <gz/sim/Link.hh>
+#include <gz/sim/Model.hh>
+#include <gz/sim/components/Link.hh>
+#include <gz/sim/components/Model.hh>
+#include <gz/sim/components/Name.hh>
+#include <gz/sim/components/ParentEntity.hh>
+#include <gz/sim/components/Pose.hh>
+#include <gz/sim/components/PoseCmd.hh>
+
+#include <gz/sim/components/AngularVelocityCmd.hh>
+#include <gz/sim/components/LinearVelocityCmd.hh>
+
+#include <gz/transport/Node.hh>
+
+#include "BallShooterPlugin.hh"
+
+using namespace gz;
+using namespace vrx;
+
+/// \brief Private BallShooterPlugin data class.
+class BallShooterPlugin::Implementation
+{
+  /// \brief Callback function called when receiving a new fire message.
+  /// \param[in] _msg Unused.
+  public: void OnFire(const gz::msgs::Empty &_msg);
+
+  /// \brief Protect some member variables used in the callback.
+  public: std::mutex mutex;
+
+  /// \brief Gz transport node
+  public: gz::transport::Node node;
+
+  /// \brief Number of shots allowed.
+  public: unsigned int remainingShots = math::MAX_UI32;
+
+  /// \brief The force (N) to be applied to the projectile.
+  public: double shotForce = 250;
+
+  /// \brief Projectile model entity.
+  public: gz::sim::Model projectileModel;
+
+  /// \brief Projectile link entity.
+  public: gz::sim::Link projectileLink;
+
+  /// \brief Link/model entity that the projectile pose uses as its frame of
+  /// reference.
+  public: gz::sim::Entity frame;
+
+  /// \brief Pose in which the projectile should be placed before launching it.
+  public: gz::math::Pose3d pose = gz::math::Pose3d::Zero;
+
+  /// \brief Ready to shoot a ball when true.
+  public: bool shotReady = false;
+
+  /// \brief True to reset ball velocities
+  public: bool resetVel = false;
+};
+
+//////////////////////////////////////////////////
+BallShooterPlugin::BallShooterPlugin()
+  : System(), dataPtr(utils::MakeUniqueImpl<Implementation>())
+{
+}
+
+//////////////////////////////////////////////////
+void BallShooterPlugin::Configure(const sim::Entity &_entity,
+  const std::shared_ptr<const sdf::Element> &_sdf,
+  sim::EntityComponentManager &_ecm, sim::EventManager &_eventMgr)
+{
+  auto sdf = _sdf->Clone();
+
+  // Parse the required <projectile> element.
+  if (!sdf->HasElement("projectile"))
+  {
+    gzerr << "BallShooterPlugin: Missing <projectile> element" << std::endl;
+    return;
+  }
+
+  sdf::ElementPtr projectileElem = sdf->GetElement("projectile");
+
+  // Parse the required <projectile><model_name> used as projectile.
+  if (!projectileElem->HasElement("model_name"))
+  {
+    gzerr << "BallShooterPlugin: Missing <projectile><model_name> element\n";
+    return;
+  }
+
+  std::string projectileName =
+    projectileElem->GetElement("model_name")->Get<std::string>();
+
+  sim::Entity projectileModelEntity = _ecm.EntityByComponents(
+      sim::components::Model(), sim::components::Name(projectileName));
+
+  if (projectileModelEntity == sim::kNullEntity)
+  {
+    gzerr << "BallShooterPlugin: The model '" << projectileName
+          << "' does not exist" << std::endl;
+    return;
+  }
+  this->dataPtr->projectileModel = sim::Model(projectileModelEntity);
+
+  // Parse the required <projectile><link_name>
+  if (!projectileElem->HasElement("link_name"))
+  {
+    gzerr << "BallShooterPlugin: Missing <projectile><link_name> element\n";
+    return;
+  }
+
+  std::string projectileLinkName =
+    projectileElem->GetElement("link_name")->Get<std::string>();
+
+  sim::Entity projectileLinkEntity = _ecm.EntityByComponents(
+      sim::components::Link(), sim::components::Name(projectileLinkName),
+      sim::components::ParentEntity(this->dataPtr->projectileModel.Entity()));
+
+  if (projectileLinkEntity == sim::kNullEntity)
+  {
+    gzerr << "BallShooterPlugin: The link '" << projectileLinkName
+          << "' does not exist within '" << projectileName << "'" << std::endl;
+    return;
+  }
+  this->dataPtr->projectileLink = sim::Link(projectileLinkEntity);
+
+  // Parse <frame> if available.
+  std::string frameName;
+  if (projectileElem->HasElement("frame"))
+  {
+    frameName = projectileElem->Get<std::string>("frame");
+
+    this->dataPtr->frame = _ecm.EntityByComponents(
+        sim::components::Name(frameName));
+
+    if (this->dataPtr->frame == sim::kNullEntity)
+    {
+      gzerr << "The frame '" << frameName << "' does not exist" << std::endl;
+      frameName = "";
+    }
+    else
+    {
+      auto isModel = _ecm.Component<sim::components::Model>(
+          this->dataPtr->frame);
+      auto isLink = _ecm.Component<sim::components::Link>(this->dataPtr->frame);
+      if (isLink)
+      {
+        // create world pose comp to be populated by physics if it does not
+        // exist yet
+        auto worldPoseComp = _ecm.Component<sim::components::WorldPose>(
+            this->dataPtr->frame);
+        if (!worldPoseComp)
+        {
+          _ecm.CreateComponent(
+              this->dataPtr->frame,
+              sim::components::WorldPose());
+        }
+      }
+      else if (!isModel)
+      {
+        this->dataPtr->frame = sim::kNullEntity;
+        frameName = "";
+        gzerr << "<frame> tag must list the name of a link or model" << std::endl;
+      }
+    }
+  }
+
+  // Parse <pose> if available.
+  if (projectileElem->HasElement("pose"))
+    this->dataPtr->pose = projectileElem->Get<math::Pose3d>("pose");
+
+  // Parse <topic> if available.
+  std::string topic = "/ball_shooter/fire";
+  if (sdf->HasElement("topic"))
+    topic = sdf->GetElement("topic")->Get<std::string>();
+
+  // Parse <num_shots> if available.
+  if (sdf->HasElement("num_shots"))
+    this->dataPtr->remainingShots = sdf->GetElement("num_shots")->Get<unsigned int>();
+
+  // Parse <shot_force> if available.
+  if (sdf->HasElement("shot_force"))
+    this->dataPtr->shotForce = sdf->GetElement("shot_force")->Get<double>();
+
+  this->dataPtr->node.Subscribe(topic,
+    &BallShooterPlugin::Implementation::OnFire, this->dataPtr.get());
+
+  // Debug output.
+  gzdbg << "<projectile><model_name>: " << projectileName << std::endl;
+  gzdbg << "<projectile><link_name>: " << projectileLinkName << std::endl;
+  gzdbg << "<frame>: " << frameName << std::endl;
+  gzdbg << "<num_shots>: " << this->dataPtr->remainingShots << std::endl;
+  gzdbg << "<pose>: " << this->dataPtr->pose.Pos() << " "
+                       << this->dataPtr->pose.Rot().Euler() << std::endl;
+  gzdbg << "<shot_force>: " << this->dataPtr->shotForce << std::endl;
+  gzdbg << "<topic>: " << topic << std::endl;
+}
+
+//////////////////////////////////////////////////
+void BallShooterPlugin::PreUpdate(const sim::UpdateInfo &,
+    sim::EntityComponentManager &_ecm)
+
+{
+  std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+
+  if (!this->dataPtr->shotReady ||
+      this->dataPtr->projectileModel.Entity() == sim::kNullEntity ||
+      this->dataPtr->projectileLink.Entity() == sim::kNullEntity)
+    return;
+
+  // reset so the ball does not accumulate vel
+  // Do this for one physics iteration first. Then fire the shooter in the next
+  // iteration.
+  if (!this->dataPtr->resetVel)
+  {
+    this->dataPtr->projectileLink.SetLinearVelocity(_ecm, math::Vector3d::Zero);
+    this->dataPtr->projectileLink.SetAngularVelocity(_ecm, math::Vector3d::Zero);
+    this->dataPtr->resetVel = true;
+    return;
+  }
+  else
+  {
+    // make sure to remove the comp otherwise the physics system will keep
+    // setting zero vel to the link
+    _ecm.RemoveComponent<sim::components::AngularVelocityCmd>(
+        this->dataPtr->projectileLink.Entity());
+    _ecm.RemoveComponent<sim::components::LinearVelocityCmd>(
+        this->dataPtr->projectileLink.Entity());
+  }
+
+  // Set the new pose of the projectile based on the frame.
+  math::Pose3d projectilePose = this->dataPtr->pose;
+  if (this->dataPtr->frame != sim::kNullEntity)
+  {
+    // get frame entity's world pose
+    math::Pose3d framePose;
+    if (_ecm.Component<sim::components::Model>(this->dataPtr->frame))
+    {
+      framePose = _ecm.Component<sim::components::Pose>(
+          this->dataPtr->frame)->Data();
+    }
+    else if (_ecm.Component<sim::components::Link>(this->dataPtr->frame))
+    {
+      framePose = _ecm.Component<sim::components::WorldPose>(
+          this->dataPtr->frame)->Data();
+    }
+
+    math::Matrix4d transMat(framePose);
+    math::Matrix4d poseLocal(this->dataPtr->pose);
+    projectilePose = (transMat * poseLocal).Pose();
+  }
+
+  // Teleport the projectile to the ball shooter.
+  this->dataPtr->projectileModel.SetWorldPoseCmd(_ecm, projectilePose);
+
+  // Ignition!
+  const auto worldPose = this->dataPtr->projectileLink.WorldPose(_ecm);
+  auto force = worldPose->Rot().RotateVector(
+      math::Vector3d(this->dataPtr->shotForce, 0, 0));
+  this->dataPtr->projectileLink.AddWorldForce(_ecm, force);
+
+  --this->dataPtr->remainingShots;
+  this->dataPtr->shotReady = false;
+  this->dataPtr->resetVel = false;
+}
+
+//////////////////////////////////////////////////
+void BallShooterPlugin::Implementation::OnFire(const gz::msgs::Empty &_msg)
+{
+  std::lock_guard<std::mutex> lock(this->mutex);
+
+  if (this->remainingShots <= 0)
+  {
+    gzdbg << "BallShooterPlugin: Maximum number of shots already reached. "
+          << "Request ignored" << std::endl;
+    return;
+  }
+
+  this->shotReady = true;
+}
+
+GZ_ADD_PLUGIN(BallShooterPlugin,
+              sim::System,
+              BallShooterPlugin::ISystemConfigure,
+              BallShooterPlugin::ISystemPreUpdate)
+
+GZ_ADD_PLUGIN_ALIAS(vrx::BallShooterPlugin,
+                    "vrx::BallShooterPlugin")

--- a/vrx_gz/src/BallShooterPlugin.hh
+++ b/vrx_gz/src/BallShooterPlugin.hh
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef VRX_BALL_SHOOTER_PLUGIN_HH_
+#define VRX_BALL_SHOOTER_PLUGIN_HH_
+
+#include <gz/msgs/empty.pb.h>
+
+#include <memory>
+#include <gz/sim/System.hh>
+#include <gz/utils/ImplPtr.hh>
+#include <sdf/sdf.hh>
+
+namespace vrx
+{
+/// \brief Simulate a ball shooter. A projectile is launched when a
+/// ROS message is received. The ball is reused (teleported) from previous
+/// shots.
+///
+/// The plugin accepts the following SDF parameters:
+/// * Required parameters:
+/// <projectile> The object used as projectile should be declared as a
+///              <projectile> element with the following parameters:
+///                 * <model_name> The name of the model used as projectile.
+///                                Required parameter.
+///                 * <link_name> The name of the link within the projectile
+///                               model where the force will be applied when
+///                               firing the shooter. Required parameter.
+///                 * <frame> If present, the <pose> parameter will be in the
+///                           frame of this link/model. Otherwise the world
+///                           frame is used. Optional parameter.
+///                 * <pose> - Pose of the projectile right before being shot.
+///                            Optional parameter. Default to {0 0 0 0 0 0}.
+///
+/// * Optional parameters:
+/// <num_shots> - Number of shots allowed. Default to UINT_MAX.
+/// <shot_force> - Force (N) applied to the projectile. Default to 250 N.
+/// <topic> - Name of the ROS topic to shoot. Default to "/ball_shooter/fire".
+///
+/// Here's an example:
+/// <plugin name="ball_shooter_plugin" filename="libball_shooter_plugin.so">
+///   <projectile>
+///     <model_name>a_projectile</model_name>
+///     <link_name>link</link_name>
+///     <frame>my_robot/ball_shooter_link</frame>
+///     <pose>0.2 0 0 0 0 0</pose>
+///   </projectile>
+///   <shot_force>250</shot_force>
+///   <topic>my_robot/ball_shooter/fire</topic>
+/// </plugin>
+class BallShooterPlugin
+    : public gz::sim::System,
+      public gz::sim::ISystemConfigure,
+      public gz::sim::ISystemPreUpdate
+{
+  // \brief Constructor.
+  public: BallShooterPlugin();
+
+  /// \brief Destructor.
+  public: ~BallShooterPlugin() override = default;
+
+  // Documentation inherited.
+  public: void Configure(const gz::sim::Entity &_entity,
+                         const std::shared_ptr<const sdf::Element> &_sdf,
+                         gz::sim::EntityComponentManager &_ecm,
+                         gz::sim::EventManager &_eventMgr) override;
+
+  // Documentation inherited.
+  public: void PreUpdate(const gz::sim::UpdateInfo &_info,
+                         gz::sim::EntityComponentManager &_ecm) override;
+
+  /// \brief Private data pointer.
+  GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
+};
+}
+#endif

--- a/vrx_gz/src/vrx_gz/payload_bridges.py
+++ b/vrx_gz/src/vrx_gz/payload_bridges.py
@@ -126,6 +126,14 @@ def odometry(model_name):
         ros_type='nav_msgs/msg/Odometry',
         direction=BridgeDirection.GZ_TO_ROS)
 
+def ball_shooter(model_name):
+    return Bridge(
+        gz_topic=f'/{model_name}/shooters/ball_shooter/fire',
+        ros_topic=f'shooters/ball_shooter/fire',
+        gz_type='ignition.msgs.Empty',
+        ros_type='std_msgs/msg/Empty',
+        direction=BridgeDirection.ROS_TO_GZ)
+
 
 def payload_bridges(world_name, model_name, link_name, sensor_name, sensor_type):
     bridges = []
@@ -162,4 +170,9 @@ def payload_bridges(world_name, model_name, link_name, sensor_name, sensor_type)
         bridges = [
             odometry(model_name),
         ]
+    elif 'BallShooter' in sensor_name:
+        bridges = [
+            ball_shooter(model_name),
+        ]
+
     return bridges

--- a/vrx_gz/worlds/perception_task.sdf
+++ b/vrx_gz/worlds/perception_task.sdf
@@ -400,11 +400,43 @@
     </include>
 
     <!-- The projectile for the ball shooter -->
-    <!-- <include>
+    <include>
       <name>blue_projectile</name>
       <pose>-545 60 0.03 0 0 0</pose>
       <uri>blue_projectile</uri>
-    </include> -->
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.02 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <size>1000 1000</size>
+          <cell_count>50 50></cell_count>
+          <wave>
+            <model>PMS</model>
+            <period>5.0</period>
+            <number>3</number>
+            <scale>1.1</scale>
+            <gain>0.3</gain>
+            <direction>1 0</direction>
+            <angle>0.4</angle>
+            <tau>2.0</tau>
+            <amplitude>0.0</amplitude>
+            <steepness>0.0</steepness>
+          </wave>
+        </wavefield>
+      </plugin>
+    </include>
 
     <wind>
       <linear_velocity>0 0 0</linear_velocity>

--- a/vrx_gz/worlds/stationkeeping_task.sdf
+++ b/vrx_gz/worlds/stationkeeping_task.sdf
@@ -638,11 +638,43 @@
     </include>
 
     <!-- The projectile for the ball shooter -->
-    <!-- <include>
+    <include>
       <name>blue_projectile</name>
       <pose>-545 60 0.03 0 0 0</pose>
       <uri>blue_projectile</uri>
-    </include> -->
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.02 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <size>1000 1000</size>
+          <cell_count>50 50></cell_count>
+          <wave>
+            <model>PMS</model>
+            <period>5.0</period>
+            <number>3</number>
+            <scale>1.1</scale>
+            <gain>0.3</gain>
+            <direction>1 0</direction>
+            <angle>0.4</angle>
+            <tau>2.0</tau>
+            <amplitude>0.0</amplitude>
+            <steepness>0.0</steepness>
+          </wave>
+        </wavefield>
+      </plugin>
+    </include>
 
     <wind>
       <linear_velocity>0 0 0</linear_velocity>

--- a/vrx_gz/worlds/sydney_regatta.sdf
+++ b/vrx_gz/worlds/sydney_regatta.sdf
@@ -638,11 +638,43 @@
     </include>
 
     <!-- The projectile for the ball shooter -->
-    <!-- <include>
+    <include>
       <name>blue_projectile</name>
       <pose>-545 60 0.03 0 0 0</pose>
       <uri>blue_projectile</uri>
-    </include> -->
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.02 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <size>1000 1000</size>
+          <cell_count>50 50></cell_count>
+          <wave>
+            <model>PMS</model>
+            <period>5.0</period>
+            <number>3</number>
+            <scale>1.1</scale>
+            <gain>0.3</gain>
+            <direction>1 0</direction>
+            <angle>0.4</angle>
+            <tau>2.0</tau>
+            <amplitude>0.0</amplitude>
+            <steepness>0.0</steepness>
+          </wave>
+        </wavefield>
+      </plugin>
+    </include>
 
     <wind>
       <linear_velocity>0 0 0</linear_velocity>

--- a/vrx_gz/worlds/wayfinding_task.sdf
+++ b/vrx_gz/worlds/wayfinding_task.sdf
@@ -638,11 +638,43 @@
     </include>
 
     <!-- The projectile for the ball shooter -->
-    <!-- <include>
+    <include>
       <name>blue_projectile</name>
       <pose>-545 60 0.03 0 0 0</pose>
       <uri>blue_projectile</uri>
-    </include> -->
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.02 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <size>1000 1000</size>
+          <cell_count>50 50></cell_count>
+          <wave>
+            <model>PMS</model>
+            <period>5.0</period>
+            <number>3</number>
+            <scale>1.1</scale>
+            <gain>0.3</gain>
+            <direction>1 0</direction>
+            <angle>0.4</angle>
+            <tau>2.0</tau>
+            <amplitude>0.0</amplitude>
+            <steepness>0.0</steepness>
+          </wave>
+        </wavefield>
+      </plugin>
+    </include>
 
     <wind>
       <linear_velocity>0 0 0</linear_velocity>

--- a/vrx_gz/worlds/wildlife_task.sdf
+++ b/vrx_gz/worlds/wildlife_task.sdf
@@ -553,11 +553,43 @@
     </include>
 
     <!-- The projectile for the ball shooter -->
-    <!-- <include>
+    <include>
       <name>blue_projectile</name>
       <pose>-545 60 0.03 0 0 0</pose>
       <uri>blue_projectile</uri>
-    </include> -->
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.02 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.0285</radius>
+            </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <size>1000 1000</size>
+          <cell_count>50 50></cell_count>
+          <wave>
+            <model>PMS</model>
+            <period>5.0</period>
+            <number>3</number>
+            <scale>1.1</scale>
+            <gain>0.3</gain>
+            <direction>1 0</direction>
+            <angle>0.4</angle>
+            <tau>2.0</tau>
+            <amplitude>0.0</amplitude>
+            <steepness>0.0</steepness>
+          </wave>
+        </wavefield>
+      </plugin>
+    </include>
 
     <wind>
       <linear_velocity>0 0 0</linear_velocity>

--- a/vrx_urdf/vrx_gazebo/models/blue_projectile/model.config
+++ b/vrx_urdf/vrx_gazebo/models/blue_projectile/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<model>
+  <name>blue_projectile</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Carlos Agüero</name>
+    <email>caguero@openrobotics.org</email>
+  </author>
+
+  <description>
+    A blue projectile to be used with the ball shooter.
+    Reference: https://bit.ly/3jaJDzs
+  </description>
+</model>

--- a/vrx_urdf/vrx_gazebo/models/blue_projectile/model.sdf
+++ b/vrx_urdf/vrx_gazebo/models/blue_projectile/model.sdf
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name="blue_projectile">
+    <link name="link">
+      <inertial>
+        <mass>0.04</mass>
+        <!-- Mark only - based on cylinder -->
+        <inertia>
+          <ixx>0.00002166</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>00002166</iyy>
+          <iyz>0</iyz>
+          <izz>00002166</izz>
+        </inertia>
+      </inertial>
+      <collision name="collision">
+        <geometry>
+          <sphere>
+            <radius>0.0285</radius>
+          </sphere>
+        </geometry>
+      </collision>
+      <visual name="visual">
+        <geometry>
+	        <sphere>
+            <radius>0.0285</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <ambient>0.3176 0.6118 0.8353</ambient>
+          <diffuse>0.3176 0.6118 0.8353</diffuse>
+          <specular>0.3176 0.6118 0.8353</specular>
+        </material>
+      </visual>
+    </link>
+  </model>
+</sdf>

--- a/vrx_urdf/wamv_gazebo/urdf/components/ball_shooter.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/ball_shooter.xacro
@@ -61,9 +61,9 @@
       <parent link="${namespace}/${name}_base_link"/>
       <child link="${namespace}/${name}_launcher_link"/>
     </joint>
-<!--
+
     <gazebo>
-      <plugin name="ball_shooter_plugin" filename="libball_shooter_plugin.so">
+      <plugin name="vrx::BallShooterPlugin" filename="libBallShooterPlugin.so">
         <projectile>
           <model_name>blue_projectile</model_name>
           <link_name>link</link_name>
@@ -75,6 +75,5 @@
         <topic>${namespace}/${shooter_namespace}${name}/fire</topic>
       </plugin>
     </gazebo>
--->
   </xacro:macro>
 </robot>


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@openrobotics.org>

Add ball shooter plugin and `blue_projectile` model to all worlds

To test:

1. Follow the instructions in #526 to generate and launch the world with the wamv urdf file. 

1. Run the cmd below to fire the ball shooter:

```
ros2 topic pub --once /wamv/shooters/ball_shooter/fire std_msgs/Empty
```

![vrx_ball_shooter](https://user-images.githubusercontent.com/4000684/195475825-d252befc-d346-415e-b5cb-843e85b66429.gif)

