### PR TITLE
removing underscore from stationkeeping task name

### DIFF
--- a/vrx_gz/worlds/2022_practice/practice_2022_stationkeeping0_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_stationkeeping0_task.sdf
@@ -575,7 +575,7 @@
       filename="libStationkeepingScoringPlugin.so"
       name="vrx::StationkeepingScoringPlugin">
       <vehicle>wamv</vehicle>
-      <task_name>station_keeping</task_name>
+      <task_name>stationkeeping</task_name>
       <task_info_topic>/vrx/task/info</task_info_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>

--- a/vrx_gz/worlds/2022_practice/practice_2022_stationkeeping1_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_stationkeeping1_task.sdf
@@ -575,7 +575,7 @@
       filename="libStationkeepingScoringPlugin.so"
       name="vrx::StationkeepingScoringPlugin">
       <vehicle>wamv</vehicle>
-      <task_name>station_keeping</task_name>
+      <task_name>stationkeeping</task_name>
       <task_info_topic>/vrx/task/info</task_info_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>

--- a/vrx_gz/worlds/2022_practice/practice_2022_stationkeeping2_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_stationkeeping2_task.sdf
@@ -575,7 +575,7 @@
       filename="libStationkeepingScoringPlugin.so"
       name="vrx::StationkeepingScoringPlugin">
       <vehicle>wamv</vehicle>
-      <task_name>station_keeping</task_name>
+      <task_name>stationkeeping</task_name>
       <task_info_topic>/vrx/task/info</task_info_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>

--- a/vrx_gz/worlds/stationkeeping_task.sdf
+++ b/vrx_gz/worlds/stationkeeping_task.sdf
@@ -629,7 +629,7 @@
       filename="libStationkeepingScoringPlugin.so"
       name="vrx::StationkeepingScoringPlugin">
       <vehicle>wamv</vehicle>
-      <task_name>station_keeping</task_name>
+      <task_name>stationkeeping</task_name>
       <task_info_topic>/vrx/task/info</task_info_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>


### PR DESCRIPTION
To review:

Inspect code to verify that `stationkeeping` is now spelled without an underscore everywhere.

Optionally, test the 4 stationkeeping_task worlds to make sure we aren't overlooking anything.