### PR TITLE
Use separate topics to publish animal poses

### DIFF
--- a/vrx_gz/src/WildlifeScoringPlugin.cc
+++ b/vrx_gz/src/WildlifeScoringPlugin.cc
@@ -15,7 +15,7 @@
  *
 */
 
-#include <gz/msgs/param_v.pb.h>
+#include <gz/msgs/pose.pb.h>
 #include <memory>
 #include <string>
 #include <vector>
@@ -468,7 +468,7 @@ class WildlifeScoringPlugin::Implementation
   public: std::vector<Buoy> buoys;
 
   /// \brief The name of the topic where the animal locations are published.
-  public: std::string animalsTopic = "/vrx/wildlife_animals";
+  public: std::string topicPrefix = "/vrx/wildlife/animal";
 
   /// \brief Time bonus granted for each goal achieved.
   public: double timeBonus = 30.0;
@@ -480,8 +480,8 @@ class WildlifeScoringPlugin::Implementation
   /// \brief Transport node.
   public: transport::Node node;
 
-  /// \brief Publisher for the animal locations.
-  public: transport::Node::Publisher animalsPub;
+  /// \brief Vector of publishers for the animal locations.
+  public: std::vector<transport::Node::Publisher> animalPubs;
 
   /// \brief True when a vehicle collision is detected.
   public: std::atomic<bool> collisionDetected{false};
@@ -513,9 +513,9 @@ void WildlifeScoringPlugin::Configure(const sim::Entity &_entity,
   sim::World world(worldEntity);
   this->dataPtr->sc = world.SphericalCoordinates(_ecm).value();
 
-  // Parse the optional <animals_topic> element.
-  if (_sdf->HasElement("animals_topic"))
-    this->dataPtr->animalsTopic = _sdf->Get<std::string>("animals_topic");
+  // Parse the optional <topic_prefix> element.
+  if (_sdf->HasElement("topic_prefix"))
+    this->dataPtr->topicPrefix = _sdf->Get<std::string>("topic_prefix");
 
   // Parse the optional <engagement_distance> element.
   if (_sdf->HasElement("engagement_distance"))
@@ -529,10 +529,6 @@ void WildlifeScoringPlugin::Configure(const sim::Entity &_entity,
     this->dataPtr->timeBonus = _sdf->Get<double>("time_bonus");
 
   gzmsg << "Task [" << this->TaskName() << "]" << std::endl;
-
-  // Setup publisher.
-  this->dataPtr->animalsPub =
-    this->dataPtr->node.Advertise<msgs::Param_V>(this->dataPtr->animalsTopic);
 }
 
 //////////////////////////////////////////////////
@@ -557,6 +553,14 @@ void WildlifeScoringPlugin::PreUpdate(const sim::UpdateInfo &_info,
         gzerr << "Score has been disabled" << std::endl;
         return;
       }
+
+      // Advertise the topic for each animal.
+      for (auto i = 0; i < this->dataPtr->buoys.size(); ++i)
+      {
+        auto topic = this->dataPtr->topicPrefix + std::to_string(i) + "/pose";
+        this->dataPtr->animalPubs.push_back(
+          this->dataPtr->node.Advertise<msgs::Pose>(topic));
+      };
     }
   }
 
