### PR TITLE
Make state change and collision messages timely and uniform

### DIFF
--- a/vrx_gz/src/GymkhanaScoringPlugin.cc
+++ b/vrx_gz/src/GymkhanaScoringPlugin.cc
@@ -211,19 +211,6 @@ void GymkhanaScoringPlugin::PreUpdate(const gz::sim::UpdateInfo &_info,
 }
 
 //////////////////////////////////////////////////
-void GymkhanaScoringPlugin::OnRunning()
-{
-  if (!this->dataPtr->silent)
-  {
-    gzmsg << "GymkhanaScoringPlugin::OnRunning" << std::endl;
-    std::cout << std::flush;
-  }
-  ScoringPlugin::OnRunning();
-}
-
-
-
-//////////////////////////////////////////////////
 void GymkhanaScoringPlugin::OnFinished()
 {
   // TODO: fix obstacle penalty (Navigation Plugin Implementation)

--- a/vrx_gz/src/GymkhanaScoringPlugin.hh
+++ b/vrx_gz/src/GymkhanaScoringPlugin.hh
@@ -87,9 +87,6 @@ namespace vrx
     public: void ChannelCallback(const gz::msgs::Param &_msg);
 
     // Documentation inherited.
-    private: void OnRunning() override;
- 
-    // Documentation inherited.
     protected: void OnFinished() override;
  
     /// \brief Private data pointer.

--- a/vrx_gz/src/NavigationScoringPlugin.cc
+++ b/vrx_gz/src/NavigationScoringPlugin.cc
@@ -457,49 +457,6 @@ void NavigationScoringPlugin::Fail()
   ScoringPlugin::Finish();
 }
 
-//////////////////////////////////////////////////
-void NavigationScoringPlugin::OnReady()
-{
-  if (!this->dataPtr->silent)
-  {
-    gzmsg << "NavigationScoringPlugin::OnReady" << std::endl;
-    std::cout << std::flush;
-  }
-  ScoringPlugin::OnReady();
-}
-
-//////////////////////////////////////////////////
-void NavigationScoringPlugin::OnRunning()
-{
-  if (!this->dataPtr->silent)
-  {
-    gzmsg << "NavigationScoringPlugin::OnRunning" << std::endl;
-    std::cout << std::flush;
-  }
-  ScoringPlugin::OnRunning();
-}
-
-//////////////////////////////////////////////////
-void NavigationScoringPlugin::OnFinished()
-{
-  if (!this->dataPtr->silent)
-  {
-    gzmsg << "NavigationScoringPlugin::OnFinished" << std::endl;
-  }
-  ScoringPlugin::OnFinished();
-}
-
-//////////////////////////////////////////////////
-void NavigationScoringPlugin::OnCollision()
-{
-  if (!this->dataPtr->silent)
-  {
-    gzmsg << "NavigationScoringPlugin::OnCollision" << std::endl;
-    std::cout << std::flush;
-  }
-  ScoringPlugin::OnCollision();
-}
-
 GZ_ADD_PLUGIN(vrx::NavigationScoringPlugin,
                     sim::System,
                     vrx::NavigationScoringPlugin::ISystemConfigure,

--- a/vrx_gz/src/NavigationScoringPlugin.hh
+++ b/vrx_gz/src/NavigationScoringPlugin.hh
@@ -100,18 +100,6 @@ namespace vrx
     public: void PreUpdate(const gz::sim::UpdateInfo &_info,
                            gz::sim::EntityComponentManager &_ecm) override;
 
-    // Documentation inherited.
-    protected: void OnReady() override;
-
-    // Documentation inherited.
-    protected: void OnRunning() override;
-
-    // Documentation inherited.
-    protected: void OnFinished() override;
-
-    // Documentation inherited.
-    protected: void OnCollision() override;
-
     /// \brief Set the score to 0 and change to state to "finish".
     protected: void Fail();
 

--- a/vrx_gz/src/PerceptionScoringPlugin.cc
+++ b/vrx_gz/src/PerceptionScoringPlugin.cc
@@ -502,6 +502,7 @@ void PerceptionScoringPlugin::OnRunning()
 {
   this->dataPtr->node.Subscribe(this->dataPtr->objectTopic,
     &PerceptionScoringPlugin::Implementation::OnAttempt, this->dataPtr.get());
+  ScoringPlugin::OnRunning();
 }
 
 //////////////////////////////////////////////////

--- a/vrx_gz/src/PerceptionScoringPlugin.cc
+++ b/vrx_gz/src/PerceptionScoringPlugin.cc
@@ -490,7 +490,7 @@ void PerceptionScoringPlugin::PreUpdate(const sim::UpdateInfo &_info,
     this->SetScore(this->Score() / this->dataPtr->objects.size());
     gzdbg << "Perception run score: " << this->Score() << std::endl;
 
-    this->Exit();
+    ScoringPlugin::Finish();
   }
 
   // If we have requests, let's process them.

--- a/vrx_gz/src/ScanDockScoringPlugin.cc
+++ b/vrx_gz/src/ScanDockScoringPlugin.cc
@@ -823,6 +823,7 @@ void ScanDockScoringPlugin::OnReady()
   // Announce the symbol if needed.
   for (auto &dockChecker : this->dataPtr->dockCheckers)
     dockChecker->AnnounceSymbol();
+  ScoringPlugin::OnReady();
 }
 
 //////////////////////////////////////////////////
