### PR TITLE
Restore marker support

### DIFF
--- a/vrx_gz/CMakeLists.txt
+++ b/vrx_gz/CMakeLists.txt
@@ -81,6 +81,21 @@ install(
   TARGETS ScoringPlugin
   DESTINATION lib)
 
+# Stationkeeping scoring plugin
+add_library(StationkeepingScoringPlugin SHARED
+  src/StationkeepingScoringPlugin.cc
+  src/WaypointMarkers
+)
+target_link_libraries(StationkeepingScoringPlugin PUBLIC
+  gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
+  gz-sim${GZ_SIM_VER}::core
+  gz-math${GZ_MATH_VER}
+  ScoringPlugin
+)
+install(
+  TARGETS StationkeepingScoringPlugin
+  DESTINATION lib)
+
 # Wayfinding scoring plugin
 add_library(WayfindingScoringPlugin SHARED
   src/WayfindingScoringPlugin.cc
@@ -107,7 +122,6 @@ list(APPEND VRX_GZ_PLUGINS
   PlacardPlugin
   ScanDockScoringPlugin
   SimpleHydrodynamics
-  StationkeepingScoringPlugin
   Surface
   WaveVisual
   WildlifeScoringPlugin

--- a/vrx_gz/src/WayfindingScoringPlugin.cc
+++ b/vrx_gz/src/WayfindingScoringPlugin.cc
@@ -200,7 +200,7 @@ void WayfindingScoringPlugin::Configure(const sim::Entity &_entity,
     for (const auto waypoint : this->dataPtr->localWaypoints)
     {
       if (!this->dataPtr->waypointMarkers.DrawMarker(markerId, waypoint.X(),
-            waypoint.Y(), waypoint.Z(), std::to_string(markerId)))
+            waypoint.Y(), waypoint.Z()))
       {
         gzerr << "Error creating visual marker" << std::endl;
       }

--- a/vrx_gz/src/WaypointMarkers.cc
+++ b/vrx_gz/src/WaypointMarkers.cc
@@ -26,16 +26,13 @@ using namespace vrx;
 
 /////////////////////////////////////////////////
 WaypointMarkers::WaypointMarkers(const std::string &_namespace)
-  : ns(_namespace), material("Gazebo/Red"), scaling{0.2, 0.2, 1.5}, height(4.0)
+  : ns(_namespace), scaling{0.2, 0.2, 1.5}, height(4.0)
 {
 }
 
 /////////////////////////////////////////////////
 void WaypointMarkers::Load(const std::shared_ptr<const sdf::Element> &_sdf)
 {
-  if (_sdf->HasElement("material"))
-    this->material = _sdf->Get<std::string>("material");
-
   if (_sdf->HasElement("scaling"))
     this->scaling = _sdf->Get<math::Vector3d>("scaling");
 
@@ -47,22 +44,27 @@ void WaypointMarkers::Load(const std::shared_ptr<const sdf::Element> &_sdf)
 }
 
 /////////////////////////////////////////////////
-bool WaypointMarkers::DrawMarker(double _x, double _y, double _yaw,
-  const std::string &_text)
+bool WaypointMarkers::DrawMarker(double _x, double _y, double _yaw)
 {
-  return this->DrawMarker(this->id++, _x, _y, _yaw, _text);
+  return this->DrawMarker(this->id++, _x, _y, _yaw);
 }
 
 /////////////////////////////////////////////////
 bool WaypointMarkers::DrawMarker(int _markerId, double _x, double _y,
-  double _yaw, const std::string &_text)
+  double _yaw)
 {
- //TODO: Fix below. The markers are not showing up.
   msgs::Marker markerMsg;
   markerMsg.set_ns(this->ns);
   markerMsg.set_action(msgs::Marker_Action_ADD_MODIFY);
-  msgs::Material *matMsg = markerMsg.mutable_material();
-  matMsg->mutable_script()->set_name(this->material);
+  markerMsg.set_visibility(gz::msgs::Marker::GUI);
+  markerMsg.mutable_material()->mutable_ambient()->set_r(1);
+  markerMsg.mutable_material()->mutable_ambient()->set_g(1);
+  markerMsg.mutable_material()->mutable_ambient()->set_b(1);
+  markerMsg.mutable_material()->mutable_ambient()->set_a(1);
+  markerMsg.mutable_material()->mutable_diffuse()->set_r(1);
+  markerMsg.mutable_material()->mutable_diffuse()->set_g(1);
+  markerMsg.mutable_material()->mutable_diffuse()->set_b(1);
+  markerMsg.mutable_material()->mutable_diffuse()->set_a(1);
 
   // draw cylinder
   markerMsg.set_type(msgs::Marker_Type_CYLINDER);
@@ -79,25 +81,9 @@ bool WaypointMarkers::DrawMarker(int _markerId, double _x, double _y,
   msgs::Set(markerMsg.mutable_scale(), this->scaling);
   msgs::Set(markerMsg.mutable_pose(),  math::Pose3d(
     _x + cos(_yaw), _y + sin(_yaw), this->height + this->scaling.Z() / 2.0,
-    0, M_PI/2, _yaw));
+    0, M_PI / 2, _yaw));
   markerMsg.set_id((_markerId + 1) * 1000);
   result = node.Request("/marker", markerMsg);
-  if (!result)
-    return false;
 
-  // draw text
-//  if (!_text.empty())
-//  {
-//    markerMsg.set_type(msgs::Marker_Type_TEXT);
-//    markerMsg.set_text(_text);
-//    msgs::Set(markerMsg.mutable_scale(),
-//                        math::Vector3d(1.0, 1.0, 1.0));
-//    msgs::Set(markerMsg.mutable_pose(),
-//                        math::Pose3d(_x, _y - 0.2,
-//                            this->height + this->scaling.Z() + 0.8,
-//                            0, 0, 0));
-//    markerMsg.set_id((_markerId + 1) * 10000);
-//    result = node.Request("/marker", markerMsg);
-//  }
   return result;
 }

