### PR TITLE
`generate_wamv.py` should not produce a compliance error on an empty WAMV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     container: 
       image: npslearninglab/watery_robots:humble_current
+      options: --user root
     steps:
       - run: sudo chown -R `whoami`:`whoami` .
       - name: Checkout vrx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Ubuntu CI
 on: [pull_request]
 
 jobs:
-  test-fortress-galactic:
+  test-humble-garden:
 
     runs-on: ubuntu-20.04
     container: 
@@ -11,13 +11,13 @@ jobs:
     steps:
       - run: sudo chown -R `whoami`:`whoami` .
       - name: Checkout vrx
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
         with:
             ref: main
             path: vrx
 
       - name: Checkout Gazebosim 
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
         with:
             repository: gazebosim/ros_gz
             ref: humble

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   test-humble-garden:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: 
       image: npslearninglab/watery_robots:humble_current
     steps:

--- a/vrx_urdf/vrx_gazebo/src/vrx_gazebo/utils.py
+++ b/vrx_urdf/vrx_gazebo/src/vrx_gazebo/utils.py
@@ -41,7 +41,7 @@ def create_xacro_file(xacro_target,
         if requested_macros is None:
             xacro_file.write(boiler_plate_bot)
             xacro_file.close()
-            return
+            return True
 
     # Object must be available
     for key, objects in requested_macros.items():


### PR DESCRIPTION
This fixes issue #640

To test, follow this tutorial: https://github.com/osrf/vrx/wiki/empty_wamv_tutorial

Make sure there is no error message in the output; i.e. after running
```
ros2 launch vrx_gazebo generate_wamv.launch.py component_yaml:=`pwd`/empty_component_config.yaml thruster_yaml:=`pwd`/empty_thruster_config.yaml wamv_target:=`pwd`/wamv_target.urdf wamv_locked:=False
```
you should NOT see:
```
[generate_wamv.py-1] [ERROR] [1683911879.733853761] [configure_wamv]: 
[generate_wamv.py-1] This component/thruster configuration is NOT compliant with the (current) VRX constraints. A urdf file will be created, but please note that the above errors must be fixed for this to be a valid configuration for the VRX competition.
```