### PR TITLE
Do not lock the WAM-V in Sydney Regatta

### DIFF
--- a/vrx_gz/worlds/sydney_regatta.sdf
+++ b/vrx_gz/worlds/sydney_regatta.sdf
@@ -355,11 +355,6 @@
     </include>
 
     <include>
-      <name>platform</name>
-      <uri>platform</uri>
-    </include>
-
-    <include>
       <name>mb_marker_buoy_red</name>
       <pose>-528 191 0 0 1.57 0</pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_red</uri>


### PR DESCRIPTION
Related with #545 . Without this patch, the WAM-V is locked and can't be moved. 

How to test it?

* Launch the `sydney_regatta` world:
```
ros2 launch vrx_gz competition.launch.py world:=sydney_regatta
```

* Apply thrust:
```
ros2 topic pub /wamv/thrusters/right/thrust std_msgs/msg/Float64 data:\ 100.0\
```

You should see the WAM-V moving since you sent this command.