### PR TITLE
[caguero] Add pinger plugin to wamv_pinger.xacro

### DIFF
--- a/vrx_urdf/wamv_gazebo/urdf/components/wamv_pinger.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/wamv_pinger.xacro
@@ -21,35 +21,37 @@
       <child link="${namespace}/${name}"/>
     </joint>
 
-<!--
     <gazebo>
-      <plugin name="pinger_plugin" filename="libusv_gazebo_acoustic_pinger_plugin.so">
-        <frameId>${frameId}</frameId>
-        <topicName>${namespace}/${sensor_namespace}${pinger_namespace}${name}/range_bearing</topicName>
-        <setPositionTopicName>${namespace}/${sensor_namespace}${pinger_namespace}${name}/set_pinger_position</setPositionTopicName>
-        <rangeNoise>
+      <plugin
+        filename="libAcousticPingerPlugin.so"
+        name="vrx::AcousticPingerPlugin">
+        <position>${position}</position>
+        <topic>${namespace}/${pinger_namespace}${name}/range_bearing</topic>
+        <set_position_topic>${namespace}/${pinger_namespace}${name}/set_pinger_position
+        </set_position_topic>
+        <frame_id>${namespace}/${name}</frame_id>
+        <range_noise>
           <noise>
             <type>gaussian</type>
             <mean>0.0</mean>
             <stddev>3.0</stddev>
           </noise>
-        </rangeNoise>
-        <bearingNoise>
+        </range_noise>
+        <bearing_noise>
           <noise>
             <type>gaussian</type>
             <mean>0.0</mean>
             <stddev>0.01</stddev>
           </noise>
-        </bearingNoise>
-        <elevationNoise>
+        </bearing_noise>
+        <elevation_noise>
           <noise>
             <type>gaussian</type>
             <mean>0.0</mean>
             <stddev>0.01</stddev>
           </noise>
-        </elevationNoise>
+        </elevation_noise>
       </plugin>
     </gazebo>
--->
   </xacro:macro>
 </robot>

--- a/vrx_urdf/wamv_gazebo/urdf/wamv_gazebo.urdf.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/wamv_gazebo.urdf.xacro
@@ -162,7 +162,7 @@
 
     <!-- Add pinger -->
     <xacro:if value="$(arg pinger_enabled)">
-      <xacro:wamv_pinger name="pinger" position="1.0 0 -1.0" />
+      <xacro:wamv_pinger name="pinger" position="-528 191 -2.0" />
     </xacro:if>
 
     <!-- Add ball shooter (default pitch angle: ~-60 deg) -->
@@ -194,7 +194,7 @@
       <xacro:lidar name="lidar_wamv" type="16_beam"/>
 
       <!-- Add pinger -->
-      <xacro:wamv_pinger name="pinger" position="1.0 0 -1.0" />
+      <xacro:wamv_pinger name="pinger" position="-528 191 -2.0" />
 
       <!-- Add ball shooter (default pitch angle: ~-60 deg) -->
       <xacro:wamv_ball_shooter name="ball_shooter" x="0.54" y="0.30" z="1.296" pitch="-1.04"/>


### PR DESCRIPTION
After #526 , the pinger plugin wasn't working. This pull request adds the plugin to the xacro macro.

For testing, follow the instructions detailed in #531 .