@@ -848,6 +849,8 @@ void ScanDockScoringPlugin::OnRunning()
   // Announce the symbol if needed.
   for (auto &dockChecker : this->dataPtr->dockCheckers)
     dockChecker->AnnounceSymbol();
+
+  ScoringPlugin::OnRunning();
 }
 
 GZ_ADD_PLUGIN(ScanDockScoringPlugin,

--- a/vrx_gz/src/ScoringPlugin.cc
+++ b/vrx_gz/src/ScoringPlugin.cc
@@ -548,21 +548,31 @@ void ScoringPlugin::Exit()
 void ScoringPlugin::OnReady()
 {
   if (!this->dataPtr->silent)
-    gzdbg << "ScoringPlugin::OnReady" << std::endl;
+  {
+    gzmsg << "ScoringPlugin::OnReady" << std::endl;
+    std::cout << std::flush;
+  }
 }
 
 //////////////////////////////////////////////////
 void ScoringPlugin::OnRunning()
 {
   if (!this->dataPtr->silent)
-    gzdbg << "ScoringPlugin::OnRunning" << std::endl;
+  {
+    gzmsg << "ScoringPlugin::OnRunning" << std::endl;
+    std::cout << std::flush;
+  }
 }
 
 //////////////////////////////////////////////////
 void ScoringPlugin::OnFinished()
 {
   if (!this->dataPtr->silent)
-    gzdbg << this->dataPtr->currentTime.count() << "  OnFinished" << std::endl;
+  {
+    gzmsg << "ScoringPlugin::OnFinished at time=" 
+          << this->dataPtr->currentTime.count()  << std::endl;
+    std::cout << std::flush;
+  }
 
   // If a timeoutScore was specified, use it.
   if (this->dataPtr->timedOut && this->dataPtr->timeoutScore > 0.0)

--- a/vrx_gz/src/ScoringPlugin.cc
+++ b/vrx_gz/src/ScoringPlugin.cc
@@ -616,6 +616,7 @@ void ScoringPlugin::OnContacts(const gz::msgs::Contacts &_contacts)
               << "] New collision counted between ["
               << _contacts.contact(i).collision1().name() << "] and ["
               << _contacts.contact(i).collision2().name() << "]" << std::endl;
+        std::cout << std::flush;
       }
 
       this->dataPtr->lastCollisionTime = this->dataPtr->currentTime;

--- a/vrx_gz/src/StationkeepingScoringPlugin.cc
+++ b/vrx_gz/src/StationkeepingScoringPlugin.cc
@@ -309,39 +309,6 @@ void StationkeepingScoringPlugin::PreUpdate( const sim::UpdateInfo &_info,
 }
 
 //////////////////////////////////////////////////
-void StationkeepingScoringPlugin::OnReady()
-{
-  if (!this->dataPtr->silent)
-  {
-    gzmsg << "StationkeepingScoringPlugin::OnReady" << std::endl;
-    std::cout << std::flush;
-  }
-  ScoringPlugin::OnReady();
-}
-
-//////////////////////////////////////////////////
-void StationkeepingScoringPlugin::OnRunning()
-{
-  if (!this->dataPtr->silent)
-  {
-    gzmsg << "StationkeepingScoringPlugin::OnRunning" << std::endl;
-    std::cout << std::flush;
-  }
-  ScoringPlugin::OnRunning();
-}
-
-//////////////////////////////////////////////////
-void StationkeepingScoringPlugin::OnFinished()
-{
-  if (!this->dataPtr->silent)
-  {
-    gzmsg << "StationkeepingScoringPlugin::OnFinished" << std::endl;
-    std::cout << std::flush;
-  }
-  ScoringPlugin::OnFinished();
-}
-
-//////////////////////////////////////////////////
 void StationkeepingScoringPlugin::OnCollision()
 {
   if (!this->dataPtr->silent)

--- a/vrx_gz/src/StationkeepingScoringPlugin.cc
+++ b/vrx_gz/src/StationkeepingScoringPlugin.cc
@@ -309,15 +309,6 @@ void StationkeepingScoringPlugin::PreUpdate( const sim::UpdateInfo &_info,
 }
 
 //////////////////////////////////////////////////
-void StationkeepingScoringPlugin::OnCollision()
-{
-  if (!this->dataPtr->silent)
-  {
-    gzmsg << "StationkeepingScoringPlugin::OnCollision" << std::endl;
-    std::cout << std::flush;
-  }
-  ScoringPlugin::OnCollision();
-}
 
 GZ_ADD_PLUGIN(vrx::StationkeepingScoringPlugin,
               sim::System,

--- a/vrx_gz/src/StationkeepingScoringPlugin.cc
+++ b/vrx_gz/src/StationkeepingScoringPlugin.cc
@@ -314,6 +314,7 @@ void StationkeepingScoringPlugin::OnReady()
   if (!this->dataPtr->silent)
   {
     gzmsg << "StationkeepingScoringPlugin::OnReady" << std::endl;
+    std::cout << std::flush;
   }
   ScoringPlugin::OnReady();
 }
@@ -324,6 +325,7 @@ void StationkeepingScoringPlugin::OnRunning()
   if (!this->dataPtr->silent)
   {
     gzmsg << "StationkeepingScoringPlugin::OnRunning" << std::endl;
+    std::cout << std::flush;
   }
   ScoringPlugin::OnRunning();
 }
@@ -334,6 +336,7 @@ void StationkeepingScoringPlugin::OnFinished()
   if (!this->dataPtr->silent)
   {
     gzmsg << "StationkeepingScoringPlugin::OnFinished" << std::endl;
+    std::cout << std::flush;
   }
   ScoringPlugin::OnFinished();
 }