--- a/vrx_gz/src/WaypointMarkers.hh
+++ b/vrx_gz/src/WaypointMarkers.hh
@@ -27,11 +27,8 @@
 namespace vrx
 {
   /// \brief This class is used to display waypoint markers.
-  /// Cylindrical Gazebo markers are drawn with text on top
   ///
   /// The marker properties can be set using sdf:
-  /// material: Optional parameter (string type) to specify the material
-  ///           for marker. Default: Gazebo/Green
   /// scaling: Optional parameter (vector type) to specify marker scaling.
   ///          Default: 0.2 0.2 1.5
   /// height: Optional parameter (double type) height of marker above water.
@@ -39,7 +36,6 @@ namespace vrx
   /// drawing markers without explicitly specifying ID.
   /// E.g.
   /// <markers>
-  ///   <material>Gazebo/Green</material>
   ///   <scaling>0.2 0.2 2.0</scaling>
   ///   <height>0.5</height>
   /// </markers>
@@ -59,30 +55,23 @@ namespace vrx
     /// \param[in] _x X coordinate of waypoint marker
     /// \param[in] _y Y coordinate of waypoint marker
     /// \param[in] _yaw orientation of waypoint marker in radians
-    /// \param[in] _text (optional) Text above waypoint marker
     /// \return Returns true if marker is successfully sent to Gazebo
     public: bool DrawMarker(int _markerId,
                             double _x,
                             double _y,
-                            double _yaw,
-                            const std::string &_text = "");
+                            double _yaw);
 
     /// \brief Draw a new waypoint marker in Gazebo
     /// \param[in] _x X coordinate of waypoint marker
     /// \param[in] _y Y coordinate of waypoint marker
     /// \param[in] _yaw orientation of waypoint marker in radians
-    /// \param[in] _text (optional) Text above waypoint marker
     /// \return Returns true if marker is successfully sent to Gazebo
     public: bool DrawMarker(double _x,
                             double _y,
-                            double _yaw,
-                            const std::string &_text = "");
+                            double _yaw);
 
     /// \brief Namespace for Gazebo markers
     private: std::string ns;
-
-    /// \brief Name of Gazebo material for marker
-    private: std::string material;
 
     /// \brief Scaling factor for cylinder marker
     private: gz::math::Vector3d scaling;
@@ -93,7 +82,7 @@ namespace vrx
     /// \brief If an ID is not specified, the markers will start using this one.
     private: int id = 0;
 
-    /// \brief gazebo transport node
+    /// \brief Gazebo transport node
     private: gz::transport::Node node;
   };
 }

--- a/vrx_gz/worlds/2022_practice/practice_2022_stationkeeping0_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_stationkeeping0_task.sdf
@@ -490,6 +490,10 @@
       <release_topic>/vrx/release</release_topic>
       <!-- <head_error_on>false</head_error_on> -->
       <goal_pose>-33.722718 150.674031 0</goal_pose>
+      <markers>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
+      </markers>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2022_practice/practice_2022_stationkeeping1_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_stationkeeping1_task.sdf
@@ -490,6 +490,10 @@
       <release_topic>/vrx/release</release_topic>
       <!-- <head_error_on>false</head_error_on> -->
       <goal_pose>-33.72267 150.67406 2.0</goal_pose>
+      <markers>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
+      </markers>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2022_practice/practice_2022_stationkeeping2_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_stationkeeping2_task.sdf
@@ -490,6 +490,10 @@
       <release_topic>/vrx/release</release_topic>
       <!-- <head_error_on>false</head_error_on> -->
       <goal_pose>-33.7226643 150.673947 -1.0</goal_pose>
+      <markers>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
+      </markers>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/stationkeeping_task.sdf
+++ b/vrx_gz/worlds/stationkeeping_task.sdf
@@ -728,8 +728,10 @@
       <release_topic>/vrx/release</release_topic>
       <!-- <head_error_on>false</head_error_on> -->
       <goal_pose>-33.722718 150.674031 0</goal_pose>
-      <!-- <goal_pose_cart>-532 162 1</goal_pose_cart> -->
-      <!-- <markers>true</markers> -->
+      <markers>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
+      </markers>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/wayfinding_task.sdf
+++ b/vrx_gz/worlds/wayfinding_task.sdf
@@ -736,8 +736,8 @@
         </waypoint>
       </waypoints>
       <markers>
-        <scaling>0.2 0.2 2.0 </scaling>
-        <height>0.5 </height>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
       </markers>
 
       <task_info_topic>/vrx/task/info</task_info_topic>


### PR DESCRIPTION
Fixes #596.

This PR restores the support to overlay a 3D marker on the scene. 

**Known limitations:** 
* Currently, it's not possible to render a `TEXT` marker. See [this open issue](https://github.com/gazebosim/gz-rendering/issues/487).
* It's not possible to pass a _text_ material like in Gazebo classic (`Gazebo/Red`). Instead, it's possible to set ambient and diffuse values. I decided not to expose it as it seems that we're always using the same color for the markers. Let me know otherwise and we could expose it.

### How to test it?

Launch one of the stationkeeping/wayfinding world and check that a white marker shows up. Example:

```
ros2 launch vrx_gz competition.launch.py world:=practice_2022_stationkeeping2_task
```

![Screenshot from 2023-02-20 20-13-55](https://user-images.githubusercontent.com/1440739/220183973-e838e3ed-81ce-401f-8ad5-295de3cb6fdf.png)

