### PR TITLE
[Garden] Fixing missing import

### DIFF
--- a/vrx_urdf/vrx_gazebo/src/vrx_gazebo/compliance.py
+++ b/vrx_urdf/vrx_gazebo/src/vrx_gazebo/compliance.py
@@ -4,6 +4,7 @@ from ament_index_python.packages import get_package_share_directory
 
 import numpy as np
 import os
+import rclpy
 import yaml
 
 from vrx_gazebo.utils import get_macros


### PR DESCRIPTION
This pull request fixes a Python issue when customizing a WAM-V. When the yaml configuration isn't compliant, instead of showing the expected error, we were showing the following error:

```
[generate_wamv.py-1] NameError: name 'yaml' is not defined
```

This patch fixes the problem.

### How to test it?

Follow [this tutorial](https://github.com/osrf/vrx/wiki/2023-Customizing-the-WAM-V) and you shouldn't get any unexpected error.