### PR TITLE
Enable the bridge for non-default thruster configurations

### DIFF
--- a/vrx_gz/src/vrx_gz/bridges.py
+++ b/vrx_gz/src/vrx_gz/bridges.py
@@ -46,28 +46,6 @@ def cmd_vel(model_name):
         ros_type='geometry_msgs/msg/Twist',
         direction=BridgeDirection.ROS_TO_GZ)
 
-def thrust(model_name, side):
-    return Bridge(
-        gz_topic=f'{model_name}/thrusters/{side}/thrust',
-        ros_topic=f'thrusters/{side}/thrust',
-        gz_type='ignition.msgs.Double',
-        ros_type='std_msgs/msg/Float64',
-        direction=BridgeDirection.ROS_TO_GZ)
-
-def thrust_joint_pos(model_name, side):
-    # ROS naming policy indicates that first character of a name must be an alpha
-    # character. In the case below, the gz topic has the joint index 0 as the
-    # first char so the following topics fail to be created on the ROS end
-    # left_joint_topic = '/model/' + model_name + '/joint/left_chasis_engine_joint/0/cmd_pos'
-    # right_joint_topic = '/model/' + model_name + '/joint/right_chasis_engine_joint/0/cmd_pos'
-    # For now, use erb to generate unique topic names in model.sdf.erb
-    return Bridge(
-        gz_topic=f'{model_name}/thrusters/{side}/pos',
-        ros_topic=f'thrusters/{side}/pos',
-        gz_type='ignition.msgs.Double',
-        ros_type='std_msgs/msg/Float64',
-        direction=BridgeDirection.ROS_TO_GZ)
-
 def acoustic_pinger(model_name):
     return Bridge(
         gz_topic=f'{model_name}/pingers/pinger/range_bearing',
@@ -180,7 +158,6 @@ def gymkhana_blackbox_goal():
         ros_type='geometry_msgs/msg/PoseStamped',
         direction=BridgeDirection.GZ_TO_ROS)
 
-
 def gymkhana_blackbox_mean_pose_error():
     return Bridge(
         gz_topic=f'/vrx/gymkhana_blackbox/mean_pose_error',
@@ -188,7 +165,6 @@ def gymkhana_blackbox_mean_pose_error():
         gz_type='ignition.msgs.Float',
         ros_type='std_msgs/msg/Float32',
         direction=BridgeDirection.GZ_TO_ROS)
-
 
 def gymkhana_blackbox_pose_error():
     return Bridge(

--- a/vrx_gz/src/vrx_gz/payload_bridges.py
+++ b/vrx_gz/src/vrx_gz/payload_bridges.py
@@ -134,6 +134,27 @@ def ball_shooter(model_name):
         ros_type='std_msgs/msg/Empty',
         direction=BridgeDirection.ROS_TO_GZ)
 
+def thrust(model_name, side):
+    return Bridge(
+        gz_topic=f'{model_name}/thrusters/{side}/thrust',
+        ros_topic=f'thrusters/{side}/thrust',
+        gz_type='ignition.msgs.Double',
+        ros_type='std_msgs/msg/Float64',
+        direction=BridgeDirection.ROS_TO_GZ)
+
+def thrust_joint_pos(model_name, side):
+    # ROS naming policy indicates that first character of a name must be an alpha
+    # character. In the case below, the gz topic has the joint index 0 as the
+    # first char so the following topics fail to be created on the ROS end
+    # left_joint_topic = '/model/' + model_name + '/joint/left_chasis_engine_joint/0/cmd_pos'
+    # right_joint_topic = '/model/' + model_name + '/joint/right_chasis_engine_joint/0/cmd_pos'
+    # For now, use erb to generate unique topic names in model.sdf.erb
+    return Bridge(
+        gz_topic=f'{model_name}/thrusters/{side}/pos',
+        ros_topic=f'thrusters/{side}/pos',
+        gz_type='ignition.msgs.Double',
+        ros_type='std_msgs/msg/Float64',
+        direction=BridgeDirection.ROS_TO_GZ)
 
 def payload_bridges(world_name, model_name, link_name, sensor_name, sensor_type):
     bridges = []
@@ -173,6 +194,14 @@ def payload_bridges(world_name, model_name, link_name, sensor_name, sensor_type)
     elif 'BallShooter' in sensor_name:
         bridges = [
             ball_shooter(model_name),
+        ]
+    elif 'thruster_thrust_' in sensor_name:
+        bridges = [
+            thrust(model_name, sensor_type),
+        ]
+    elif 'thruster_rotate_' in sensor_name:
+        bridges = [
+            thrust_joint_pos(model_name, sensor_type),
         ]
 
     return bridges

--- a/vrx_urdf/wamv_gazebo/urdf/thruster_layouts/wamv_gazebo_thruster_config.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/thruster_layouts/wamv_gazebo_thruster_config.xacro
@@ -19,6 +19,8 @@
       <max_thrust_cmd>${((x_u + x_uu * max_velocity_mps) * max_velocity_mps)/ 2}</max_thrust_cmd>
       <namespace>${namespace}</namespace>
       <topic>thrusters/${name}/thrust</topic>
+      <!-- Not used by Gazebo but used to run the bridge easily -->
+      <name>${name}</name>
     </plugin>
 
     <plugin
@@ -27,6 +29,8 @@
       <joint_name>${namespace}/${name}_chassis_engine_joint</joint_name>
       <use_velocity_commands>true</use_velocity_commands>
       <topic>${namespace}/thrusters/${name}/pos</topic>
+      <!-- Not used by Gazebo but used to run the bridge easily -->
+      <name>${name}</name>
     </plugin>
 
   </gazebo>


### PR DESCRIPTION
1. Follow the [customizing the WAM-V tutorial](https://github.com/osrf/vrx/wiki/2023-Customizing-the-WAM-V).

2. Edit the `example_thruster_config.yaml` and add a third thruster.
```
engine:
  - prefix: "left"
    position: "-2.373776 1.027135 0.318237"
    orientation: "0.0 0.0 0.0"
  - prefix: "right"
    position: "-2.373776 -1.027135 0.318237"
    orientation: "0.0 0.0 0.0"
  - prefix: "middle"
    position: "0 0 0.318237"
    orientation: "0.0 0.0 0.0"
```

3. Follow the instructions and run the simulation with the custom thruster setup. Now, check that you have ros topics for the `middle` thruster.
```
ros2 topic list
```
You should see topics all these topic thrusters:
```
/wamv/thrusters/left/pos
/wamv/thrusters/left/thrust
/wamv/thrusters/middle/pos
/wamv/thrusters/middle/thrust
/wamv/thrusters/right/pos
/wamv/thrusters/right/thrust
```

4. Check that the thruster works:
```
 ros2 topic pub /wamv/thrusters/middle/thrust std_msgs/msg/Float64 data:\ 50
```

Your WAM-V should move!