### PR TITLE
[Garden] Fix crash on when resuming simulation from paused state

### DIFF
--- a/vrx_gz/src/PolyhedraBuoyancyDrag.cc
+++ b/vrx_gz/src/PolyhedraBuoyancyDrag.cc
@@ -249,6 +249,9 @@ void PolyhedraBuoyancyDrag::PreUpdate(const sim::UpdateInfo &_info,
 {
   GZ_PROFILE("PolyhedraBuoyancyDrag::PreUpdate");
 
+  if (_info.paused)
+    return;
+
   // Elapsed time since the last update.
   double dt;
   double simTime;


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@openrobotics.org>

Gazebo currently crashes if you pause then resume simulation. This is due to the `PolyhedraBuoyancyDrag` setting invalid link forces when `dt` is zero. The changes here just tell the plugin to skip computation when simulation is paused

To reproduce the crash:

1. Launch sim with any world (all of them should have buoys with the `PolyhedraBuoyancyDrag` plugin). 

1. Pause simulation

1. Play simulation -> crash
