### PR TITLE
Move navigation course farther from WAMV

### DIFF
--- a/vrx_gz/worlds/gymkhana_task.sdf
+++ b/vrx_gz/worlds/gymkhana_task.sdf
@@ -361,7 +361,7 @@
     <!-- The VRX short navigation course -->
     <include>
       <uri>model://short_navigation_course_0</uri>
-      <pose>-524 186 0 0 0 -1.44</pose>
+      <pose>-524 198 0 0 0 -1.44</pose>
     </include>
 
     <!-- The obstacle course -->

--- a/vrx_gz/worlds/navigation_task.sdf
+++ b/vrx_gz/worlds/navigation_task.sdf
@@ -357,7 +357,7 @@
     <!-- The VRX short navigation course -->
     <include>
       <uri>model://short_navigation_course_0</uri>
-      <pose>-524 186 0 0 0 -1.44</pose>
+      <pose>-524 198 0 0 0 -1.44</pose>
     </include>
 
     <!-- The posts for securing the WAM-V -->


### PR DESCRIPTION
A very minor tweak to make the starting position of the navigation course a little farther away from the starting position of the WAMV in the navigation and gymkhana tasks. The purpose of this is to make it a little harder to accidentally cross the first gate before the simulation has entered the `OnRunning` state (see discussion at #545).

To test:
* Start the navigation task
  ```
  ros2 launch vrx_gz competition.launch.py world:=navigation_task
  ```
* Start teleop in a separate terminal.
  ```
  ros2 launch vrx_gz usv_joy_teleop.py
  ```
* Try to drive the WAMV through the course as soon as possible.
* Confirm that the task enters the OnRunning state before you reach the first gate.
* Repeat for the gymkhana task.