### PR TITLE
Update Follow-the-path scoring

### DIFF
--- a/vrx_gz/config/wamv.yaml
+++ b/vrx_gz/config/wamv.yaml
@@ -83,7 +83,7 @@ joy_teleop:
       axis_mappings:
         data:
           axis: 1
-          scale: 400.0
+          scale: 1000.0
           offset: 0
 
     right_thrust:
@@ -94,7 +94,7 @@ joy_teleop:
       axis_mappings:
         data:
           axis: 3
-          scale: 400.0
+          scale: 1000.0
           offset: 0
 
     left_pos:

--- a/vrx_gz/src/LightBuoyPlugin.hh
+++ b/vrx_gz/src/LightBuoyPlugin.hh
@@ -51,7 +51,7 @@ namespace vrx
       public gz::sim::ISystemConfigure,
       public gz::sim::ISystemPreUpdate
   {
-    // \brief Constructor
+    /// \brief Constructor
     public: LightBuoyPlugin();
 
     /// \brief Destructor.

--- a/vrx_gz/src/NavigationScoringPlugin.cc
+++ b/vrx_gz/src/NavigationScoringPlugin.cc
@@ -136,7 +136,7 @@ class NavigationScoringPlugin::Implementation
   /// \brief Number of points granted for crossing any gate.
   public: double pointsPerGateCrossed = 10.0;
 
-  /// \brief Bonus points granted for crossing a consecutive gate.
+  /// \brief Bonus points granted for crossing two consecutive gates.
   public: double bonusConsecutiveGate = 1.0;
 
   /// \brief Display or suppress state changes
@@ -476,10 +476,10 @@ void NavigationScoringPlugin::PreUpdate( const sim::UpdateInfo &_info,
       // Add the fix number of points for crossing a gate.
       this->SetScore(this->Score() + this->dataPtr->pointsPerGateCrossed);
 
-      // Add a bonus for crossing a consecutive gate.
+      // Add a bonus for crossing two consecutive gates.
       if (i == this->dataPtr->lastGateCrossed + 1)
       {
-        gzdbg << "  Consecutive gate!" << std::endl;
+        gzdbg << "  Consecutive gate bonus!" << std::endl;
 
         this->SetScore(this->Score() + this->dataPtr->bonusConsecutiveGate);
       }

--- a/vrx_gz/src/NavigationScoringPlugin.cc
+++ b/vrx_gz/src/NavigationScoringPlugin.cc
@@ -517,7 +517,7 @@ void NavigationScoringPlugin::PreUpdate( const sim::UpdateInfo &_info,
           i == this->dataPtr->lastGateCrossed + 1)
       {
         gzdbg << "Num consecutive gates: "
-              << this->dataPtr->currentConsecutiveGatesCrossed << std::endl;
+              << this->dataPtr->currentConsecutiveGatesCrossed + 1 << std::endl;
 
         double bonus = this->dataPtr->bonuses.back();
         if (this->dataPtr->currentConsecutiveGatesCrossed <

--- a/vrx_gz/src/NavigationScoringPlugin.cc
+++ b/vrx_gz/src/NavigationScoringPlugin.cc
@@ -145,8 +145,8 @@ class NavigationScoringPlugin::Implementation
   /// \brief The index of the last gate crossed.
   public: int lastGateCrossed = -1;
 
-  /// \brief The index of the last successfully gate crossed.
-  public: int lastSuccessfullyGateCrossed = std::numeric_limits<int>::min();
+  /// \brief The index of the last gate successfully crossed.
+  public: int lastGateSuccessfullyCrossed = std::numeric_limits<int>::min();
 
   /// \brief Previous number of collisions.
   public: int prevCollisions = 0;
@@ -481,14 +481,14 @@ void NavigationScoringPlugin::PreUpdate( const sim::UpdateInfo &_info,
       this->SetScore(this->Score() + this->dataPtr->pointsPerGateCrossed);
 
       // Add a bonus for crossing two consecutive gates.
-      if (i != 0 && i == this->dataPtr->lastSuccessfullyGateCrossed + 1)
+      if (i != 0 && i == this->dataPtr->lastGateSuccessfullyCrossed + 1)
       {
         gzdbg << "  Consecutive gate bonus!" << std::endl;
         this->SetScore(this->Score() + this->dataPtr->bonusConsecutiveGate);
       }
 
       this->dataPtr->lastGateCrossed = i;
-      this->dataPtr->lastSuccessfullyGateCrossed = i;
+      this->dataPtr->lastGateSuccessfullyCrossed = i;
 
       gzdbg << "Score: " << this->Score() << std::endl;
       std::cout << std::flush;
@@ -515,7 +515,7 @@ void NavigationScoringPlugin::PreUpdate( const sim::UpdateInfo &_info,
       gzdbg << "Transited the gate in the wrong direction. Gate invalidated!"
             << std::endl;
       std::cout << std::flush;
-      this->dataPtr->lastSuccessfullyGateCrossed =
+      this->dataPtr->lastGateSuccessfullyCrossed =
         std::numeric_limits<int>::min();
       this->dataPtr->lastGateCrossed = i;
 

--- a/vrx_gz/src/NavigationScoringPlugin.cc
+++ b/vrx_gz/src/NavigationScoringPlugin.cc
@@ -137,7 +137,7 @@ class NavigationScoringPlugin::Implementation
   public: double pointsPerGateCrossed = 10.0;
 
   /// \brief Bonus points granted for crossing a consecutive gate.
-  public: double bonusConsecutiveGate = 10.0;
+  public: double bonusConsecutiveGate = 1.0;
 
   /// \brief Display or suppress state changes
   public: bool silent = false;

--- a/vrx_gz/src/NavigationScoringPlugin.hh
+++ b/vrx_gz/src/NavigationScoringPlugin.hh
@@ -32,7 +32,7 @@ namespace vrx
   ///
   /// <points_per_gate_crossed>: Number of points granted to cross any gate.
   /// <obstacle_penalty>: Specifies how many points are deducted per collision.
-  /// <gate_bonus>: ToDo.
+  /// <bonus>: Bonus granted after crossing a consecutive gate.
   /// <gates>: Specifies the collection of gates delimiting the course.
   ///
   ///   Each gate accepts the following elements:

--- a/vrx_gz/src/NavigationScoringPlugin.hh
+++ b/vrx_gz/src/NavigationScoringPlugin.hh
@@ -30,7 +30,9 @@ namespace vrx
   ///
   /// This plugin requires the following SDF parameters:
   ///
+  /// <points_per_gate_crossed>: Number of points granted to cross any gate.
   /// <obstacle_penalty>: Specifies how many points are deducted per collision.
+  /// <gate_bonus>: ToDo.
   /// <gates>: Specifies the collection of gates delimiting the course.
   ///
   ///   Each gate accepts the following elements:
@@ -50,7 +52,21 @@ namespace vrx
   ///   <vehicle>wamv</vehicle>
   ///   <task_name>navigation_scoring_plugin</task_name>
   ///   <course_name>vrx_navigation_course</course_name>
-  ///   <obstacle_penalty>10</obstable_penalty>
+  ///   <points_per_gate_crossed>10</points_per_gate_crossed>
+  ///   <obstacle_penalty>3</obstable_penalty>
+  ///   <gate_bonus>
+  ///     <gate>1</gate>
+  ///     <gate>2</gate>
+  ///     <gate>4</gate>
+  ///     <gate>7</gate>
+  ///     <gate>11</gate>
+  ///     <gate>16</gate>
+  ///     <gate>22</gate>
+  ///     <gate>29</gate>
+  ///     <gate>37</gate>
+  ///     <gate>46</gate>
+  ///     <gate>56</gate>
+  ///   </gate_bonus>
   ///   <gates>
   ///     <gate>
   ///       <left_marker>red_bound_0</left_marker>

--- a/vrx_gz/src/NavigationScoringPlugin.hh
+++ b/vrx_gz/src/NavigationScoringPlugin.hh
@@ -54,19 +54,7 @@ namespace vrx
   ///   <course_name>vrx_navigation_course</course_name>
   ///   <points_per_gate_crossed>10</points_per_gate_crossed>
   ///   <obstacle_penalty>3</obstable_penalty>
-  ///   <gate_bonus>
-  ///     <gate>1</gate>
-  ///     <gate>2</gate>
-  ///     <gate>4</gate>
-  ///     <gate>7</gate>
-  ///     <gate>11</gate>
-  ///     <gate>16</gate>
-  ///     <gate>22</gate>
-  ///     <gate>29</gate>
-  ///     <gate>37</gate>
-  ///     <gate>46</gate>
-  ///     <gate>56</gate>
-  ///   </gate_bonus>
+  ///   <bonus>1</bonus>
   ///   <gates>
   ///     <gate>
   ///       <left_marker>red_bound_0</left_marker>

--- a/vrx_gz/worlds/2022_practice/practice_2022_follow_path0_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_follow_path0_task.sdf
@@ -486,7 +486,7 @@
       <course_name>short_navigation_course_0</course_name>
       <points_per_gate_crossed>10</points_per_gate_crossed>
       <obstacle_penalty>3.0</obstacle_penalty>
-      <gate_bonus>
+      <bonus>
         <gate>1</gate>
         <gate>2</gate>
         <gate>4</gate>
@@ -498,7 +498,7 @@
         <gate>37</gate>
         <gate>46</gate>
         <gate>56</gate>
-      </gate_bonus>
+      </bonus>
       <gates>
         <gate>
           <left_marker>red_bound_0</left_marker>

--- a/vrx_gz/worlds/2022_practice/practice_2022_follow_path0_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_follow_path0_task.sdf
@@ -484,7 +484,21 @@
       <release_topic>/vrx/release</release_topic>
 
       <course_name>short_navigation_course_0</course_name>
-      <obstacle_penalty>10.0</obstacle_penalty>
+      <points_per_gate_crossed>10</points_per_gate_crossed>
+      <obstacle_penalty>3.0</obstacle_penalty>
+      <gate_bonus>
+        <gate>1</gate>
+        <gate>2</gate>
+        <gate>4</gate>
+        <gate>7</gate>
+        <gate>11</gate>
+        <gate>16</gate>
+        <gate>22</gate>
+        <gate>29</gate>
+        <gate>37</gate>
+        <gate>46</gate>
+        <gate>56</gate>
+      </gate_bonus>
       <gates>
         <gate>
           <left_marker>red_bound_0</left_marker>

--- a/vrx_gz/worlds/2022_practice/practice_2022_follow_path0_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_follow_path0_task.sdf
@@ -488,16 +488,16 @@
       <obstacle_penalty>3.0</obstacle_penalty>
       <bonus>
         <gate>1</gate>
-        <gate>2</gate>
-        <gate>4</gate>
+        <gate>3</gate>
+        <gate>5</gate>
         <gate>7</gate>
+        <gate>9</gate>
         <gate>11</gate>
-        <gate>16</gate>
-        <gate>22</gate>
-        <gate>29</gate>
-        <gate>37</gate>
-        <gate>46</gate>
-        <gate>56</gate>
+        <gate>13</gate>
+        <gate>15</gate>
+        <gate>17</gate>
+        <gate>19</gate>
+        <gate>21</gate>
       </bonus>
       <gates>
         <gate>

--- a/vrx_gz/worlds/2022_practice/practice_2022_follow_path0_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_follow_path0_task.sdf
@@ -486,19 +486,7 @@
       <course_name>short_navigation_course_0</course_name>
       <points_per_gate_crossed>10</points_per_gate_crossed>
       <obstacle_penalty>3.0</obstacle_penalty>
-      <bonus>
-        <gate>1</gate>
-        <gate>3</gate>
-        <gate>5</gate>
-        <gate>7</gate>
-        <gate>9</gate>
-        <gate>11</gate>
-        <gate>13</gate>
-        <gate>15</gate>
-        <gate>17</gate>
-        <gate>19</gate>
-        <gate>21</gate>
-      </bonus>
+      <bonus>1</bonus>
       <gates>
         <gate>
           <left_marker>red_bound_0</left_marker>

--- a/vrx_gz/worlds/2022_practice/practice_2022_follow_path1_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_follow_path1_task.sdf
@@ -486,7 +486,7 @@
       <course_name>short_navigation_course_1</course_name>
       <points_per_gate_crossed>10</points_per_gate_crossed>
       <obstacle_penalty>3.0</obstacle_penalty>
-      <gate_bonus>
+      <bonus>
         <gate>1</gate>
         <gate>2</gate>
         <gate>4</gate>
@@ -498,7 +498,7 @@
         <gate>37</gate>
         <gate>46</gate>
         <gate>56</gate>
-      </gate_bonus>
+      </bonus>
       <gates>
         <gate>
           <left_marker>red_bound_0</left_marker>

--- a/vrx_gz/worlds/2022_practice/practice_2022_follow_path1_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_follow_path1_task.sdf
@@ -484,7 +484,21 @@
       <release_topic>/vrx/release</release_topic>
 
       <course_name>short_navigation_course_1</course_name>
-      <obstacle_penalty>10.0</obstacle_penalty>
+      <points_per_gate_crossed>10</points_per_gate_crossed>
+      <obstacle_penalty>3.0</obstacle_penalty>
+      <gate_bonus>
+        <gate>1</gate>
+        <gate>2</gate>
+        <gate>4</gate>
+        <gate>7</gate>
+        <gate>11</gate>
+        <gate>16</gate>
+        <gate>22</gate>
+        <gate>29</gate>
+        <gate>37</gate>
+        <gate>46</gate>
+        <gate>56</gate>
+      </gate_bonus>
       <gates>
         <gate>
           <left_marker>red_bound_0</left_marker>

--- a/vrx_gz/worlds/2022_practice/practice_2022_follow_path1_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_follow_path1_task.sdf
@@ -485,20 +485,8 @@
 
       <course_name>short_navigation_course_1</course_name>
       <points_per_gate_crossed>10</points_per_gate_crossed>
+      <bonus>1</bonus>
       <obstacle_penalty>3.0</obstacle_penalty>
-      <bonus>
-        <gate>1</gate>
-        <gate>3</gate>
-        <gate>5</gate>
-        <gate>7</gate>
-        <gate>9</gate>
-        <gate>11</gate>
-        <gate>13</gate>
-        <gate>15</gate>
-        <gate>17</gate>
-        <gate>19</gate>
-        <gate>21</gate>
-      </bonus>
       <gates>
         <gate>
           <left_marker>red_bound_0</left_marker>

--- a/vrx_gz/worlds/2022_practice/practice_2022_follow_path1_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_follow_path1_task.sdf
@@ -488,16 +488,16 @@
       <obstacle_penalty>3.0</obstacle_penalty>
       <bonus>
         <gate>1</gate>
-        <gate>2</gate>
-        <gate>4</gate>
+        <gate>3</gate>
+        <gate>5</gate>
         <gate>7</gate>
+        <gate>9</gate>
         <gate>11</gate>
-        <gate>16</gate>
-        <gate>22</gate>
-        <gate>29</gate>
-        <gate>37</gate>
-        <gate>46</gate>
-        <gate>56</gate>
+        <gate>13</gate>
+        <gate>15</gate>
+        <gate>17</gate>
+        <gate>19</gate>
+        <gate>21</gate>
       </bonus>
       <gates>
         <gate>

--- a/vrx_gz/worlds/2022_practice/practice_2022_follow_path2_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_follow_path2_task.sdf
@@ -486,19 +486,7 @@
       <course_name>short_navigation_course_2</course_name>
       <points_per_gate_crossed>10</points_per_gate_crossed>
       <obstacle_penalty>3.0</obstacle_penalty>
-      <bonus>
-        <gate>1</gate>
-        <gate>3</gate>
-        <gate>5</gate>
-        <gate>7</gate>
-        <gate>9</gate>
-        <gate>11</gate>
-        <gate>13</gate>
-        <gate>15</gate>
-        <gate>17</gate>
-        <gate>19</gate>
-        <gate>21</gate>
-      </bonus>
+      <bonus>1</bonus>
       <gates>
         <gate>
           <left_marker>red_bound_0</left_marker>

--- a/vrx_gz/worlds/2022_practice/practice_2022_follow_path2_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_follow_path2_task.sdf
@@ -486,7 +486,7 @@
       <course_name>short_navigation_course_2</course_name>
       <points_per_gate_crossed>10</points_per_gate_crossed>
       <obstacle_penalty>3.0</obstacle_penalty>
-      <gate_bonus>
+      <bonus>
         <gate>1</gate>
         <gate>2</gate>
         <gate>4</gate>
@@ -498,7 +498,7 @@
         <gate>37</gate>
         <gate>46</gate>
         <gate>56</gate>
-      </gate_bonus>
+      </bonus>
       <gates>
         <gate>
           <left_marker>red_bound_0</left_marker>

--- a/vrx_gz/worlds/2022_practice/practice_2022_follow_path2_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_follow_path2_task.sdf
@@ -484,7 +484,21 @@
       <release_topic>/vrx/release</release_topic>
 
       <course_name>short_navigation_course_2</course_name>
-      <obstacle_penalty>10.0</obstacle_penalty>
+      <points_per_gate_crossed>10</points_per_gate_crossed>
+      <obstacle_penalty>3.0</obstacle_penalty>
+      <gate_bonus>
+        <gate>1</gate>
+        <gate>2</gate>
+        <gate>4</gate>
+        <gate>7</gate>
+        <gate>11</gate>
+        <gate>16</gate>
+        <gate>22</gate>
+        <gate>29</gate>
+        <gate>37</gate>
+        <gate>46</gate>
+        <gate>56</gate>
+      </gate_bonus>
       <gates>
         <gate>
           <left_marker>red_bound_0</left_marker>

--- a/vrx_gz/worlds/2022_practice/practice_2022_follow_path2_task.sdf
+++ b/vrx_gz/worlds/2022_practice/practice_2022_follow_path2_task.sdf
@@ -488,16 +488,16 @@
       <obstacle_penalty>3.0</obstacle_penalty>
       <bonus>
         <gate>1</gate>
-        <gate>2</gate>
-        <gate>4</gate>
+        <gate>3</gate>
+        <gate>5</gate>
         <gate>7</gate>
+        <gate>9</gate>
         <gate>11</gate>
-        <gate>16</gate>
-        <gate>22</gate>
-        <gate>29</gate>
-        <gate>37</gate>
-        <gate>46</gate>
-        <gate>56</gate>
+        <gate>13</gate>
+        <gate>15</gate>
+        <gate>17</gate>
+        <gate>19</gate>
+        <gate>21</gate>
       </bonus>
       <gates>
         <gate>

--- a/vrx_gz/worlds/follow_path_task.sdf
+++ b/vrx_gz/worlds/follow_path_task.sdf
@@ -486,7 +486,7 @@
       <course_name>short_navigation_course_0</course_name>
       <points_per_gate_crossed>10</points_per_gate_crossed>
       <obstacle_penalty>3.0</obstacle_penalty>
-      <gate_bonus>
+      <bonus>
         <gate>1</gate>
         <gate>2</gate>
         <gate>4</gate>
@@ -498,7 +498,7 @@
         <gate>37</gate>
         <gate>46</gate>
         <gate>56</gate>
-      </gate_bonus>
+      </bonus>
       <gates>
         <gate>
           <left_marker>red_bound_0</left_marker>

--- a/vrx_gz/worlds/follow_path_task.sdf
+++ b/vrx_gz/worlds/follow_path_task.sdf
@@ -484,7 +484,22 @@
       <release_topic>/vrx/release</release_topic>
 
       <course_name>short_navigation_course_0</course_name>
-      <obstacle_penalty>10.0</obstacle_penalty>
+      <points_per_gate_crossed>10</points_per_gate_crossed>
+      <obstacle_penalty>3.0</obstacle_penalty>
+      <gate_bonus>
+        <gate>0</gate>
+        <gate>1</gate>
+        <gate>2</gate>
+        <gate>4</gate>
+        <gate>7</gate>
+        <gate>11</gate>
+        <gate>16</gate>
+        <gate>22</gate>
+        <gate>29</gate>
+        <gate>37</gate>
+        <gate>46</gate>
+        <gate>56</gate>
+      </gate_bonus>
       <gates>
         <gate>
           <left_marker>red_bound_0</left_marker>

--- a/vrx_gz/worlds/follow_path_task.sdf
+++ b/vrx_gz/worlds/follow_path_task.sdf
@@ -487,7 +487,6 @@
       <points_per_gate_crossed>10</points_per_gate_crossed>
       <obstacle_penalty>3.0</obstacle_penalty>
       <gate_bonus>
-        <gate>0</gate>
         <gate>1</gate>
         <gate>2</gate>
         <gate>4</gate>

--- a/vrx_gz/worlds/follow_path_task.sdf
+++ b/vrx_gz/worlds/follow_path_task.sdf
@@ -488,16 +488,16 @@
       <obstacle_penalty>3.0</obstacle_penalty>
       <bonus>
         <gate>1</gate>
-        <gate>2</gate>
-        <gate>4</gate>
+        <gate>3</gate>
+        <gate>5</gate>
         <gate>7</gate>
+        <gate>9</gate>
         <gate>11</gate>
-        <gate>16</gate>
-        <gate>22</gate>
-        <gate>29</gate>
-        <gate>37</gate>
-        <gate>46</gate>
-        <gate>56</gate>
+        <gate>13</gate>
+        <gate>15</gate>
+        <gate>17</gate>
+        <gate>19</gate>
+        <gate>21</gate>
       </bonus>
       <gates>
         <gate>

--- a/vrx_gz/worlds/follow_path_task.sdf
+++ b/vrx_gz/worlds/follow_path_task.sdf
@@ -486,19 +486,7 @@
       <course_name>short_navigation_course_0</course_name>
       <points_per_gate_crossed>10</points_per_gate_crossed>
       <obstacle_penalty>3.0</obstacle_penalty>
-      <bonus>
-        <gate>1</gate>
-        <gate>3</gate>
-        <gate>5</gate>
-        <gate>7</gate>
-        <gate>9</gate>
-        <gate>11</gate>
-        <gate>13</gate>
-        <gate>15</gate>
-        <gate>17</gate>
-        <gate>19</gate>
-        <gate>21</gate>
-      </bonus>
+      <bonus>1</bonus>
       <gates>
         <gate>
           <left_marker>red_bound_0</left_marker>


### PR DESCRIPTION
Fixes #623 .

This patch updates the Follow-the-path task according to the discussion in issue #623 .

### How to test it?

Launch the teleoperation node:
```
ros2 launch vrx_gz usv_joy_teleop.py
```

Launch a practice world. E.g.:
```
ros2 launch vrx_gz competition.launch.py world:=practice_2022_follow_path2_task
```

Verify the following things:

* Make sure that if you skip the first gate, nothing happens (no gates crossed or invalid reported on the console).
* Cross the starting gate (`+10` points).
* Make sure that if you cross another gate you get `10` points + a bonus. The bonus is declared as a parameter in the SDF.
* Make sure that if you skip a gate, you'll get 10 points for crossing the next gate and no bonus.
* Make sure that if you invalidate a gate (crossing it backwards), it no longer produces points even if you later cross it properly.
* Make sure that when you cross the last gate, the task terminates.
* Make sure that if you hit an obstacle, you get a penalty of `-3` points.

Some notes:

* I bumped the teleoperation speed a bit.
* I left a few `gzdbg` in the plugin to help us debug the bonuses, penalties, etc.