### PR TITLE
Remove obsolete comment about heightmap pose

### DIFF
--- a/vrx_gz/worlds/gymkhana_task.sdf
+++ b/vrx_gz/worlds/gymkhana_task.sdf
@@ -341,8 +341,6 @@
     </light>
 
     <include>
-      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
-      to go into the model file to change the altitude/height! -->
       <pose> 0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>

--- a/vrx_gz/worlds/navigation_task.sdf
+++ b/vrx_gz/worlds/navigation_task.sdf
@@ -337,8 +337,6 @@
     </light>
 
     <include>
-      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
-      to go into the model file to change the altitude/height! -->
       <pose> 0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>

--- a/vrx_gz/worlds/perception_task.sdf
+++ b/vrx_gz/worlds/perception_task.sdf
@@ -342,8 +342,6 @@
     </light>
 
     <include>
-      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
-      to go into the model file to change the altitude/height! -->
       <pose> 0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>

--- a/vrx_gz/worlds/scan_dock_deliver_task.sdf
+++ b/vrx_gz/worlds/scan_dock_deliver_task.sdf
@@ -342,8 +342,6 @@
     </light>
 
     <include>
-      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
-      to go into the model file to change the altitude/height! -->
       <pose> 0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>

--- a/vrx_gz/worlds/stationkeeping_task.sdf
+++ b/vrx_gz/worlds/stationkeeping_task.sdf
@@ -342,8 +342,6 @@
     </light>
 
     <include>
-      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
-      to go into the model file to change the altitude/height! -->
       <pose> 0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>

--- a/vrx_gz/worlds/sydney_regatta.sdf
+++ b/vrx_gz/worlds/sydney_regatta.sdf
@@ -342,8 +342,6 @@
     </light>
 
     <include>
-      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
-      to go into the model file to change the altitude/height! -->
       <pose> 0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>

--- a/vrx_gz/worlds/wayfinding_task.sdf
+++ b/vrx_gz/worlds/wayfinding_task.sdf
@@ -342,8 +342,6 @@
     </light>
 
     <include>
-      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
-      to go into the model file to change the altitude/height! -->
       <pose> 0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>

--- a/vrx_gz/worlds/wildlife_task.sdf
+++ b/vrx_gz/worlds/wildlife_task.sdf
@@ -342,8 +342,6 @@
     </light>
 
     <include>
-      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
-      to go into the model file to change the altitude/height! -->
       <pose> 0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>


### PR DESCRIPTION
A simple PR to remove the following comment from our sdfs:
```
      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
      to go into the model file to change the altitude/height! -->
```
Per discussion in #536 this comment does not seem to be true anymore.

## To test
Edit `sydney_regatta.sdf` to change the `pose` tag for the `sydney_regatta` model to alter the `z` value. Then rebuild and  run:

```
ros2 launch vrx_gz competition.launch.py world:=sydney_regatta
```
Observe that the pose of the heightmap has changed.