### PR TITLE
[Garden] Fix issue #563 and inertias

### DIFF
--- a/vrx_urdf/wamv_gazebo/urdf/components/wamv_pinger.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/wamv_pinger.xacro
@@ -4,19 +4,13 @@
     <link name="${namespace}/${name}">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <box size="0.1 0.1 0.1" />
-        </geometry>
       </visual>
-      <collision name="${name}_collision">
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <box size="0.1 0.1 0.1" />
-        </geometry>
-      </collision>
+      <inertial>
+        <mass value="0.1"/>
+        <inertia ixx="0.00000542" ixy="0.0" ixz="0.0" iyy="0.00002104" iyz="0.0" izz="0.00002604"/>
+      </inertial>
     </link>
     <joint name="${namespace}/${name}_pinger_joint" type="fixed">
-      <origin xyz="${position}" rpy="${orientation}"/>
       <parent link="${namespace}/base_link"/>
       <child link="${namespace}/${name}"/>
     </joint>

--- a/vrx_urdf/wamv_gazebo/urdf/wamv_gazebo.urdf.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/wamv_gazebo.urdf.xacro
@@ -72,8 +72,32 @@
   <!-- === Decide if we lock the robot to the world === -->
   <xacro:if value="$(arg locked)">
     <gazebo>
-      <link name="wamv_external_link"/>
-      <link name="wamv_external_link_base"/>
+      <link name="wamv_external_link">
+        <inertial>
+          <mass>0.001</mass>
+          <inertia>
+            <ixx>0.00000004</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00000004</iyy>
+            <iyz>0</iyz>
+            <izz>0.00000004</izz>
+          </inertia>
+        </inertial>
+      </link>
+      <link name="wamv_external_link_base">
+        <inertial>
+          <mass>0.001</mass>
+          <inertia>
+            <ixx>0.00000004</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.00000004</iyy>
+            <iyz>0</iyz>
+            <izz>0.00000004</izz>
+          </inertia>
+        </inertial>
+      </link>
       <joint name="wamv_external_pivot_joint" type="universal">
         <parent>wamv_external_link</parent>
         <child>wamv/base_link</child>


### PR DESCRIPTION
Fix issue #563.

The problem was in the `wamv_pinger.xacro`. We were creating a visual with an offset equals to the `position` of the pinger in world coordinates. This is wrong as the visual (if any) should represent the acoustic sensor and it should be inside the wam-v. 

I removed the visual and its collision as it's not very useful.

Bonus: I added some missing inertias, otherwise the default inertia values were incorrect. The inertias look good now:

![Screenshot from 2023-01-04 17-20-04](https://user-images.githubusercontent.com/1440739/210602688-b4c10e91-0745-4917-ab2c-9460c20e946b.png)


### How to test it?

* Recheck the instructions described in #531 to confirm that the pinger is still working correctly.
* Click on the WAM-V. Verify that the bounding box is now correct.
* Right click and select `View->Inertia` to confirm that the inertias are reasonable. **Note that the inertia visualization is very slow the first time that you request it. This is a Gazebo issue.**