@@ -344,6 +347,7 @@ void StationkeepingScoringPlugin::OnCollision()
   if (!this->dataPtr->silent)
   {
     gzmsg << "StationkeepingScoringPlugin::OnCollision" << std::endl;
+    std::cout << std::flush;
   }
   ScoringPlugin::OnCollision();
 }

--- a/vrx_gz/src/StationkeepingScoringPlugin.hh
+++ b/vrx_gz/src/StationkeepingScoringPlugin.hh
@@ -61,9 +61,6 @@ namespace vrx
     public: void PreUpdate(const gz::sim::UpdateInfo &_info,
                        gz::sim::EntityComponentManager &_ecm) override;
 
-    // Documentation
-    protected: void OnCollision() override;
-
     /// \brief Private data pointer.
     GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };

--- a/vrx_gz/src/StationkeepingScoringPlugin.hh
+++ b/vrx_gz/src/StationkeepingScoringPlugin.hh
@@ -61,15 +61,6 @@ namespace vrx
     public: void PreUpdate(const gz::sim::UpdateInfo &_info,
                        gz::sim::EntityComponentManager &_ecm) override;
 
-    // Documentation inherited.
-    protected: void OnReady() override;
-
-    // Documentation inherited.
-    protected: void OnRunning() override;
-
-    // Documentation inherited.
-    protected: void OnFinished() override;
-
     // Documentation
     protected: void OnCollision() override;
 