@@ -696,11 +700,9 @@ bool WildlifeScoringPlugin::Implementation::AddBuoy(const std::string &_name,
 void WildlifeScoringPlugin::Implementation::PublishAnimalLocations(
   const sim::UpdateInfo &_info, sim::EntityComponentManager &_ecm)
 {
-  msgs::Param_V geoPathMsg;
-
   auto stamp = sim::convert<msgs::Time>(_info.simTime);
-  geoPathMsg.mutable_header()->mutable_stamp()->CopyFrom(stamp);
 
+  uint8_t i = 0u;
   for (auto const &buoy : this->buoys)
   {
     // Conversion from Gazebo Cartesian coordinates to spherical.
@@ -723,60 +725,36 @@ void WildlifeScoringPlugin::Implementation::PublishAnimalLocations(
     const math::Quaternion<double> orientation = pose.Rot();
 
     // Fill the message.
-    auto *animal = geoPathMsg.add_param();
-    auto *param = animal->mutable_params();
+    msgs::Pose geoPoseMsg;
 
-    msgs::Any positionXValue;
-    positionXValue.set_type(msgs::Any_ValueType::Any_ValueType_DOUBLE);
-    positionXValue.set_double_value(latlon.X());
-    (*param)["position_x"] = positionXValue;
+    // header->stamp
+    geoPoseMsg.mutable_header()->mutable_stamp()->CopyFrom(stamp);
 
-    msgs::Any positionYValue;
-    positionYValue.set_type(msgs::Any_ValueType::Any_ValueType_DOUBLE);
-    positionYValue.set_double_value(latlon.Y());
-    (*param)["position_y"] = positionYValue;
+    // header->frame_id - We set the buoy type based on its goal.
+    auto frame = geoPoseMsg.mutable_header()->add_data();
+    frame->set_key("frame_id");
 
-    msgs::Any positionZValue;
-    positionZValue.set_type(msgs::Any_ValueType::Any_ValueType_DOUBLE);
-    positionZValue.set_double_value(latlon.Z());
-    (*param)["position_z"] = positionZValue;
-
-    msgs::Any orientationXValue;
-    orientationXValue.set_type(msgs::Any_ValueType::Any_ValueType_DOUBLE);
-    orientationXValue.set_double_value(orientation.X());
-    (*param)["orientation_x"] = orientationXValue;
-
-    msgs::Any orientationYValue;
-    orientationYValue.set_type(msgs::Any_ValueType::Any_ValueType_DOUBLE);
-    orientationYValue.set_double_value(orientation.Y());
-    (*param)["orientation_y"] = orientationYValue;
-
-    msgs::Any orientationZValue;
-    orientationZValue.set_type(msgs::Any_ValueType::Any_ValueType_DOUBLE);
-    orientationZValue.set_double_value(orientation.Z());
-    (*param)["orientation_z"] = orientationZValue;
-
-    msgs::Any orientationWValue;
-    orientationWValue.set_type(msgs::Any_ValueType::Any_ValueType_DOUBLE);
-    orientationWValue.set_double_value(orientation.W());
-    (*param)["orientation_w"] = orientationWValue;
-
-    msgs::Any nameValue;
-    nameValue.set_type(msgs::Any_ValueType::Any_ValueType_STRING);
-    
     if (buoy.goal == BuoyGoal::AVOID)
-      nameValue.set_string_value("crocodile");
+      frame->add_value("crocodile");
     else if (buoy.goal == BuoyGoal::CIRCUMNAVIGATE_CLOCKWISE)
-      nameValue.set_string_value("platypus");
+      frame->add_value("platypus");
     else if (buoy.goal == BuoyGoal::CIRCUMNAVIGATE_COUNTERCLOCKWISE)
-      nameValue.set_string_value("turtle");
+      frame->add_value("turtle");
     else
-      nameValue.set_string_value("unknown");
+      frame->add_value("unknown");
 
-    (*param)["type"] = nameValue;
+    // pose
+    geoPoseMsg.mutable_position()->set_x(latlon.X());
+    geoPoseMsg.mutable_position()->set_y(latlon.Y());
+    geoPoseMsg.mutable_position()->set_z(latlon.Z());
+    geoPoseMsg.mutable_orientation()->set_x(orientation.X());
+    geoPoseMsg.mutable_orientation()->set_y(orientation.Y());
+    geoPoseMsg.mutable_orientation()->set_z(orientation.Z());
+    geoPoseMsg.mutable_orientation()->set_w(orientation.W());
+
+    this->animalPubs[i].Publish(geoPoseMsg);
+    ++i;
   }
-
-  this->animalsPub.Publish(geoPathMsg);
 }
 
 //////////////////////////////////////////////////

--- a/vrx_gz/src/WildlifeScoringPlugin.hh
+++ b/vrx_gz/src/WildlifeScoringPlugin.hh
@@ -36,8 +36,12 @@ namespace vrx
   ///
   /// * Optional parameters
   ///
-  /// <animals_topic>: The topic that publishes the animal poses.
-  ///                  Defaults to "/vrx/wildlife/animals/poses"
+  /// <topic_prefix>: The topic prefix used to publish an animal pose.
+  ///                 Defaults to "/vrx/wildlife/animal". The final topic will
+  ///                 be constructed by appending a numeric index
+  ///                 starting from 0, followed by "/pose".
+  ///                 E.g. of final topic: "/vrx/wildfile/animal0/pose"
+  ///                 Note that this topic will be advertised for each animal.
   /// <buoys>: Specifies the collection of buoys to circumnavigate, avoid, etc.
   ///
   ///   <buoy>: A buoy to circumnavigate, avoid.
@@ -79,7 +83,7 @@ namespace vrx
   ///   </buoys>
   ///   <engagement_distance>10.0</engagement_distance>
   ///   <time_bonus>30.0</time_bonus>
-  ///   <animals_topic>/vrx/wildlife/animals/poses</animals_topic>
+  ///   <topic_prefix>/vrx/wildlife/animal</topic_prefix>
   /// <plugin>
   class WildlifeScoringPlugin : public ScoringPlugin
   {

--- a/vrx_gz/src/vrx_gz/bridges.py
+++ b/vrx_gz/src/vrx_gz/bridges.py
@@ -166,12 +166,12 @@ def perception_reports():
         ros_type='geometry_msgs/msg/PoseStamped',
         direction=BridgeDirection.ROS_TO_GZ)
 
-def animal_poses():
+def animal_pose(topic):
     return Bridge(
-        gz_topic=f'/vrx/wildlife/animals/poses',
-        ros_topic=f'/vrx/wildlife/animals/poses',
-        gz_type='ignition.msgs.Param_V',
-        ros_type='ros_gz_interfaces/msg/ParamVec',
+        gz_topic=f'{topic}',
+        ros_topic=f'{topic}',
+        gz_type='ignition.msgs.Pose',
+        ros_type='geometry_msgs/msg/PoseStamped',
         direction=BridgeDirection.GZ_TO_ROS)
 
 def gymkhana_blackbox_goal():

--- a/vrx_gz/src/vrx_gz/launch.py
+++ b/vrx_gz/src/vrx_gz/launch.py
@@ -149,7 +149,9 @@ def competition_bridges(world_name):
         ]
     elif world_name in WILDLIFE_WORLDS:
         task_bridges = [
-            vrx_gz.bridges.animal_poses(),
+            vrx_gz.bridges.animal_pose('/vrx/wildlife/animal0/pose'),
+            vrx_gz.bridges.animal_pose('/vrx/wildlife/animal1/pose'),
+            vrx_gz.bridges.animal_pose('/vrx/wildlife/animal2/pose'),
         ]
     elif world_name in SCAN_DOCK_DELIVER_WORLDS:
         task_bridges = [

--- a/vrx_gz/worlds/2022_practice/practice_2022_wildlife0_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_wildlife0_task.sdf
@@ -714,7 +714,7 @@
       </buoys>
       <engagement_distance>10.0</engagement_distance>
       <time_bonus>30.0</time_bonus>
-      <animals_topic>/vrx/wildlife/animals/poses</animals_topic>
+      <topic_prefix>/vrx/wildlife/animal</topic_prefix>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2022_practice/practice_2022_wildlife1_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_wildlife1_task.sdf
@@ -714,7 +714,7 @@
       </buoys>
       <engagement_distance>10.0</engagement_distance>
       <time_bonus>30.0</time_bonus>
-      <animals_topic>/vrx/wildlife/animals/poses</animals_topic>
+      <topic_prefix>/vrx/wildlife/animal</topic_prefix>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2022_practice/practice_2022_wildlife2_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_wildlife2_task.sdf
@@ -714,7 +714,7 @@
       </buoys>
       <engagement_distance>10.0</engagement_distance>
       <time_bonus>30.0</time_bonus>
-      <animals_topic>/vrx/wildlife/animals/poses</animals_topic>
+      <topic_prefix>/vrx/wildlife/animal</topic_prefix>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/wildlife_task.sdf
+++ b/vrx_gz/worlds/wildlife_task.sdf
@@ -608,7 +608,7 @@
       </buoys>
       <engagement_distance>10.0</engagement_distance>
       <time_bonus>30.0</time_bonus>
-      <animals_topic>/vrx/wildlife/animals/poses</animals_topic>
+      <topic_prefix>/vrx/wildlife/animal</topic_prefix>
     </plugin>
 
     <!-- The wave field -->


### PR DESCRIPTION
This patch modifies the way we're publishing the animal poses in the wildlife task. Instead of publishing all the animals in a single topic but with a complicated message type, we now use multiple topics with a simple message type.

The new message type is `gz.msgs.Pose` in the Gazebo side and `geometry_msgs/msg/PoseStamped` in the ROS 2 side.

The new topics are:
```
/vrx/wildlife/animal0/pose
/vrx/wildlife/animal1/pose
/vrx/wildlife/animal2/pose
```

### How to test it?

Launch any of the wildlife task worlds. E.g.:
```
 ros2 launch vrx_gz competition.launch.py world:=practice_2022_wildlife0_task
```

In a separate terminal, run:
```
ros2 topic echo /vrx/wildlife/animal0/pose
```

You should get messages similar to:
```
---
header:
  stamp:
    sec: 30
    nanosec: 840000000
  frame_id: crocodile
pose:
  position:
    x: -33.722606181379355
    y: 150.67410482692787
    z: -0.018011017702519894
  orientation:
    x: -0.001717489220954667
    y: -0.0002733092516185349
    z: 0.9870658578174363
    w: -0.16030585723534135
---
```

Repeat the previous command for the topics `/vrx/wildlife/animal1/pos` and `/vrx/wildlife/animal2/pos`. Verify that the `frame_id` field changes to `platypus` and `turtle` respectively. 