--- a/vrx_gz/src/WayfindingScoringPlugin.cc
+++ b/vrx_gz/src/WayfindingScoringPlugin.cc
@@ -290,18 +290,6 @@ void WayfindingScoringPlugin::PreUpdate(const sim::UpdateInfo &_info,
   ScoringPlugin::SetScore(this->dataPtr->meanError); 
 }
 
-//////////////////////////////////////////////////
-void WayfindingScoringPlugin::OnReady()
-{
-  gzmsg << "WayfindingScoringPlugin::OnReady" << std::endl;
-}
-
-//////////////////////////////////////////////////
-void WayfindingScoringPlugin::OnRunning()
-{
-  gzmsg << "WayfindingScoringPlugin::OnRunning" << std::endl;
-}
-
 GZ_ADD_PLUGIN(WayfindingScoringPlugin,
               sim::System,
               ScoringPlugin::ISystemConfigure,

--- a/vrx_gz/src/WayfindingScoringPlugin.hh
+++ b/vrx_gz/src/WayfindingScoringPlugin.hh
@@ -79,12 +79,6 @@ class WayfindingScoringPlugin : public ScoringPlugin
                     const gz::sim::UpdateInfo &_info,
                     gz::sim::EntityComponentManager &_ecm) override;
 
-  // Documentation inherited.
-  protected: void OnReady() override;
-
-  // Documentation inherited.
-  protected: void OnRunning() override;
-
   /// \brief Private data pointer.
   GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
 };


### PR DESCRIPTION
Addresses issue #552 by:
* Removing all implementations of state transition functions (OnReady, OnRunning, OnFinished) from Stationkeeping, Wayfinding and Navigation tasks.
* Removing OnRunning from the Gymkhana task.
* Removing the unneeded OnCollision function from Stationkeeping.
* Flushing state transition messages and collision messages displayed by ScoringPlugin class.
* Replacing the call to Exit in the Perception class with ScoringPlugin::Finish().

Bonus:
* Changes the format of the OnFinished message to clarify that it is printing the time.

To test:
* Set the timeout value to a low number for all worlds:
  ```
  cd vrx/vrx_gz/worlds
  sed -i 's/duration>300/duration>60/g' *.sdf
  ```
* Run the Stationkeeping, Wayfinding, Perception, Navigation, Wildlife, Gymkhana and ScanDockDeliver tasks.
* Check that each task displays the following messages at the appropriate times:
  ```
  [Msg] ScoringPlugin::OnReady
  [Msg] ScoringPlugin::OnRunning
  [Msg] ScoringPlugin::OnFinished at time=80
  ```
* Check that collisions produce a message like:
  ```
  [Dbg] [ScoringPlugin.cc:615] [1] New collision counted between 
  [wamv::wamv/base_link::wamv/base_link_fixed_joint_lump__left_mid_float_collision_18] and 
  [short_navigation_course_0::red_bound_1::link::collision_outer]
  ```
