### PR TITLE
Rename 2022_practice worlds to 2023_practice

### DIFF
--- a/vrx_gz/hooks/resource_paths.dsv.in
+++ b/vrx_gz/hooks/resource_paths.dsv.in
@@ -1,5 +1,5 @@
 prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;@CMAKE_INSTALL_PREFIX@/share/@PROJECT_NAME@/worlds
-prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;@CMAKE_INSTALL_PREFIX@/share/@PROJECT_NAME@/worlds/2022_practice
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;@CMAKE_INSTALL_PREFIX@/share/@PROJECT_NAME@/worlds/2023_practice
 prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;@CMAKE_INSTALL_PREFIX@/share/@PROJECT_NAME@/models
 prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;@CMAKE_INSTALL_PREFIX@/share/@PROJECT_NAME@/models/tmp
 prepend-non-duplicate;GZ_SIM_SYSTEM_PLUGIN_PATH;@CMAKE_INSTALL_PREFIX@/lib

--- a/vrx_gz/hooks/resource_paths.sh
+++ b/vrx_gz/hooks/resource_paths.sh
@@ -1,5 +1,5 @@
 ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/vrx_gz/worlds"
-ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/vrx_gz/worlds/2022_practice"
+ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/vrx_gz/worlds/2023_practice"
 ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/vrx_gz/models"
 ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/vrx_gz/models/tmp"
 ament_prepend_unique_value GZ_SIM_SYSTEM_PLUGIN_PATH "$AMENT_CURRENT_PREFIX/lib"

--- a/vrx_gz/src/vrx_gz/launch.py
+++ b/vrx_gz/src/vrx_gz/launch.py
@@ -36,51 +36,51 @@ GYMKHANA_WORLDS = [
 
 PERCEPTION_WORLDS = [
   'perception_task',
-  'practice_2022_perception0_task',
-  'practice_2022_perception1_task',
-  'practice_2022_perception2_task'
+  'practice_2023_perception0_task',
+  'practice_2023_perception1_task',
+  'practice_2023_perception2_task'
 ]
 
 STATIONKEEPING_WORLDS = [
   'stationkeeping_task',
-  'practice_2022_stationkeeping0_task',
-  'practice_2022_stationkeeping1_task',
-  'practice_2022_stationkeeping2_task',
+  'practice_2023_stationkeeping0_task',
+  'practice_2023_stationkeeping1_task',
+  'practice_2023_stationkeeping2_task',
 ]
 
 WAYFINDING_WORLDS = [
   'wayfinding_task',
-  'practice_2022_wayfinding0_task',
-  'practice_2022_wayfinding1_task',
-  'practice_2022_wayfinding2_task',
+  'practice_2023_wayfinding0_task',
+  'practice_2023_wayfinding1_task',
+  'practice_2023_wayfinding2_task',
 ]
 
 WILDLIFE_WORLDS = [
   'wildlife_task',
-  'practice_2022_wildlife0_task',
-  'practice_2022_wildlife1_task',
-  'practice_2022_wildlife2_task'
+  'practice_2023_wildlife0_task',
+  'practice_2023_wildlife1_task',
+  'practice_2023_wildlife2_task'
 ]
 
 SCAN_DOCK_DELIVER_WORLDS = [
   'scan_dock_deliver_task',
-  'practice_2022_scan_dock_deliver0_task',
-  'practice_2022_scan_dock_deliver1_task',
-  'practice_2022_scan_dock_deliver2_task'
+  'practice_2023_scan_dock_deliver0_task',
+  'practice_2023_scan_dock_deliver1_task',
+  'practice_2023_scan_dock_deliver2_task'
 ]
 
 ACOUSTIC_TRACKING_WORLDS = [
   'acoustic_tracking_task',
-  'practice_2022_acoustic_tracking0_task',
-  'practice_2022_acoustic_tracking1_task',
-  'practice_2022_acoustic_tracking2_task'
+  'practice_2023_acoustic_tracking0_task',
+  'practice_2023_acoustic_tracking1_task',
+  'practice_2023_acoustic_tracking2_task'
 ]
 
 FOLLOWPATH_WORLDS = [
   'follow_path_task',
-  'practice_2022_follow_path0_task',
-  'practice_2022_follow_path1_task',
-  'practice_2022_follow_path2_task'
+  'practice_2023_follow_path0_task',
+  'practice_2023_follow_path1_task',
+  'practice_2023_follow_path2_task'
 ]
 
 def simulation(world_name, headless=False):

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception0_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_perception2_task">
+  <world name="practice_2023_acoustic_perception0_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -423,557 +423,56 @@
       </plugin>
     </include>
 
+
+    <!-- Publish the pinger pose -->
+    <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
+      <message type="gz.msgs.Vector3d" topic="/wamv/pingers/pinger/set_pinger_position" at="1.0">
+        x: -560,
+        y: 185,
+        z: -2
+      </message>
+    </plugin>
+
+    <!-- The acoustic perception scoring plugin -->
+    <plugin
+      filename="libAcousticPerceptionScoringPlugin.so"
+      name="vrx::AcousticPerceptionScoringPlugin">
+      <vehicle>wamv</vehicle>
+      <task_name>acoustic_perception</task_name>
+      <contact_debug_topic>/vrx/acoustic_perception/debug/contact</contact_debug_topic>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_topic>/vrx/release</release_topic>      
+      <goal_tolerance>3</goal_tolerance>
+      <pinger_position>-560 185 -2</pinger_position>
+      <markers>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
+      </markers>
+    </plugin>
+
     <!-- Load the plugin for the wind -->
     <plugin
-      filename="libUSVWind.so"
+       filename="libUSVWind.so"
       name="vrx::USVWind">
-      <!-- models to be effected by the wind -->
+     <!-- models to be effected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
-        <coeff_vector> .5 .5 .33</coeff_vector>
+        <coeff_vector>.5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
       <wind_direction>240</wind_direction>
       <!-- in degrees -->
       <wind_mean_velocity>0.0</wind_mean_velocity>
-      <var_wind_gain_constants>0.0</var_wind_gain_constants>
+      <var_wind_gain_constants>0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
       <random_seed>10</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
-    </plugin>
-
-    <!-- Include all the objects we plan to use for perception.
-       Stash them out of the field of view for now -->
-    <include>
-      <name>orange_round_0</name>
-      <pose>-200 100 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>orange_round_1</name>
-      <pose>-200 114 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>green_0</name>
-      <pose>-200 102 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_green</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>green_1</name>
-      <pose>-200 130 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_green</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>black_round_0</name>
-      <pose>-200 106 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>black_round_1</name>
-      <pose>-200 112 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>white_0</name>
-      <pose>-200 118 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_white</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>white_1</name>
-      <pose>-200 120 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_white</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>white_2</name>
-      <pose>-200 122 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_white</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>white_3</name>
-      <pose>-200 124 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_white</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>black_0</name>
-      <pose>-200 108 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_black</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>black_1</name>
-      <pose>-200 132 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_black</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>red_0</name>
-      <pose>-200 110 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_red</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>red_1</name>
-      <pose>-200 126 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_red</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>red_2</name>
-      <pose>-200 128 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_red</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <!-- The perception scoring plugin -->
-    <plugin
-      filename="libPerceptionScoringPlugin.so"
-      name="vrx::PerceptionScoringPlugin">
-      <!-- Parameters for ScoringPlugin base class -->
-      <vehicle>wamv</vehicle>
-      <task_name>perception</task_name>
-      <initial_state_duration>10.0</initial_state_duration>
-      <ready_state_duration>10.0</ready_state_duration>
-      <running_state_duration>300</running_state_duration>
-      <!-- Parameters for PerceptionScoringPlugin -->
-      <frame>wamv</frame>
-      <!-- Pose of each object is expressed relative to the body frame
-           of the object named in the frame field - i.e., relative to
-           the wam-v-->
-      <object_sequence>
-        <object>
-          <time>5.0</time>
-          <type>mb_round_buoy_orange</type>
-          <name>orange_round_0</name>
-          <pose>8 0.4 0.4 0 0 0</pose>
-        </object>
-        <object>
-          <time>5.0</time>
-          <type>mb_round_buoy_orange</type>
-          <name>orange_round_1</name>
-          <pose>7.5 1 0.4 0 0 0</pose>
-        </object>
-        <object>
-          <time>5.0</time>
-          <type>mb_round_buoy_black</type>
-          <name>black_round_0</name>
-          <pose>7.0 1.7 0.4 0 0 0</pose>
-        </object>
-        <object>
-          <time>5.0</time>
-          <type>mb_round_buoy_black</type>
-          <name>black_round_1</name>
-          <pose>6.5 2.34 0.4 0 0 0</pose>
-        </object>
-        <object>
-          <time>15.0</time>
-          <type>mb_marker_buoy_green</type>
-          <name>green_0</name>
-          <pose>9 0.1 0.7 0 0 0</pose>
-        </object>
-        <object>
-          <time>15.0</time>
-          <type>mb_marker_buoy_green</type>
-          <name>green_1</name>
-          <pose>6.5 0.7 0.7 0 0 0</pose>
-        </object>
-        <object>
-          <time>15.0</time>
-          <type>mb_marker_buoy_red</type>
-          <name>red_0</name>
-          <pose>8.63 1.9 0.7 0 0 0</pose>
-        </object>
-        <object>
-          <time>15.0</time>
-          <type>mb_marker_buoy_white</type>
-          <name>white_0</name>
-          <pose>4.4 2.37 0.7 0 0 0</pose>
-        </object>
-        <object>
-          <time>25.0</time>
-          <type>mb_marker_buoy_black</type>
-          <name>black_0</name>
-          <pose>10 0.15 0.3 0 0 0</pose>
-        </object>
-        <object>
-          <time>25.0</time>
-          <type>mb_marker_buoy_green</type>
-          <name>green_0</name>
-          <pose>16.5 0.7 0.3 0 0 0</pose>
-        </object>
-        <object>
-          <time>25.0</time>
-          <type>mb_marker_buoy_red</type>
-          <name>red_0</name>
-          <pose>7.63 1.85 0.3 0 0 0</pose>
-        </object>
-        <object>
-          <time>25.0</time>
-          <type>mb_marker_buoy_green</type>
-          <name>green_1</name>
-          <pose>12.4 2.37 0.3 0 0 0</pose>
-        </object>
-        <object>
-          <time>25.0</time>
-          <type>mb_marker_buoy_black</type>
-          <name>black_1</name>
-          <pose>5.4 2.1 0.3 0 0 0</pose>
-        </object>
-        <object>
-          <time>25.0</time>
-          <type>mb_marker_buoy_red</type>
-          <name>red_1</name>
-          <pose>4.4 -0.43 0.3 0 0 0</pose>
-        </object>
-        <object>
-          <time>35.0</time>
-          <type>mb_marker_buoy_white</type>
-          <name>white_0</name>
-          <pose>8.63 1.9 0.7 0 0 0</pose>
-        </object>
-        <object>
-          <time>35.0</time>
-          <type>mb_marker_buoy_white</type>
-          <name>white_1</name>
-          <pose>7.43 2.1 0.7 0 0 0</pose>
-        </object>
-        <object>
-          <time>35.0</time>
-          <type>mb_marker_buoy_white</type>
-          <name>white_2</name>
-          <pose>7 1.68 0.7 0 0 0</pose>
-        </object>
-        <object>
-          <time>35.0</time>
-          <type>mb_marker_buoy_white</type>
-          <name>white_3</name>
-          <pose>30 -1.99 0.7 0 0 0</pose>
-        </object>
-      </object_sequence>
     </plugin>
 
     <!-- The wave field -->
@@ -1017,7 +516,7 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.8
+            double_value: 0.3
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception1_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_acoustic_perception0_task">
+  <world name="practice_2023_acoustic_perception1_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -427,8 +427,8 @@
     <!-- Publish the pinger pose -->
     <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
       <message type="gz.msgs.Vector3d" topic="/wamv/pingers/pinger/set_pinger_position" at="1.0">
-        x: -560,
-        y: 185,
+        x: -528,
+        y: 225,
         z: -2
       </message>
     </plugin>
@@ -445,7 +445,7 @@
       <running_state_duration>300</running_state_duration>
       <release_topic>/vrx/release</release_topic>      
       <goal_tolerance>3</goal_tolerance>
-      <pinger_position>-560 185 -2</pinger_position>
+      <pinger_position>-528 225 -2</pinger_position>
       <markers>
         <scaling>0.2 0.2 2.0</scaling>
         <height>0.5</height>
@@ -454,26 +454,26 @@
 
     <!-- Load the plugin for the wind -->
     <plugin
-       filename="libUSVWind.so"
+      filename="libUSVWind.so"
       name="vrx::USVWind">
-     <!-- models to be effected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
-        <coeff_vector>.5 .5 .33</coeff_vector>
+        <coeff_vector> .5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>240</wind_direction>
+      <wind_direction>96</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>0.0</wind_mean_velocity>
-      <var_wind_gain_constants>0</var_wind_gain_constants>
+      <wind_mean_velocity>3.0</wind_mean_velocity>
+      <var_wind_gain_constants>2.0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>10</random_seed>
+      <random_seed>11</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
     </plugin>
+
 
     <!-- The wave field -->
     <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
@@ -516,7 +516,7 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.3
+            double_value: 0.5
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception2_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_scan_dock_deliver2_task">
+  <world name="practice_2023_acoustic_perception2_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -342,7 +342,7 @@
     </light>
 
     <include>
-      <pose> 0 0 0.2 0 0 0 </pose>
+      <pose>0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>
 
@@ -355,42 +355,6 @@
     <include>
       <name>platform</name>
       <uri>platform</uri>
-    </include>
-
-    <include>
-      <name>robotx_light_buoy_yrg</name>
-      <pose>-510 175 0.32 0 0 0</pose>
-      <uri>robotx_light_buoy_yrg</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>1000.0</linear_drag>
-        <angular_drag>200.0</angular_drag>
-        <buoyancy name="buoyancy_base">
-          <link_name>base_link</link_name>
-          <pose>0 0 -0.1 0 0 0</pose>
-          <geometry>
-            <box>
-              <size>1.5 1.5 0.4</size>
-            </box>
-          </geometry>
-        </buoyancy>
-        <buoyancy name="buoyancy_body">
-          <link_name>base_link</link_name>
-          <pose>0 0 0.8 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.2</radius>
-              <length>0.15</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
     </include>
 
     <!-- The posts for securing the WAM-V -->
@@ -459,16 +423,33 @@
       </plugin>
     </include>
 
-    <!-- Needed to detect the projectile in the placard detectors -->
-    <plugin name="gz::sim" filename="dummy">
-      <performer name="perf_blue_projectile">
-        <ref>blue_projectile</ref>
-        <geometry>
-          <box>
-            <size>0.057 0.057 0.057</size>
-          </box>
-        </geometry>
-      </performer>
+
+    <!-- Publish the pinger pose -->
+    <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
+      <message type="gz.msgs.Vector3d" topic="/wamv/pingers/pinger/set_pinger_position" at="1.0">
+        x: -490,
+        y: 175,
+        z: -2
+      </message>
+    </plugin>
+
+    <!-- The acoustic perception scoring plugin -->
+    <plugin
+      filename="libAcousticPerceptionScoringPlugin.so"
+      name="vrx::AcousticPerceptionScoringPlugin">
+      <vehicle>wamv</vehicle>
+      <task_name>acoustic_perception</task_name>
+      <contact_debug_topic>/vrx/acoustic_perception/debug/contact</contact_debug_topic>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_topic>/vrx/release</release_topic>      
+      <goal_tolerance>3</goal_tolerance>
+      <pinger_position>-490 175 -2</pinger_position>
+      <markers>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
+      </markers>
     </plugin>
 
     <!-- Load the plugin for the wind -->
@@ -493,7 +474,7 @@
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
     </plugin>
-
+    
     <!-- The wave field -->
     <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
@@ -598,91 +579,6 @@
           }
         }
       </message>
-    </plugin>
-
-    <include>
-      <uri>dock_2022</uri>
-      <pose>-540 210 0 0 0 3.14</pose>
-    </include>
-
-    <!-- The scan, dock, deliver scoring plugin -->
-    <plugin
-      filename="libScanDockScoringPlugin.so"
-      name="vrx::ScanDockScoringPlugin">
-      <vehicle>wamv</vehicle>
-      <task_name>scan_dock_deliver</task_name>
-      <task_info_topic>/vrx/task/info</task_info_topic>
-      <initial_state_duration>10</initial_state_duration>
-      <ready_state_duration>10</ready_state_duration>
-      <running_state_duration>300</running_state_duration>
-      <release_topic>/vrx/release</release_topic>
-      <!-- Color sequence -->
-      <color_sequence_topic>/vrx/scan_dock_deliver/color_sequence</color_sequence_topic>
-      <color_1>yellow</color_1>
-      <color_2>red</color_2>
-      <color_3>green</color_3>
-      <!-- Dock checkers -->
-      <dock_bonus_points>15</dock_bonus_points>
-      <correct_dock_bonus_points>5</correct_dock_bonus_points>
-      <bays>
-        <bay>
-          <name>bay1</name>
-          <internal_activation_topic>/vrx/dock_2022/bay_1/contain</internal_activation_topic>
-          <external_activation_topic>/vrx/dock_2022/bay_1_external/contain</external_activation_topic>
-          <symbol_topic>/vrx/dock_2022_placard1/symbol</symbol_topic>
-          <min_dock_time>10.0</min_dock_time>
-          <correct_dock>True</correct_dock>
-          <symbol>yellow_triangle</symbol>
-        </bay>
-        <bay>
-          <name>bay2</name>
-          <internal_activation_topic>/vrx/dock_2022/bay_2/contain</internal_activation_topic>
-          <external_activation_topic>/vrx/dock_2022/bay_2_external/contain</external_activation_topic>
-          <symbol_topic>/vrx/dock_2022_placard2/symbol</symbol_topic>
-          <min_dock_time>10.0</min_dock_time>
-          <correct_dock>False</correct_dock>
-          <symbol>blue_cross</symbol>
-        </bay>
-        <bay>
-          <name>bay3</name>
-          <internal_activation_topic>/vrx/dock_2022/bay_3/contain</internal_activation_topic>
-          <external_activation_topic>/vrx/dock_2022/bay_3_external/contain</external_activation_topic>
-          <symbol_topic>/vrx/dock_2022_placard3/symbol</symbol_topic>
-          <min_dock_time>10.0</min_dock_time>
-          <correct_dock>False</correct_dock>
-          <symbol>green_rectangle</symbol>
-        </bay>
-      </bays>
-      <!-- Shooting targets -->
-      <targets>
-        <!-- Placard #1 -->
-        <target>
-          <topic>/vrx/dock_2022_placard1_big_hole/contain</topic>
-          <bonus_points>5</bonus_points>
-        </target>
-        <target>
-          <topic>/vrx/dock_2022_placard1_small_hole/contain</topic>
-          <bonus_points>10</bonus_points>
-        </target>
-        <!-- Placard #2 -->
-        <target>
-          <topic>/vrx/dock_2022_placard2_big_hole/contain</topic>
-          <bonus_points>5</bonus_points>
-        </target>
-        <target>
-          <topic>/vrx/dock_2022_placard2_small_hole/contain</topic>
-          <bonus_points>10</bonus_points>
-        </target>
-        <!-- Placard #3 -->
-        <target>
-          <topic>/vrx/dock_2022_placard3_big_hole/contain</topic>
-          <bonus_points>5</bonus_points>
-        </target>
-        <target>
-          <topic>/vrx/dock_2022_placard3_small_hole/contain</topic>
-          <bonus_points>10</bonus_points>
-        </target>
-      </targets>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking0_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_wildlife0_task">
+  <world name="practice_2023_acoustic_tracking0_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -342,7 +342,7 @@
     </light>
 
     <include>
-      <pose> 0 0 0.2 0 0 0 </pose>
+      <pose>0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>
 
@@ -355,120 +355,6 @@
     <include>
       <name>platform</name>
       <uri>platform</uri>
-    </include>
-
-    <!-- The crocodile buoy -->
-    <include>
-      <pose>-520 180 0 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/crocodile</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="buoyancy_box">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <box>
-              <size>0.80 0.40 0.15</size>
-            </box>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-
-      <plugin filename="gz-sim-trajectory-follower-system"
-              name="gz::sim::systems::TrajectoryFollower">
-        <link_name>link</link_name>
-        <loop>true</loop>
-        <force>18</force>
-        <torque>1.5</torque>
-        <waypoints>
-          <waypoint>-523 179</waypoint>
-          <waypoint>-520 180</waypoint>
-        </waypoints>
-      </plugin>
-    </include>
-
-    <!-- The turtle buoy -->
-    <include>
-      <pose>-550 230 0 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/turtle</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="buoyancy_sphere">
-          <link_name>link</link_name>
-          <pose>0 0 0.2 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.35</radius>
-            </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-
-      <plugin filename="gz-sim-trajectory-follower-system"
-              name="gz::sim::systems::TrajectoryFollower">
-        <link_name>link</link_name>
-        <loop>true</loop>
-        <force>6</force>
-        <torque>1</torque>
-        <waypoints>
-          <waypoint>-551 233</waypoint>
-          <waypoint>-550 230</waypoint>
-        </waypoints>
-      </plugin>
-    </include>
-
-    <!-- The platypus buoy -->
-    <include>
-      <pose>-500 210 0 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/platypus</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="buoyancy_box">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <box>
-              <size>0.75 0.35 0.16</size>
-            </box>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-
-      <plugin filename="gz-sim-trajectory-follower-system"
-              name="gz::sim::systems::TrajectoryFollower">
-        <link_name>link</link_name>
-        <loop>true</loop>
-        <force>18</force>
-        <torque>1.5</torque>
-        <waypoints>
-          <waypoint>-496 211</waypoint>
-          <waypoint>-500 210</waypoint>
-        </waypoints>
-      </plugin>
     </include>
 
     <!-- The posts for securing the WAM-V -->
@@ -537,10 +423,343 @@
       </plugin>
     </include>
 
+    <include>
+      <name>mb_round_buoy_black_0</name>
+      <pose>-527 200 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_1</name>
+      <pose>-523 180 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_2</name>
+      <pose>-525 203 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_3</name>
+      <pose>-530 190 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_4</name>
+      <pose>-525 160 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_5</name>
+      <pose>-505 203 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_6</name>
+      <pose>-528.5 190 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_7</name>
+      <pose>-530 206 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_8</name>
+      <pose>-504 196 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_9</name>
+      <pose>-512 185 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <!-- The moving pinger -->
+    <model name="pinger">
+      <pose>-525 167 0 0 0 0</pose>
+      <link name="link">
+        <inertial>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <mass>20</mass>
+          <inertia>
+            <ixx>0.24683</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.98016</iyy>
+            <iyz>0</iyz>
+            <izz>1.14166</izz>
+          </inertia>
+        </inertial>
+        <!-- Uncomment to visualize the pinger -->
+        <!-- <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.5</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
+            <specular>1 1 1 1</specular>
+          </material>
+        </visual> -->
+      </link>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="buoyancy_box">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.75 0.35 0.16</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+
+      <plugin filename="gz-sim-trajectory-follower-system"
+              name="gz::sim::systems::TrajectoryFollower">
+        <link_name>link</link_name>
+        <loop>true</loop>
+        <force>350</force>
+        <torque>1.5</torque>
+        <waypoints>
+          <waypoint>-526 170</waypoint>
+          <waypoint>-530 210</waypoint>
+          <waypoint>-502 201</waypoint>
+        </waypoints>
+      </plugin>
+    </model>
+
+    <!-- The acoustic tracking scoring plugin -->
+    <plugin
+      filename="libAcousticTrackingScoringPlugin.so"
+      name="vrx::AcousticTrackingScoringPlugin">
+      <vehicle>wamv</vehicle>
+      <task_name>acoustic_tracking</task_name>
+      <task_info_topic>/vrx/task/info</task_info_topic>
+      <contact_debug_topic>/vrx/acoustic_tracking/debug/contact</contact_debug_topic>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_topic>/vrx/release</release_topic>      
+      <set_pinger_position_topic>/wamv/pingers/pinger/set_pinger_position</set_pinger_position_topic>
+      <pinger_model>pinger</pinger_model>
+      <pinger_depth>2.0</pinger_depth>
+    </plugin>
+
     <!-- Load the plugin for the wind -->
     <plugin
-      filename="libUSVWind.so"
+       filename="libUSVWind.so"
       name="vrx::USVWind">
+     <!-- models to be effected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
@@ -557,7 +776,7 @@
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
-     </plugin>
+    </plugin>
 
     <!-- The wave field -->
     <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
@@ -600,7 +819,7 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.2
+            double_value: 0.3
           }
         }
         params {
@@ -663,39 +882,6 @@
           }
         }
       </message>
-    </plugin>
-
-    <!-- The wildlife scoring plugin -->
-    <plugin
-      filename="libWildlifeScoringPlugin.so"
-      name="vrx::WildlifeScoringPlugin">
-
-      <!-- Common parameters -->
-      <vehicle>wamv</vehicle>
-      <task_name>wildlife</task_name>
-      <initial_state_duration>10</initial_state_duration>
-      <ready_state_duration>10</ready_state_duration>
-      <running_state_duration>300</running_state_duration>
-      <collision_buffer>10</collision_buffer>
-
-      <!-- wildlife specific parameters -->
-      <buoys>
-        <buoy>
-          <name>crocodile::link</name>
-          <goal>avoid</goal>
-        </buoy>
-        <buoy>
-          <name>platypus::link</name>
-          <goal>circumnavigate_clockwise</goal>
-        </buoy>
-        <buoy>
-          <name>turtle::link</name>
-          <goal>circumnavigate_counterclockwise</goal>
-        </buoy>
-      </buoys>
-      <engagement_distance>10.0</engagement_distance>
-      <time_bonus>30.0</time_bonus>
-      <topic_prefix>/vrx/wildlife/animal</topic_prefix>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking1_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_acoustic_perception1_task">
+  <world name="practice_2023_acoustic_tracking1_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -423,33 +423,540 @@
       </plugin>
     </include>
 
+    <include>
+      <name>mb_round_buoy_black_0</name>
+      <pose>-527 200 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
 
-    <!-- Publish the pinger pose -->
-    <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
-      <message type="gz.msgs.Vector3d" topic="/wamv/pingers/pinger/set_pinger_position" at="1.0">
-        x: -528,
-        y: 225,
-        z: -2
-      </message>
-    </plugin>
+    <include>
+      <name>mb_round_buoy_black_1</name>
+      <pose>-523 180 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
 
-    <!-- The acoustic perception scoring plugin -->
+    <include>
+      <name>mb_round_buoy_black_2</name>
+      <pose>-525 203 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_3</name>
+      <pose>-530 190 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_4</name>
+      <pose>-530 182 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_10</name>
+      <pose>-525 160 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+
+    <include>
+      <name>mb_round_buoy_black_5</name>
+      <pose>-527 183 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_11</name>
+      <pose>-505 203 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+
+    <include>
+      <name>mb_round_buoy_black_6</name>
+      <pose>-528.5 190 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_7</name>
+      <pose>-530 206 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_8</name>
+      <pose>-529 175 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_9</name>
+      <pose>-531 170 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_12</name>
+      <pose>-504 196 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_13</name>
+      <pose>-512 185 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+<!--     <include>
+      <name>mb_round_buoy_orange_1</name>
+      <pose>-536 167 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_orange_2</name>
+      <pose>-505 200 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_orange_3</name>
+      <pose>-536 200 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_orange_4</name>
+      <pose>-505 167 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include> -->
+
+
+    <!-- The moving pinger -->
+    <model name="pinger">
+      <pose>-536 167 0 0 0 0</pose>
+      <link name="link">
+        <inertial>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <mass>20</mass>
+          <inertia>
+            <ixx>0.24683</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.98016</iyy>
+            <iyz>0</iyz>
+            <izz>1.14166</izz>
+          </inertia>
+        </inertial>
+        <!-- Uncomment to visualize the pinger -->
+        <!-- <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.5</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
+            <specular>1 1 1 1</specular>
+          </material>
+        </visual> -->
+      </link>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="buoyancy_box">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.75 0.35 0.16</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+
+      <plugin filename="gz-sim-trajectory-follower-system"
+              name="gz::sim::systems::TrajectoryFollower">
+        <link_name>link</link_name>
+        <loop>true</loop>
+        <force>350</force>
+        <torque>1.5</torque>
+        <waypoints>
+          <waypoint>-536 167</waypoint>
+          <waypoint>-505 200</waypoint>
+          <waypoint>-536 200</waypoint>
+          <waypoint>-505 167</waypoint>
+        </waypoints>
+      </plugin>
+    </model>
+
+    <!-- The acoustic tracking scoring plugin -->
     <plugin
-      filename="libAcousticPerceptionScoringPlugin.so"
-      name="vrx::AcousticPerceptionScoringPlugin">
+      filename="libAcousticTrackingScoringPlugin.so"
+      name="vrx::AcousticTrackingScoringPlugin">
       <vehicle>wamv</vehicle>
-      <task_name>acoustic_perception</task_name>
-      <contact_debug_topic>/vrx/acoustic_perception/debug/contact</contact_debug_topic>
+      <task_name>acoustic_tracking</task_name>
+      <task_info_topic>/vrx/task/info</task_info_topic>
+      <contact_debug_topic>/vrx/acoustic_tracking/debug/contact</contact_debug_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>
       <release_topic>/vrx/release</release_topic>      
-      <goal_tolerance>3</goal_tolerance>
-      <pinger_position>-528 225 -2</pinger_position>
-      <markers>
-        <scaling>0.2 0.2 2.0</scaling>
-        <height>0.5</height>
-      </markers>
+      <set_pinger_position_topic>/wamv/pingers/pinger/set_pinger_position</set_pinger_position_topic>
+      <pinger_model>pinger</pinger_model>
+      <pinger_depth>2.0</pinger_depth>
     </plugin>
 
     <!-- Load the plugin for the wind -->
@@ -473,7 +980,6 @@
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
     </plugin>
-
 
     <!-- The wave field -->
     <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking2_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_wildlife2_task">
+  <world name="practice_2023_acoustic_tracking2_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -342,7 +342,7 @@
     </light>
 
     <include>
-      <pose> 0 0 0.2 0 0 0 </pose>
+      <pose>0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>
 
@@ -355,123 +355,6 @@
     <include>
       <name>platform</name>
       <uri>platform</uri>
-    </include>
-
-    <!-- The crocodile buoy -->
-    <include>
-      <name>crocodile1</name>
-      <pose>-550 189 0 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/crocodile</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="buoyancy_box">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <box>
-              <size>0.80 0.40 0.15</size>
-            </box>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-
-      <plugin filename="gz-sim-trajectory-follower-system"
-              name="gz::sim::systems::TrajectoryFollower">
-        <link_name>link</link_name>
-        <loop>true</loop>
-        <force>18</force>
-        <torque>1.5</torque>
-        <waypoints>
-          <waypoint>-550 189</waypoint>
-          <waypoint>-520 190</waypoint>
-        </waypoints>
-      </plugin>
-    </include>
-
-    <!-- The crocodile buoy -->
-    <include>
-      <name>crocodile2</name>
-      <pose>-520 225 0 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/crocodile</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="buoyancy_box">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <box>
-              <size>0.80 0.40 0.15</size>
-            </box>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-
-      <plugin filename="gz-sim-trajectory-follower-system"
-              name="gz::sim::systems::TrajectoryFollower">
-        <link_name>link</link_name>
-        <loop>true</loop>
-        <force>18</force>
-        <torque>1.5</torque>
-        <waypoints>
-          <waypoint>-520 225</waypoint>
-          <waypoint>-500 224</waypoint>
-        </waypoints>
-      </plugin>
-    </include>
-
-    <!-- A platypus buoy -->
-    <include>
-      <name>platypus</name>
-      <pose>-500 260 0 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/platypus</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="buoyancy_box">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <box>
-              <size>0.75 0.35 0.16</size>
-            </box>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-
-      <plugin filename="gz-sim-trajectory-follower-system"
-              name="gz::sim::systems::TrajectoryFollower">
-        <link_name>link</link_name>
-        <loop>true</loop>
-        <force>18</force>
-        <torque>1.5</torque>
-        <waypoints>
-          <waypoint>-500 260</waypoint>
-          <waypoint>-500 270</waypoint>
-        </waypoints>
-      </plugin>
     </include>
 
     <!-- The posts for securing the WAM-V -->
@@ -540,29 +423,462 @@
       </plugin>
     </include>
 
+    <include>
+      <name>mb_round_buoy_black_0</name>
+      <pose>-527 200 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_1</name>
+      <pose>-504 180 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_2</name>
+      <pose>-525 203 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_3</name>
+      <pose>-536.5 190 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_4</name>
+      <pose>-535.5 182 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_5</name>
+      <pose>-527 183 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_6</name>
+      <pose>-505 190 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_7</name>
+      <pose>-530 206 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_8</name>
+      <pose>-520 167 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_black_9</name>
+      <pose>-531 170 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <!-- <include>
+      <name>mb_round_buoy_orange_1</name>
+      <pose>-536 167 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_orange_2</name>
+      <pose>-505 200 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_orange_3</name>
+      <pose>-536 200 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>mb_round_buoy_orange_4</name>
+      <pose>-505 167 0.0 0 0 0 </pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include> -->
+
+    <!-- The moving pinger -->
+    <model name="pinger">
+      <pose>-536 167 0 0 0 0</pose>
+      <link name="link">
+        <inertial>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <mass>20</mass>
+          <inertia>
+            <ixx>0.24683</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.98016</iyy>
+            <iyz>0</iyz>
+            <izz>1.14166</izz>
+          </inertia>
+        </inertial>
+        <!-- Uncomment to visualize the pinger -->
+        <!-- <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.5</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 1 1</ambient>
+            <diffuse>1 1 1</diffuse>
+            <specular>1 1 1 1</specular>
+          </material>
+        </visual> -->
+      </link>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="buoyancy_box">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.75 0.35 0.16</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+
+      <plugin filename="gz-sim-trajectory-follower-system"
+              name="gz::sim::systems::TrajectoryFollower">
+        <link_name>link</link_name>
+        <loop>true</loop>
+        <force>350</force>
+        <torque>1.5</torque>
+        <waypoints>
+          <waypoint>-536 167</waypoint>
+          <waypoint>-536 200</waypoint>
+          <waypoint>-505 200</waypoint>
+          <waypoint>-505 167</waypoint>
+        </waypoints>
+      </plugin>
+    </model>
+
+    <!-- The acoustic tracking scoring plugin -->
+    <plugin
+      filename="libAcousticTrackingScoringPlugin.so"
+      name="vrx::AcousticTrackingScoringPlugin">
+      <vehicle>wamv</vehicle>
+      <task_name>acoustic_tracking</task_name>
+      <task_info_topic>/vrx/task/info</task_info_topic>
+      <contact_debug_topic>/vrx/acoustic_tracking/debug/contact</contact_debug_topic>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_topic>/vrx/release</release_topic>      
+      <set_pinger_position_topic>/wamv/pingers/pinger/set_pinger_position</set_pinger_position_topic>
+      <pinger_model>pinger</pinger_model>
+      <pinger_depth>2.0</pinger_depth>
+    </plugin>
+
     <!-- Load the plugin for the wind -->
     <plugin
       filename="libUSVWind.so"
       name="vrx::USVWind">
-      <!-- models to be affected by the wind -->
+      <!-- models to be effected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
         <coeff_vector> .5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>359</wind_direction>
+      <wind_direction>17</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>6.35</wind_mean_velocity>
-      <var_wind_gain_constants>4.1</var_wind_gain_constants>
+      <wind_mean_velocity>8.0</wind_mean_velocity>
+      <var_wind_gain_constants>4.0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>11</random_seed>
+      <random_seed>19</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
     </plugin>
-
+        
     <!-- The wave field -->
     <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
@@ -667,40 +983,6 @@
           }
         }
       </message>
-    </plugin>
-
-    <!-- The wildlife scoring plugin -->
-    <plugin
-      filename="libWildlifeScoringPlugin.so"
-      name="vrx::WildlifeScoringPlugin">
-
-      <!-- Common parameters -->
-      <vehicle>wamv</vehicle>
-      <task_name>wildlife</task_name>
-      <initial_state_duration>10</initial_state_duration>
-      <ready_state_duration>10</ready_state_duration>
-      <running_state_duration>300</running_state_duration>
-      <collision_buffer>10</collision_buffer>
-
-      <!-- wildlife specific parameters -->
-      <buoys>
-        <buoy>
-          <name>crocodile1::link</name>
-          <goal>avoid</goal>
-        </buoy>
-        <buoy>
-          <name>crocodile2::link</name>
-          <goal>avoid</goal>
-        </buoy>
-        <buoy>
-          <name>platypus::link</name>
-          <goal>circumnavigate_clockwise</goal>
-        </buoy>
-      </buoys>
-      <engagement_distance>10.0</engagement_distance>
-      <time_bonus>30.0</time_bonus>
-      <topic_prefix>/vrx/wildlife/animal</topic_prefix>
-      <publication_frequency>0.1</publication_frequency>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_follow_path0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_follow_path0_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_scan_dock_deliver0_task">
+  <world name="practice_2023_follow_path0_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -308,7 +308,6 @@
       filename="gz-sim-navsat-system"
       name="gz::sim::systems::NavSat">
     </plugin>
-
     <scene>
       <sky></sky>
       <grid>false</grid>
@@ -357,40 +356,10 @@
       <uri>platform</uri>
     </include>
 
+    <!-- The VRX short navigation course -->
     <include>
-      <name>robotx_light_buoy_rgy</name>
-      <pose>-532 175 0.32 0 0 0</pose>
-      <uri>robotx_light_buoy_rgy</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>1000.0</linear_drag>
-        <angular_drag>200.0</angular_drag>
-        <buoyancy name="buoyancy_base">
-          <link_name>base_link</link_name>
-          <pose>0 0 -0.1 0 0 0</pose>
-          <geometry>
-            <box>
-              <size>1.5 1.5 0.4</size>
-            </box>
-          </geometry>
-        </buoyancy>
-        <buoyancy name="buoyancy_body">
-          <link_name>base_link</link_name>
-          <pose>0 0 0.8 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.2</radius>
-              <length>0.15</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
+      <uri>model://short_navigation_course_0</uri>
+      <pose>-524 186 0 0 0 -1.44</pose>
     </include>
 
     <!-- The posts for securing the WAM-V -->
@@ -459,22 +428,11 @@
       </plugin>
     </include>
 
-    <!-- Needed to detect the projectile in the placard detectors -->
-    <plugin name="gz::sim" filename="dummy">
-      <performer name="perf_blue_projectile">
-        <ref>blue_projectile</ref>
-        <geometry>
-          <box>
-            <size>0.057 0.057 0.057</size>
-          </box>
-        </geometry>
-      </performer>
-    </plugin>
-
     <!-- Load the plugin for the wind -->
     <plugin
-      filename="libUSVWind.so"
+       filename="libUSVWind.so"
       name="vrx::USVWind">
+     <!-- models to be effected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
@@ -492,195 +450,39 @@
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
     </plugin>
-    <!-- The wave field -->
-    <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
-      <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
-               every="2.0">
-        params {
-          key: "amplitude"
-          value {
-            type: DOUBLE
-            double_value: 0
-          }
-        }
-        params {
-          key: "angle"
-          value {
-            type: DOUBLE
-            double_value: 0.4
-          }
-        }
-        params {
-          key: "cell_count"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 300
-              y: 300
-            }
-          }
-        }
-        params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.2
-          }
-        }
-        params {
-          key: "model"
-          value {
-            type: STRING
-            string_value: "PMS"
-          }
-        }
-        params {
-          key: "number"
-          value {
-            type: INT32
-            int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
-          }
-        }
-        params {
-          key: "phase"
-          value {
-            type: DOUBLE
-            double_value: 0
-          }
-        }
-        params {
-          key: "scale"
-          value {
-            type: DOUBLE
-            double_value: 1.1
-          }
-        }
-        params {
-          key: "size"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 6000
-              y: 6000
-            }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
-          }
-        }
-        params {
-          key: "tau"
-          value {
-            type: DOUBLE
-            double_value: 2
-          }
-        }
-      </message>
-    </plugin>
 
-    <include>
-      <uri>dock_2022</uri>
-      <pose>-480 190 0 0 0 1.0</pose>
-    </include>
-
-    <!-- The scan, dock, deliver scoring plugin -->
+    <!-- Scoring Plugin -->
     <plugin
-      filename="libScanDockScoringPlugin.so"
-      name="vrx::ScanDockScoringPlugin">
+      filename="libNavigationScoringPlugin.so"
+      name="vrx::NavigationScoringPlugin">
       <vehicle>wamv</vehicle>
-      <task_name>scan_dock_deliver</task_name>
+      <task_name>follow_path</task_name>
       <task_info_topic>/vrx/task/info</task_info_topic>
+      <contact_debug_topic>/vrx/follow_path/debug/contact</contact_debug_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>
+      <collision_buffer>10</collision_buffer>
       <release_topic>/vrx/release</release_topic>
-      <!-- Color sequence -->
-      <color_sequence_topic>/vrx/scan_dock_deliver/color_sequence</color_sequence_topic>
-      <color_1>red</color_1>
-      <color_2>green</color_2>
-      <color_3>yellow</color_3>
-      <!-- Dock checkers -->
-      <dock_bonus_points>15</dock_bonus_points>
-      <correct_dock_bonus_points>5</correct_dock_bonus_points>
-      <bays>
-        <bay>
-          <name>bay1</name>
-          <internal_activation_topic>/vrx/dock_2022/bay_1/contain</internal_activation_topic>
-          <external_activation_topic>/vrx/dock_2022/bay_1_external/contain</external_activation_topic>
-          <symbol_topic>/vrx/dock_2022_placard1/symbol</symbol_topic>
-          <min_dock_time>10.0</min_dock_time>
-          <correct_dock>True</correct_dock>
-          <symbol>red_rectangle</symbol>
-        </bay>
-        <bay>
-          <name>bay2</name>
-          <internal_activation_topic>/vrx/dock_2022/bay_2/contain</internal_activation_topic>
-          <external_activation_topic>/vrx/dock_2022/bay_2_external/contain</external_activation_topic>
-          <symbol_topic>/vrx/dock_2022_placard2/symbol</symbol_topic>
-          <min_dock_time>10.0</min_dock_time>
-          <correct_dock>False</correct_dock>
-          <symbol>blue_triangle</symbol>
-        </bay>
-        <bay>
-          <name>bay3</name>
-          <internal_activation_topic>/vrx/dock_2022/bay_3/contain</internal_activation_topic>
-          <external_activation_topic>/vrx/dock_2022/bay_3_external/contain</external_activation_topic>
-          <symbol_topic>/vrx/dock_2022_placard3/symbol</symbol_topic>
-          <min_dock_time>10.0</min_dock_time>
-          <correct_dock>False</correct_dock>
-          <symbol>yellow_circle</symbol>
-        </bay>
-      </bays>
-      <!-- Shooting targets -->
-      <targets>
-        <!-- Placard #1 -->
-        <target>
-          <topic>/vrx/dock_2022_placard1_big_hole/contain</topic>
-          <bonus_points>5</bonus_points>
-        </target>
-        <target>
-          <topic>/vrx/dock_2022_placard1_small_hole/contain</topic>
-          <bonus_points>10</bonus_points>
-        </target>
-        <!-- Placard #2 -->
-        <target>
-          <topic>/vrx/dock_2022_placard2_big_hole/contain</topic>
-          <bonus_points>5</bonus_points>
-        </target>
-        <target>
-          <topic>/vrx/dock_2022_placard2_small_hole/contain</topic>
-          <bonus_points>10</bonus_points>
-        </target>
-        <!-- Placard #3 -->
-        <target>
-          <topic>/vrx/dock_2022_placard3_big_hole/contain</topic>
-          <bonus_points>5</bonus_points>
-        </target>
-        <target>
-          <topic>/vrx/dock_2022_placard3_small_hole/contain</topic>
-          <bonus_points>10</bonus_points>
-        </target>
-      </targets>
+
+      <course_name>short_navigation_course_0</course_name>
+      <points_per_gate_crossed>10</points_per_gate_crossed>
+      <obstacle_penalty>3.0</obstacle_penalty>
+      <bonus>1</bonus>
+      <gates>
+        <gate>
+          <left_marker>red_bound_0</left_marker>
+          <right_marker>green_bound_0</right_marker>
+        </gate>
+        <gate>
+          <left_marker>red_bound_1</left_marker>
+          <right_marker>green_bound_1</right_marker>
+        </gate>
+        <gate>
+          <left_marker>red_bound_2</left_marker>
+          <right_marker>green_bound_2</right_marker>
+        </gate>
+      </gates>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_follow_path1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_follow_path1_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_follow_path0_task">
+  <world name="practice_2023_follow_path1_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -358,8 +358,8 @@
 
     <!-- The VRX short navigation course -->
     <include>
-      <uri>model://short_navigation_course_0</uri>
-      <pose>-524 186 0 0 0 -1.44</pose>
+      <uri>model://short_navigation_course_1</uri>
+      <pose>-535 180 0 0 0 -1.44</pose>
     </include>
 
     <!-- The posts for securing the WAM-V -->
@@ -430,21 +430,21 @@
 
     <!-- Load the plugin for the wind -->
     <plugin
-       filename="libUSVWind.so"
+      filename="libUSVWind.so"
       name="vrx::USVWind">
-     <!-- models to be effected by the wind -->
+      <!-- models to be effected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
-        <coeff_vector>.5 .5 .33</coeff_vector>
+        <coeff_vector> .5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>240</wind_direction>
+      <wind_direction>72</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>0.0</wind_mean_velocity>
-      <var_wind_gain_constants>0</var_wind_gain_constants>
+      <wind_mean_velocity>5.0</wind_mean_velocity>
+      <var_wind_gain_constants>4.0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>10</random_seed>
+      <random_seed>7</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
@@ -465,10 +465,10 @@
       <collision_buffer>10</collision_buffer>
       <release_topic>/vrx/release</release_topic>
 
-      <course_name>short_navigation_course_0</course_name>
+      <course_name>short_navigation_course_1</course_name>
       <points_per_gate_crossed>10</points_per_gate_crossed>
-      <obstacle_penalty>3.0</obstacle_penalty>
       <bonus>1</bonus>
+      <obstacle_penalty>3.0</obstacle_penalty>
       <gates>
         <gate>
           <left_marker>red_bound_0</left_marker>
@@ -481,6 +481,18 @@
         <gate>
           <left_marker>red_bound_2</left_marker>
           <right_marker>green_bound_2</right_marker>
+        </gate>
+        <gate>
+          <left_marker>red_bound_3</left_marker>
+          <right_marker>green_bound_3</right_marker>
+        </gate>
+        <gate>
+          <left_marker>red_bound_4</left_marker>
+          <right_marker>green_bound_4</right_marker>
+        </gate>
+        <gate>
+          <left_marker>red_bound_5</left_marker>
+          <right_marker>green_bound_5</right_marker>
         </gate>
       </gates>
     </plugin>

--- a/vrx_gz/worlds/2023_practice/practice_2023_follow_path2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_follow_path2_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_scan_dock_deliver1_task">
+  <world name="practice_2023_follow_path2_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -308,7 +308,6 @@
       filename="gz-sim-navsat-system"
       name="gz::sim::systems::NavSat">
     </plugin>
-
     <scene>
       <sky></sky>
       <grid>false</grid>
@@ -357,40 +356,10 @@
       <uri>platform</uri>
     </include>
 
+    <!-- The VRX short navigation course -->
     <include>
-      <name>robotx_light_buoy_ybr</name>
-      <pose>-515 180 0.32 0 0 0</pose>
-      <uri>robotx_light_buoy_ybr</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>1000.0</linear_drag>
-        <angular_drag>200.0</angular_drag>
-        <buoyancy name="buoyancy_base">
-          <link_name>base_link</link_name>
-          <pose>0 0 -0.1 0 0 0</pose>
-          <geometry>
-            <box>
-              <size>1.5 1.5 0.4</size>
-            </box>
-          </geometry>
-        </buoyancy>
-        <buoyancy name="buoyancy_body">
-          <link_name>base_link</link_name>
-          <pose>0 0 0.8 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.2</radius>
-              <length>0.15</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
+      <uri>model://short_navigation_course_2</uri>
+      <pose>-524 186 0 0 0 -1.44</pose>
     </include>
 
     <!-- The posts for securing the WAM-V -->
@@ -459,229 +428,85 @@
       </plugin>
     </include>
 
-    <!-- Needed to detect the projectile in the placard detectors -->
-    <plugin name="gz::sim" filename="dummy">
-      <performer name="perf_blue_projectile">
-        <ref>blue_projectile</ref>
-        <geometry>
-          <box>
-            <size>0.057 0.057 0.057</size>
-          </box>
-        </geometry>
-      </performer>
-    </plugin>
-
     <!-- Load the plugin for the wind -->
     <plugin
       filename="libUSVWind.so"
       name="vrx::USVWind">
+      <!-- models to be effected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
         <coeff_vector> .5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>96</wind_direction>
+      <wind_direction>355</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>3.0</wind_mean_velocity>
-      <var_wind_gain_constants>2.0</var_wind_gain_constants>
+      <wind_mean_velocity>9.0</wind_mean_velocity>
+      <var_wind_gain_constants>5.0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>11</random_seed>
+      <random_seed>19</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
     </plugin>
-  
-    <!-- The wave field -->
-    <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
-      <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
-               every="2.0">
-        params {
-          key: "amplitude"
-          value {
-            type: DOUBLE
-            double_value: 0
-          }
-        }
-        params {
-          key: "angle"
-          value {
-            type: DOUBLE
-            double_value: 0.4
-          }
-        }
-        params {
-          key: "cell_count"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 300
-              y: 300
-            }
-          }
-        }
-        params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.5
-          }
-        }
-        params {
-          key: "model"
-          value {
-            type: STRING
-            string_value: "PMS"
-          }
-        }
-        params {
-          key: "number"
-          value {
-            type: INT32
-            int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
-          }
-        }
-        params {
-          key: "phase"
-          value {
-            type: DOUBLE
-            double_value: 0
-          }
-        }
-        params {
-          key: "scale"
-          value {
-            type: DOUBLE
-            double_value: 1.1
-          }
-        }
-        params {
-          key: "size"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 6000
-              y: 6000
-            }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
-          }
-        }
-        params {
-          key: "tau"
-          value {
-            type: DOUBLE
-            double_value: 2
-          }
-        }
-      </message>
-    </plugin>
 
-    <include>
-      <uri>dock_2022</uri>
-      <pose>-500 190 0 0 0 0</pose>
-    </include>
-
-    <!-- The scan, dock, deliver scoring plugin -->
+    <!-- Scoring Plugin -->
     <plugin
-      filename="libScanDockScoringPlugin.so"
-      name="vrx::ScanDockScoringPlugin">
+      filename="libNavigationScoringPlugin.so"
+      name="vrx::NavigationScoringPlugin">
       <vehicle>wamv</vehicle>
-      <task_name>scan_dock_deliver</task_name>
+      <task_name>follow_path</task_name>
       <task_info_topic>/vrx/task/info</task_info_topic>
+      <contact_debug_topic>/vrx/follow_path/debug/contact</contact_debug_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>
+      <collision_buffer>10</collision_buffer>
       <release_topic>/vrx/release</release_topic>
-      <!-- Color sequence -->
-      <color_sequence_topic>/vrx/scan_dock_deliver/color_sequence</color_sequence_topic>
-      <color_1>yellow</color_1>
-      <color_2>blue</color_2>
-      <color_3>red</color_3>
-      <!-- Dock checkers -->
-      <dock_bonus_points>15</dock_bonus_points>
-      <correct_dock_bonus_points>5</correct_dock_bonus_points>
-      <bays>
-        <bay>
-          <name>bay1</name>
-          <internal_activation_topic>/vrx/dock_2022/bay_1/contain</internal_activation_topic>
-          <external_activation_topic>/vrx/dock_2022/bay_1_external/contain</external_activation_topic>
-          <symbol_topic>/vrx/dock_2022_placard1/symbol</symbol_topic>
-          <min_dock_time>10.0</min_dock_time>
-          <correct_dock>False</correct_dock>
-          <symbol>blue_rectangle</symbol>
-        </bay>
-        <bay>
-          <name>bay2</name>
-          <internal_activation_topic>/vrx/dock_2022/bay_2/contain</internal_activation_topic>
-          <external_activation_topic>/vrx/dock_2022/bay_2_external/contain</external_activation_topic>
-          <symbol_topic>/vrx/dock_2022_placard2/symbol</symbol_topic>
-          <min_dock_time>10.0</min_dock_time>
-          <correct_dock>False</correct_dock>
-          <symbol>red_cross</symbol>
-        </bay>
-        <bay>
-          <name>bay3</name>
-          <internal_activation_topic>/vrx/dock_2022/bay_3/contain</internal_activation_topic>
-          <external_activation_topic>/vrx/dock_2022/bay_3_external/contain</external_activation_topic>
-          <symbol_topic>/vrx/dock_2022_placard3/symbol</symbol_topic>
-          <min_dock_time>10.0</min_dock_time>
-          <correct_dock>True</correct_dock>
-          <symbol>yellow_circle</symbol>
-        </bay>
-      </bays>
-      <!-- Shooting targets -->
-      <targets>
-        <!-- Placard #1 -->
-        <target>
-          <topic>/vrx/dock_2022_placard1_big_hole/contain</topic>
-          <bonus_points>5</bonus_points>
-        </target>
-        <target>
-          <topic>/vrx/dock_2022_placard1_small_hole/contain</topic>
-          <bonus_points>10</bonus_points>
-        </target>
-        <!-- Placard #2 -->
-        <target>
-          <topic>/vrx/dock_2022_placard2_big_hole/contain</topic>
-          <bonus_points>5</bonus_points>
-        </target>
-        <target>
-          <topic>/vrx/dock_2022_placard2_small_hole/contain</topic>
-          <bonus_points>10</bonus_points>
-        </target>
-        <!-- Placard #3 -->
-        <target>
-          <topic>/vrx/dock_2022_placard3_big_hole/contain</topic>
-          <bonus_points>5</bonus_points>
-        </target>
-        <target>
-          <topic>/vrx/dock_2022_placard3_small_hole/contain</topic>
-          <bonus_points>10</bonus_points>
-        </target>
-      </targets>
+
+      <course_name>short_navigation_course_2</course_name>
+      <points_per_gate_crossed>10</points_per_gate_crossed>
+      <obstacle_penalty>3.0</obstacle_penalty>
+      <bonus>1</bonus>
+      <gates>
+        <gate>
+          <left_marker>red_bound_0</left_marker>
+          <right_marker>green_bound_0</right_marker>
+        </gate>
+        <gate>
+          <left_marker>red_bound_1</left_marker>
+          <right_marker>green_bound_1</right_marker>
+        </gate>
+        <gate>
+          <left_marker>red_bound_2</left_marker>
+          <right_marker>green_bound_2</right_marker>
+        </gate>
+        <gate>
+          <left_marker>red_bound_3</left_marker>
+          <right_marker>green_bound_3</right_marker>
+        </gate>
+        <gate>
+          <left_marker>red_bound_4</left_marker>
+          <right_marker>green_bound_4</right_marker>
+        </gate>
+        <gate>
+          <left_marker>red_bound_5</left_marker>
+          <right_marker>green_bound_5</right_marker>
+        </gate>
+        <gate>
+          <left_marker>red_bound_6</left_marker>
+          <right_marker>green_bound_6</right_marker>
+        </gate>
+        <gate>
+          <left_marker>red_bound_7</left_marker>
+          <right_marker>green_bound_7</right_marker>
+        </gate>
+         <gate>
+          <left_marker>red_bound_8</left_marker>
+          <right_marker>green_bound_8</right_marker>
+        </gate>
+     </gates>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_perception0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception0_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_stationkeeping2_task">
+  <world name="practice_2023_perception0_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -342,7 +342,7 @@
     </light>
 
     <include>
-      <pose> 0 0 0.2 0 0 0 </pose>
+      <pose>0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>
 
@@ -424,27 +424,148 @@
     </include>
 
     <!-- Load the plugin for the wind -->
-
     <plugin
       filename="libUSVWind.so"
       name="vrx::USVWind">
+      <!-- models to be effected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
-        <coeff_vector>.5 .5 .33</coeff_vector>
+        <coeff_vector> .5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>265</wind_direction>
+      <wind_direction>240</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>7.0</wind_mean_velocity>
-      <var_wind_gain_constants>1.5</var_wind_gain_constants>
+      <wind_mean_velocity>0.0</wind_mean_velocity>
+      <var_wind_gain_constants>0.0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>12</random_seed>
+      <random_seed>10</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
-     </plugin>
+    </plugin>
+
+
+    <!-- Include all the objects we plan to use for perception.
+       Stash them out of the field of view for now -->
+    <include>
+      <name>red_0</name>
+      <pose>-200 100 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_red</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>green_0</name>
+      <pose>-200 102 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_green</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>white_0</name>
+      <pose>-200 104 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_white</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <!-- The perception scoring plugin -->
+    <plugin
+      filename="libPerceptionScoringPlugin.so"
+      name="vrx::PerceptionScoringPlugin">
+      <!-- Parameters for ScoringPlugin base class -->
+      <vehicle>wamv</vehicle>
+      <task_name>perception</task_name>
+      <initial_state_duration>10.0</initial_state_duration>
+      <ready_state_duration>10.0</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <!-- Parameters for PerceptionScoringPlugin -->
+      <frame>wamv</frame>
+      <!-- Pose of each object is expressed relative to the body frame
+           of the object named in the frame field - i.e., relative to
+           the wam-v-->
+      <object_sequence>
+        <object>
+          <time>5</time>
+          <type>mb_marker_buoy_red</type>
+          <name>red_0</name>
+          <pose>7.8 2.1 0.7 0 0 0</pose>
+        </object>
+        <object>
+          <time>15</time>
+          <type>mb_marker_buoy_green</type>
+          <name>green_0</name>
+          <pose>8.3 0.1 0.7 0 0 0</pose>
+        </object>
+        <object>
+          <time>25.0</time>
+          <type>mb_marker_buoy_white</type>
+          <name>white_0</name>
+          <pose>4.9 -2.32 0.2 0 0 0</pose>
+        </object>
+      </object_sequence>
+    </plugin>
 
     <!-- The wave field -->
     <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
@@ -487,7 +608,7 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.8
+            double_value: 0.2
           }
         }
         params {
@@ -550,25 +671,6 @@
           }
         }
       </message>
-    </plugin>
-
-    <!-- The station keeping scoring plugin -->
-    <plugin
-      filename="libStationkeepingScoringPlugin.so"
-      name="vrx::StationkeepingScoringPlugin">
-      <vehicle>wamv</vehicle>
-      <task_name>stationkeeping</task_name>
-      <task_info_topic>/vrx/task/info</task_info_topic>
-      <initial_state_duration>10</initial_state_duration>
-      <ready_state_duration>10</ready_state_duration>
-      <running_state_duration>300</running_state_duration>
-      <release_topic>/vrx/release</release_topic>
-      <!-- <head_error_on>false</head_error_on> -->
-      <goal_pose>-33.7226643 150.673947 -1.0</goal_pose>
-      <markers>
-        <scaling>0.2 0.2 2.0</scaling>
-        <height>0.5</height>
-      </markers>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_perception1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception1_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_stationkeeping0_task">
+  <world name="practice_2023_perception1_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -423,28 +423,229 @@
       </plugin>
     </include>
 
-    <!-- Load the plugin for the wind -->
+     <!-- Load the plugin for the wind -->
     <plugin
       filename="libUSVWind.so"
       name="vrx::USVWind">
+      <!-- models to be effected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
-        <coeff_vector>.5 .5 .33</coeff_vector>
+        <coeff_vector> .5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>120</wind_direction>
+      <wind_direction>240</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>5.0</wind_mean_velocity>
-      <var_wind_gain_constants>2.0</var_wind_gain_constants>
+      <wind_mean_velocity>0.0</wind_mean_velocity>
+      <var_wind_gain_constants>0.0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>15</random_seed>
+      <random_seed>10</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
-     </plugin>
+    </plugin>
 
+    <!-- Include all the objects we plan to use for perception.
+       Stash them out of the field of view for now -->
+    <include>
+      <name>orange_round</name>
+      <pose>-200 100 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>green_0</name>
+      <pose>-200 102 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_green</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>black_round_0</name>
+      <pose>-200 106 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>black_round_1</name>
+      <pose>-200 112 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>white_0</name>
+      <pose>-200 104 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_white</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <!-- The perception scoring plugin -->
+    <plugin
+      filename="libPerceptionScoringPlugin.so"
+      name="vrx::PerceptionScoringPlugin">
+      <!-- Parameters for ScoringPlugin base class -->
+      <vehicle>wamv</vehicle>
+      <task_name>perception</task_name>
+      <initial_state_duration>10.0</initial_state_duration>
+      <ready_state_duration>10.0</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <!-- Parameters for PerceptionScoringPlugin -->
+      <frame>wamv</frame>
+      <!-- Pose of each object is expressed relative to the body frame
+           of the object named in the frame field - i.e., relative to
+           the wam-v-->
+      <object_sequence>
+        <object>
+          <time>5.0</time>
+          <type>mb_round_buoy_orange</type>
+          <name>orange_round</name>
+          <pose>7.8 2.1 0.7 0 0 0</pose>
+        </object>
+        <object>
+          <time>5.0</time>
+          <type>mb_marker_buoy_green</type>
+          <name>green_0</name>
+          <pose>7.8 -2.1 0.7 0 0 0</pose>
+        </object>
+        <object>
+          <time>15.0</time>
+          <type>mb_marker_buoy_green</type>
+          <name>green_0</name>
+          <pose>8.3 1.5 0.7 0 0 0</pose>
+        </object>
+        <object>
+          <time>15.0</time>
+          <type>mb_round_buoy_orange</type>
+          <name>orange_round</name>
+          <pose>6.0 -1.0 0.7 0 0 0</pose>
+        </object>
+        <object>
+          <time>25.0</time>
+          <type>mb_round_buoy_black</type>
+          <name>black_round_0</name>
+          <pose>4.9 1.32 0.2 0 0 0</pose>
+        </object>
+        <object>
+          <time>25.0</time>
+          <type>mb_round_buoy_black</type>
+          <name>black_round_1</name>
+          <pose>4.7 0.7 0.2 0 0 0</pose>
+        </object>
+        <object>
+          <time>35.0</time>
+          <type>mb_marker_buoy_white</type>
+          <name>white_0</name>
+          <pose>4.1 -2.2 0.2 0 0 0</pose>
+        </object>
+        <object>
+          <time>35.0</time>
+          <type>mb_round_buoy_black</type>
+          <name>black_round_0</name>
+          <pose>6.1 0.2 0.2 0 0 0</pose>
+        </object>
+      </object_sequence>
+    </plugin>
 
     <!-- The wave field -->
     <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
@@ -550,25 +751,6 @@
           }
         }
       </message>
-    </plugin>
-
-    <!-- The station keeping scoring plugin -->
-    <plugin
-      filename="libStationkeepingScoringPlugin.so"
-      name="vrx::StationkeepingScoringPlugin">
-      <vehicle>wamv</vehicle>
-      <task_name>stationkeeping</task_name>
-      <task_info_topic>/vrx/task/info</task_info_topic>
-      <initial_state_duration>10</initial_state_duration>
-      <ready_state_duration>10</ready_state_duration>
-      <running_state_duration>300</running_state_duration>
-      <release_topic>/vrx/release</release_topic>
-      <!-- <head_error_on>false</head_error_on> -->
-      <goal_pose>-33.72267 150.67406 2.0</goal_pose>
-      <markers>
-        <scaling>0.2 0.2 2.0</scaling>
-        <height>0.5</height>
-      </markers>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_perception2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception2_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_acoustic_perception2_task">
+  <world name="practice_2023_perception2_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -423,35 +423,6 @@
       </plugin>
     </include>
 
-
-    <!-- Publish the pinger pose -->
-    <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
-      <message type="gz.msgs.Vector3d" topic="/wamv/pingers/pinger/set_pinger_position" at="1.0">
-        x: -490,
-        y: 175,
-        z: -2
-      </message>
-    </plugin>
-
-    <!-- The acoustic perception scoring plugin -->
-    <plugin
-      filename="libAcousticPerceptionScoringPlugin.so"
-      name="vrx::AcousticPerceptionScoringPlugin">
-      <vehicle>wamv</vehicle>
-      <task_name>acoustic_perception</task_name>
-      <contact_debug_topic>/vrx/acoustic_perception/debug/contact</contact_debug_topic>
-      <initial_state_duration>10</initial_state_duration>
-      <ready_state_duration>10</ready_state_duration>
-      <running_state_duration>300</running_state_duration>
-      <release_topic>/vrx/release</release_topic>      
-      <goal_tolerance>3</goal_tolerance>
-      <pinger_position>-490 175 -2</pinger_position>
-      <markers>
-        <scaling>0.2 0.2 2.0</scaling>
-        <height>0.5</height>
-      </markers>
-    </plugin>
-
     <!-- Load the plugin for the wind -->
     <plugin
       filename="libUSVWind.so"
@@ -463,18 +434,548 @@
         <coeff_vector> .5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>17</wind_direction>
+      <wind_direction>240</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>8.0</wind_mean_velocity>
-      <var_wind_gain_constants>4.0</var_wind_gain_constants>
+      <wind_mean_velocity>0.0</wind_mean_velocity>
+      <var_wind_gain_constants>0.0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>19</random_seed>
+      <random_seed>10</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
     </plugin>
-    
+
+    <!-- Include all the objects we plan to use for perception.
+       Stash them out of the field of view for now -->
+    <include>
+      <name>orange_round_0</name>
+      <pose>-200 100 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>orange_round_1</name>
+      <pose>-200 114 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>green_0</name>
+      <pose>-200 102 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_green</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>green_1</name>
+      <pose>-200 130 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_green</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>black_round_0</name>
+      <pose>-200 106 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>black_round_1</name>
+      <pose>-200 112 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+          </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>white_0</name>
+      <pose>-200 118 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_white</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>white_1</name>
+      <pose>-200 120 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_white</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>white_2</name>
+      <pose>-200 122 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_white</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>white_3</name>
+      <pose>-200 124 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_white</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>black_0</name>
+      <pose>-200 108 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_black</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>black_1</name>
+      <pose>-200 132 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_black</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>red_0</name>
+      <pose>-200 110 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_red</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>red_1</name>
+      <pose>-200 126 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_red</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <include>
+      <name>red_2</name>
+      <pose>-200 128 1 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_red</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="collision_outer">
+          <link_name>link</link_name>
+          <pose>0 0 -0.3 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.325</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+    </include>
+
+    <!-- The perception scoring plugin -->
+    <plugin
+      filename="libPerceptionScoringPlugin.so"
+      name="vrx::PerceptionScoringPlugin">
+      <!-- Parameters for ScoringPlugin base class -->
+      <vehicle>wamv</vehicle>
+      <task_name>perception</task_name>
+      <initial_state_duration>10.0</initial_state_duration>
+      <ready_state_duration>10.0</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <!-- Parameters for PerceptionScoringPlugin -->
+      <frame>wamv</frame>
+      <!-- Pose of each object is expressed relative to the body frame
+           of the object named in the frame field - i.e., relative to
+           the wam-v-->
+      <object_sequence>
+        <object>
+          <time>5.0</time>
+          <type>mb_round_buoy_orange</type>
+          <name>orange_round_0</name>
+          <pose>8 0.4 0.4 0 0 0</pose>
+        </object>
+        <object>
+          <time>5.0</time>
+          <type>mb_round_buoy_orange</type>
+          <name>orange_round_1</name>
+          <pose>7.5 1 0.4 0 0 0</pose>
+        </object>
+        <object>
+          <time>5.0</time>
+          <type>mb_round_buoy_black</type>
+          <name>black_round_0</name>
+          <pose>7.0 1.7 0.4 0 0 0</pose>
+        </object>
+        <object>
+          <time>5.0</time>
+          <type>mb_round_buoy_black</type>
+          <name>black_round_1</name>
+          <pose>6.5 2.34 0.4 0 0 0</pose>
+        </object>
+        <object>
+          <time>15.0</time>
+          <type>mb_marker_buoy_green</type>
+          <name>green_0</name>
+          <pose>9 0.1 0.7 0 0 0</pose>
+        </object>
+        <object>
+          <time>15.0</time>
+          <type>mb_marker_buoy_green</type>
+          <name>green_1</name>
+          <pose>6.5 0.7 0.7 0 0 0</pose>
+        </object>
+        <object>
+          <time>15.0</time>
+          <type>mb_marker_buoy_red</type>
+          <name>red_0</name>
+          <pose>8.63 1.9 0.7 0 0 0</pose>
+        </object>
+        <object>
+          <time>15.0</time>
+          <type>mb_marker_buoy_white</type>
+          <name>white_0</name>
+          <pose>4.4 2.37 0.7 0 0 0</pose>
+        </object>
+        <object>
+          <time>25.0</time>
+          <type>mb_marker_buoy_black</type>
+          <name>black_0</name>
+          <pose>10 0.15 0.3 0 0 0</pose>
+        </object>
+        <object>
+          <time>25.0</time>
+          <type>mb_marker_buoy_green</type>
+          <name>green_0</name>
+          <pose>16.5 0.7 0.3 0 0 0</pose>
+        </object>
+        <object>
+          <time>25.0</time>
+          <type>mb_marker_buoy_red</type>
+          <name>red_0</name>
+          <pose>7.63 1.85 0.3 0 0 0</pose>
+        </object>
+        <object>
+          <time>25.0</time>
+          <type>mb_marker_buoy_green</type>
+          <name>green_1</name>
+          <pose>12.4 2.37 0.3 0 0 0</pose>
+        </object>
+        <object>
+          <time>25.0</time>
+          <type>mb_marker_buoy_black</type>
+          <name>black_1</name>
+          <pose>5.4 2.1 0.3 0 0 0</pose>
+        </object>
+        <object>
+          <time>25.0</time>
+          <type>mb_marker_buoy_red</type>
+          <name>red_1</name>
+          <pose>4.4 -0.43 0.3 0 0 0</pose>
+        </object>
+        <object>
+          <time>35.0</time>
+          <type>mb_marker_buoy_white</type>
+          <name>white_0</name>
+          <pose>8.63 1.9 0.7 0 0 0</pose>
+        </object>
+        <object>
+          <time>35.0</time>
+          <type>mb_marker_buoy_white</type>
+          <name>white_1</name>
+          <pose>7.43 2.1 0.7 0 0 0</pose>
+        </object>
+        <object>
+          <time>35.0</time>
+          <type>mb_marker_buoy_white</type>
+          <name>white_2</name>
+          <pose>7 1.68 0.7 0 0 0</pose>
+        </object>
+        <object>
+          <time>35.0</time>
+          <type>mb_marker_buoy_white</type>
+          <name>white_3</name>
+          <pose>30 -1.99 0.7 0 0 0</pose>
+        </object>
+      </object_sequence>
+    </plugin>
+
     <!-- The wave field -->
     <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"

--- a/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver0_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_wayfinding0_task">
+  <world name="practice_2023_scan_dock_deliver0_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -342,7 +342,7 @@
     </light>
 
     <include>
-      <pose>0 0 0.2 0 0 0 </pose>
+      <pose> 0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>
 
@@ -355,6 +355,42 @@
     <include>
       <name>platform</name>
       <uri>platform</uri>
+    </include>
+
+    <include>
+      <name>robotx_light_buoy_rgy</name>
+      <pose>-532 175 0.32 0 0 0</pose>
+      <uri>robotx_light_buoy_rgy</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>1000.0</linear_drag>
+        <angular_drag>200.0</angular_drag>
+        <buoyancy name="buoyancy_base">
+          <link_name>base_link</link_name>
+          <pose>0 0 -0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1.5 1.5 0.4</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <buoyancy name="buoyancy_body">
+          <link_name>base_link</link_name>
+          <pose>0 0 0.8 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.15</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
     </include>
 
     <!-- The posts for securing the WAM-V -->
@@ -423,29 +459,39 @@
       </plugin>
     </include>
 
+    <!-- Needed to detect the projectile in the placard detectors -->
+    <plugin name="gz::sim" filename="dummy">
+      <performer name="perf_blue_projectile">
+        <ref>blue_projectile</ref>
+        <geometry>
+          <box>
+            <size>0.057 0.057 0.057</size>
+          </box>
+        </geometry>
+      </performer>
+    </plugin>
+
     <!-- Load the plugin for the wind -->
     <plugin
       filename="libUSVWind.so"
       name="vrx::USVWind">
-      <!-- models to be affected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
-        <coeff_vector> .5 .5 .33</coeff_vector>
+        <coeff_vector>.5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>315</wind_direction>
+      <wind_direction>240</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>4.0</wind_mean_velocity>
-      <var_wind_gain_constants>2.0</var_wind_gain_constants>
+      <wind_mean_velocity>0.0</wind_mean_velocity>
+      <var_wind_gain_constants>0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>15</random_seed>
+      <random_seed>10</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
     </plugin>
-
     <!-- The wave field -->
     <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
@@ -487,7 +533,7 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.5
+            double_value: 0.2
           }
         }
         params {
@@ -552,37 +598,89 @@
       </message>
     </plugin>
 
-    <!-- The wayfinding scoring plugin -->
+    <include>
+      <uri>dock_2022</uri>
+      <pose>-480 190 0 0 0 1.0</pose>
+    </include>
+
+    <!-- The scan, dock, deliver scoring plugin -->
     <plugin
-      filename="libWayfindingScoringPlugin.so"
-      name="vrx::WayfindingScoringPlugin">
+      filename="libScanDockScoringPlugin.so"
+      name="vrx::ScanDockScoringPlugin">
       <vehicle>wamv</vehicle>
-      <task_name>wayfinding</task_name>
-      <waypoints>
-        <waypoint>
-          <pose>-33.722726 150.674110 1.0</pose>
-        </waypoint>
-        <waypoint>
-          <pose>-33.722418 150.673634 1.0</pose>
-        </waypoint>
-        <waypoint>
-          <pose>-33.722106 150.673663 0.5</pose>
-        </waypoint>
-        <waypoint>
-          <pose>-33.722006 150.674110 -3</pose>
-        </waypoint>
-      </waypoints>
-      <markers>
-        <scaling>0.2 0.2 2.0 </scaling>
-        <height>0.5 </height>
-      </markers>
-
-
+      <task_name>scan_dock_deliver</task_name>
       <task_info_topic>/vrx/task/info</task_info_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>
       <release_topic>/vrx/release</release_topic>
+      <!-- Color sequence -->
+      <color_sequence_topic>/vrx/scan_dock_deliver/color_sequence</color_sequence_topic>
+      <color_1>red</color_1>
+      <color_2>green</color_2>
+      <color_3>yellow</color_3>
+      <!-- Dock checkers -->
+      <dock_bonus_points>15</dock_bonus_points>
+      <correct_dock_bonus_points>5</correct_dock_bonus_points>
+      <bays>
+        <bay>
+          <name>bay1</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_1/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_1_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard1/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <correct_dock>True</correct_dock>
+          <symbol>red_rectangle</symbol>
+        </bay>
+        <bay>
+          <name>bay2</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_2/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_2_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard2/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <correct_dock>False</correct_dock>
+          <symbol>blue_triangle</symbol>
+        </bay>
+        <bay>
+          <name>bay3</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_3/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_3_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard3/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <correct_dock>False</correct_dock>
+          <symbol>yellow_circle</symbol>
+        </bay>
+      </bays>
+      <!-- Shooting targets -->
+      <targets>
+        <!-- Placard #1 -->
+        <target>
+          <topic>/vrx/dock_2022_placard1_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>/vrx/dock_2022_placard1_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <!-- Placard #2 -->
+        <target>
+          <topic>/vrx/dock_2022_placard2_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>/vrx/dock_2022_placard2_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <!-- Placard #3 -->
+        <target>
+          <topic>/vrx/dock_2022_placard3_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>/vrx/dock_2022_placard3_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+      </targets>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver1_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_wayfinding0_task">
+  <world name="practice_2023_scan_dock_deliver1_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -342,7 +342,7 @@
     </light>
 
     <include>
-      <pose>0 0 0.2 0 0 0 </pose>
+      <pose> 0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>
 
@@ -355,6 +355,42 @@
     <include>
       <name>platform</name>
       <uri>platform</uri>
+    </include>
+
+    <include>
+      <name>robotx_light_buoy_ybr</name>
+      <pose>-515 180 0.32 0 0 0</pose>
+      <uri>robotx_light_buoy_ybr</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>1000.0</linear_drag>
+        <angular_drag>200.0</angular_drag>
+        <buoyancy name="buoyancy_base">
+          <link_name>base_link</link_name>
+          <pose>0 0 -0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1.5 1.5 0.4</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <buoyancy name="buoyancy_body">
+          <link_name>base_link</link_name>
+          <pose>0 0 0.8 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.15</length>
+            </cylinder>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
     </include>
 
     <!-- The posts for securing the WAM-V -->
@@ -423,29 +459,40 @@
       </plugin>
     </include>
 
-    <!-- Load the plugin for the wind -->
+    <!-- Needed to detect the projectile in the placard detectors -->
+    <plugin name="gz::sim" filename="dummy">
+      <performer name="perf_blue_projectile">
+        <ref>blue_projectile</ref>
+        <geometry>
+          <box>
+            <size>0.057 0.057 0.057</size>
+          </box>
+        </geometry>
+      </performer>
+    </plugin>
 
+    <!-- Load the plugin for the wind -->
     <plugin
       filename="libUSVWind.so"
       name="vrx::USVWind">
-      <!-- models to be affected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
         <coeff_vector> .5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>244</wind_direction>
+      <wind_direction>96</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>8.0</wind_mean_velocity>
+      <wind_mean_velocity>3.0</wind_mean_velocity>
       <var_wind_gain_constants>2.0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>9</random_seed>
+      <random_seed>11</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
     </plugin>
+  
     <!-- The wave field -->
     <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
@@ -487,7 +534,7 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.8
+            double_value: 0.5
           }
         }
         params {
@@ -552,40 +599,89 @@
       </message>
     </plugin>
 
-    <!-- The wayfinding scoring plugin -->
+    <include>
+      <uri>dock_2022</uri>
+      <pose>-500 190 0 0 0 0</pose>
+    </include>
+
+    <!-- The scan, dock, deliver scoring plugin -->
     <plugin
-      filename="libWayfindingScoringPlugin.so"
-      name="vrx::WayfindingScoringPlugin">
+      filename="libScanDockScoringPlugin.so"
+      name="vrx::ScanDockScoringPlugin">
       <vehicle>wamv</vehicle>
-      <task_name>wayfinding</task_name>
-      <waypoints>
-        <waypoint>
-          <pose>-33.722462 150.674268 1.0</pose>
-        </waypoint>
-        <waypoint>
-          <pose>-33.722262 150.674800 -1.0</pose>
-        </waypoint>
-        <waypoint>
-          <pose>-33.7226908 150.6751165 0.0</pose>
-        </waypoint>
-        <waypoint>
-          <pose>-33.722925 150.675304 1.0</pose>
-        </waypoint>
-        <waypoint>
-          <pose>-33.7226908 150.6755165 -2.5</pose>
-        </waypoint>
-      </waypoints>
-      <markers>
-        <scaling>0.2 0.2 2.0 </scaling>
-        <height>0.5 </height>
-      </markers>
-
-
+      <task_name>scan_dock_deliver</task_name>
       <task_info_topic>/vrx/task/info</task_info_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>
       <release_topic>/vrx/release</release_topic>
+      <!-- Color sequence -->
+      <color_sequence_topic>/vrx/scan_dock_deliver/color_sequence</color_sequence_topic>
+      <color_1>yellow</color_1>
+      <color_2>blue</color_2>
+      <color_3>red</color_3>
+      <!-- Dock checkers -->
+      <dock_bonus_points>15</dock_bonus_points>
+      <correct_dock_bonus_points>5</correct_dock_bonus_points>
+      <bays>
+        <bay>
+          <name>bay1</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_1/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_1_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard1/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <correct_dock>False</correct_dock>
+          <symbol>blue_rectangle</symbol>
+        </bay>
+        <bay>
+          <name>bay2</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_2/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_2_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard2/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <correct_dock>False</correct_dock>
+          <symbol>red_cross</symbol>
+        </bay>
+        <bay>
+          <name>bay3</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_3/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_3_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard3/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <correct_dock>True</correct_dock>
+          <symbol>yellow_circle</symbol>
+        </bay>
+      </bays>
+      <!-- Shooting targets -->
+      <targets>
+        <!-- Placard #1 -->
+        <target>
+          <topic>/vrx/dock_2022_placard1_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>/vrx/dock_2022_placard1_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <!-- Placard #2 -->
+        <target>
+          <topic>/vrx/dock_2022_placard2_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>/vrx/dock_2022_placard2_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <!-- Placard #3 -->
+        <target>
+          <topic>/vrx/dock_2022_placard3_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>/vrx/dock_2022_placard3_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+      </targets>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver2_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_wildlife1_task">
+  <world name="practice_2023_scan_dock_deliver2_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -357,119 +357,39 @@
       <uri>platform</uri>
     </include>
 
-    <!-- The crocodile buoy -->
     <include>
-      <pose>-510 199 0 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/crocodile</uri>
+      <name>robotx_light_buoy_yrg</name>
+      <pose>-510 175 0.32 0 0 0</pose>
+      <uri>robotx_light_buoy_yrg</uri>
 
       <plugin name="vrx::PolyhedraBuoyancyDrag"
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="buoyancy_box">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
+        <linear_drag>1000.0</linear_drag>
+        <angular_drag>200.0</angular_drag>
+        <buoyancy name="buoyancy_base">
+          <link_name>base_link</link_name>
+          <pose>0 0 -0.1 0 0 0</pose>
           <geometry>
             <box>
-              <size>0.80 0.40 0.15</size>
+              <size>1.5 1.5 0.4</size>
             </box>
           </geometry>
         </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-
-      <plugin filename="gz-sim-trajectory-follower-system"
-              name="gz::sim::systems::TrajectoryFollower">
-        <link_name>link</link_name>
-        <loop>true</loop>
-        <force>18</force>
-        <torque>1.5</torque>
-        <waypoints>
-          <waypoint>-511 203</waypoint>
-          <waypoint>-510 199</waypoint>
-        </waypoints>
-      </plugin>
-    </include>
-
-    <!-- A turtle buoy -->
-    <include>
-      <name>turtle1</name>
-      <pose>-550 201 0 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/turtle</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="buoyancy_sphere">
-          <link_name>link</link_name>
-          <pose>0 0 0.2 0 0 0</pose>
+        <buoyancy name="buoyancy_body">
+          <link_name>base_link</link_name>
+          <pose>0 0 0.8 0 0 0</pose>
           <geometry>
-            <sphere>
-              <radius>0.35</radius>
-            </sphere>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.15</length>
+            </cylinder>
           </geometry>
         </buoyancy>
         <wavefield>
           <topic>/vrx/wavefield/parameters</topic>
         </wavefield>
-      </plugin>
-
-      <plugin filename="gz-sim-trajectory-follower-system"
-              name="gz::sim::systems::TrajectoryFollower">
-        <link_name>link</link_name>
-        <loop>true</loop>
-        <force>6</force>
-        <torque>1</torque>
-        <waypoints>
-          <waypoint>-551 203</waypoint>
-          <waypoint>-550 201</waypoint>
-        </waypoints>
-      </plugin>
-    </include>
-
-    <!-- A turtle buoy -->
-    <include>
-      <name>turtle2</name>
-      <pose>-470 200 0 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/turtle</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="buoyancy_sphere">
-          <link_name>link</link_name>
-          <pose>0 0 0.2 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.35</radius>
-            </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-
-      <plugin filename="gz-sim-trajectory-follower-system"
-              name="gz::sim::systems::TrajectoryFollower">
-        <link_name>link</link_name>
-        <loop>true</loop>
-        <force>6</force>
-        <torque>1</torque>
-        <waypoints>
-          <waypoint>-470 205</waypoint>
-          <waypoint>-470 200</waypoint>
-        </waypoints>
       </plugin>
     </include>
 
@@ -539,6 +459,18 @@
       </plugin>
     </include>
 
+    <!-- Needed to detect the projectile in the placard detectors -->
+    <plugin name="gz::sim" filename="dummy">
+      <performer name="perf_blue_projectile">
+        <ref>blue_projectile</ref>
+        <geometry>
+          <box>
+            <size>0.057 0.057 0.057</size>
+          </box>
+        </geometry>
+      </performer>
+    </plugin>
+
     <!-- Load the plugin for the wind -->
     <plugin
       filename="libUSVWind.so"
@@ -550,12 +482,12 @@
         <coeff_vector> .5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>37</wind_direction>
+      <wind_direction>17</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>3.7</wind_mean_velocity>
-      <var_wind_gain_constants>3.0</var_wind_gain_constants>
+      <wind_mean_velocity>8.0</wind_mean_velocity>
+      <var_wind_gain_constants>4.0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>12</random_seed>
+      <random_seed>19</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
@@ -603,7 +535,7 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.5
+            double_value: 0.8
           }
         }
         params {
@@ -668,38 +600,89 @@
       </message>
     </plugin>
 
-    <!-- The wildlife scoring plugin -->
-    <plugin
-      filename="libWildlifeScoringPlugin.so"
-      name="vrx::WildlifeScoringPlugin">
+    <include>
+      <uri>dock_2022</uri>
+      <pose>-540 210 0 0 0 3.14</pose>
+    </include>
 
-      <!-- Common parameters -->
+    <!-- The scan, dock, deliver scoring plugin -->
+    <plugin
+      filename="libScanDockScoringPlugin.so"
+      name="vrx::ScanDockScoringPlugin">
       <vehicle>wamv</vehicle>
-      <task_name>wildlife</task_name>
+      <task_name>scan_dock_deliver</task_name>
+      <task_info_topic>/vrx/task/info</task_info_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>
-      <collision_buffer>10</collision_buffer>
-
-      <!-- wildlife specific parameters -->
-      <buoys>
-        <buoy>
-          <name>crocodile::link</name>
-          <goal>avoid</goal>
-        </buoy>
-        <buoy>
-          <name>turtle1::link</name>
-          <goal>circumnavigate_counterclockwise</goal>
-        </buoy>
-        <buoy>
-          <name>turtle2::link</name>
-          <goal>circumnavigate_counterclockwise</goal>
-        </buoy>
-      </buoys>
-      <engagement_distance>10.0</engagement_distance>
-      <time_bonus>30.0</time_bonus>
-      <topic_prefix>/vrx/wildlife/animal</topic_prefix>
-      <publication_frequency>0.33</publication_frequency>
+      <release_topic>/vrx/release</release_topic>
+      <!-- Color sequence -->
+      <color_sequence_topic>/vrx/scan_dock_deliver/color_sequence</color_sequence_topic>
+      <color_1>yellow</color_1>
+      <color_2>red</color_2>
+      <color_3>green</color_3>
+      <!-- Dock checkers -->
+      <dock_bonus_points>15</dock_bonus_points>
+      <correct_dock_bonus_points>5</correct_dock_bonus_points>
+      <bays>
+        <bay>
+          <name>bay1</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_1/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_1_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard1/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <correct_dock>True</correct_dock>
+          <symbol>yellow_triangle</symbol>
+        </bay>
+        <bay>
+          <name>bay2</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_2/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_2_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard2/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <correct_dock>False</correct_dock>
+          <symbol>blue_cross</symbol>
+        </bay>
+        <bay>
+          <name>bay3</name>
+          <internal_activation_topic>/vrx/dock_2022/bay_3/contain</internal_activation_topic>
+          <external_activation_topic>/vrx/dock_2022/bay_3_external/contain</external_activation_topic>
+          <symbol_topic>/vrx/dock_2022_placard3/symbol</symbol_topic>
+          <min_dock_time>10.0</min_dock_time>
+          <correct_dock>False</correct_dock>
+          <symbol>green_rectangle</symbol>
+        </bay>
+      </bays>
+      <!-- Shooting targets -->
+      <targets>
+        <!-- Placard #1 -->
+        <target>
+          <topic>/vrx/dock_2022_placard1_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>/vrx/dock_2022_placard1_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <!-- Placard #2 -->
+        <target>
+          <topic>/vrx/dock_2022_placard2_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>/vrx/dock_2022_placard2_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+        <!-- Placard #3 -->
+        <target>
+          <topic>/vrx/dock_2022_placard3_big_hole/contain</topic>
+          <bonus_points>5</bonus_points>
+        </target>
+        <target>
+          <topic>/vrx/dock_2022_placard3_small_hole/contain</topic>
+          <bonus_points>10</bonus_points>
+        </target>
+      </targets>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping0_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_wayfinding0_task">
+  <world name="practice_2023_stationkeeping0_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -423,7 +423,7 @@
       </plugin>
     </include>
 
-    <!-- Load the plugin for the wind -->
+    <!-- Load the plugin for the wind --> 
     <plugin
       filename="libUSVWind.so"
       name="vrx::USVWind">
@@ -552,34 +552,23 @@
       </message>
     </plugin>
 
-    <!-- The wayfinding scoring plugin -->
+    <!-- The station keeping scoring plugin -->
     <plugin
-      filename="libWayfindingScoringPlugin.so"
-      name="vrx::WayfindingScoringPlugin">
+      filename="libStationkeepingScoringPlugin.so"
+      name="vrx::StationkeepingScoringPlugin">
       <vehicle>wamv</vehicle>
-      <task_name>wayfinding</task_name>
-      <waypoints>
-        <waypoint>
-          <pose>-33.722611 150.674051 1.0</pose>
-        </waypoint>
-        <waypoint>
-          <pose>-33.722574 150.6744381 0.0</pose>
-        </waypoint>
-        <waypoint>
-          <pose>-33.722680 150.674756 -1.0</pose>
-        </waypoint>
-      </waypoints>
-      <markers>
-        <scaling>0.2 0.2 2.0 </scaling>
-        <height>0.5 </height>
-      </markers>
-
-
+      <task_name>stationkeeping</task_name>
       <task_info_topic>/vrx/task/info</task_info_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>
       <release_topic>/vrx/release</release_topic>
+      <!-- <head_error_on>false</head_error_on> -->
+      <goal_pose>-33.722718 150.674031 0</goal_pose>
+      <markers>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
+      </markers>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping1_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_acoustic_tracking1_task">
+  <world name="practice_2023_stationkeeping0_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -423,542 +423,6 @@
       </plugin>
     </include>
 
-    <include>
-      <name>mb_round_buoy_black_0</name>
-      <pose>-527 200 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_1</name>
-      <pose>-523 180 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_2</name>
-      <pose>-525 203 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_3</name>
-      <pose>-530 190 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_4</name>
-      <pose>-530 182 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_10</name>
-      <pose>-525 160 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-
-    <include>
-      <name>mb_round_buoy_black_5</name>
-      <pose>-527 183 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_11</name>
-      <pose>-505 203 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-
-    <include>
-      <name>mb_round_buoy_black_6</name>
-      <pose>-528.5 190 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_7</name>
-      <pose>-530 206 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_8</name>
-      <pose>-529 175 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_9</name>
-      <pose>-531 170 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_12</name>
-      <pose>-504 196 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_13</name>
-      <pose>-512 185 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-<!--     <include>
-      <name>mb_round_buoy_orange_1</name>
-      <pose>-536 167 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_orange_2</name>
-      <pose>-505 200 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_orange_3</name>
-      <pose>-536 200 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_orange_4</name>
-      <pose>-505 167 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include> -->
-
-
-    <!-- The moving pinger -->
-    <model name="pinger">
-      <pose>-536 167 0 0 0 0</pose>
-      <link name="link">
-        <inertial>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <mass>20</mass>
-          <inertia>
-            <ixx>0.24683</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.98016</iyy>
-            <iyz>0</iyz>
-            <izz>1.14166</izz>
-          </inertia>
-        </inertial>
-        <!-- Uncomment to visualize the pinger -->
-        <!-- <visual name="visual">
-          <geometry>
-            <box>
-              <size>0.5 0.5 0.5</size>
-            </box>
-          </geometry>
-          <material>
-            <ambient>1 1 1</ambient>
-            <diffuse>1 1 1</diffuse>
-            <specular>1 1 1 1</specular>
-          </material>
-        </visual> -->
-      </link>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="buoyancy_box">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <box>
-              <size>0.75 0.35 0.16</size>
-            </box>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-
-      <plugin filename="gz-sim-trajectory-follower-system"
-              name="gz::sim::systems::TrajectoryFollower">
-        <link_name>link</link_name>
-        <loop>true</loop>
-        <force>350</force>
-        <torque>1.5</torque>
-        <waypoints>
-          <waypoint>-536 167</waypoint>
-          <waypoint>-505 200</waypoint>
-          <waypoint>-536 200</waypoint>
-          <waypoint>-505 167</waypoint>
-        </waypoints>
-      </plugin>
-    </model>
-
-    <!-- The acoustic tracking scoring plugin -->
-    <plugin
-      filename="libAcousticTrackingScoringPlugin.so"
-      name="vrx::AcousticTrackingScoringPlugin">
-      <vehicle>wamv</vehicle>
-      <task_name>acoustic_tracking</task_name>
-      <task_info_topic>/vrx/task/info</task_info_topic>
-      <contact_debug_topic>/vrx/acoustic_tracking/debug/contact</contact_debug_topic>
-      <initial_state_duration>10</initial_state_duration>
-      <ready_state_duration>10</ready_state_duration>
-      <running_state_duration>300</running_state_duration>
-      <release_topic>/vrx/release</release_topic>      
-      <set_pinger_position_topic>/wamv/pingers/pinger/set_pinger_position</set_pinger_position_topic>
-      <pinger_model>pinger</pinger_model>
-      <pinger_depth>2.0</pinger_depth>
-    </plugin>
-
     <!-- Load the plugin for the wind -->
     <plugin
       filename="libUSVWind.so"
@@ -966,20 +430,21 @@
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
-        <coeff_vector> .5 .5 .33</coeff_vector>
+        <coeff_vector>.5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>96</wind_direction>
+      <wind_direction>120</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>3.0</wind_mean_velocity>
+      <wind_mean_velocity>5.0</wind_mean_velocity>
       <var_wind_gain_constants>2.0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>11</random_seed>
+      <random_seed>15</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
-    </plugin>
+     </plugin>
+
 
     <!-- The wave field -->
     <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
@@ -1085,6 +550,25 @@
           }
         }
       </message>
+    </plugin>
+
+    <!-- The station keeping scoring plugin -->
+    <plugin
+      filename="libStationkeepingScoringPlugin.so"
+      name="vrx::StationkeepingScoringPlugin">
+      <vehicle>wamv</vehicle>
+      <task_name>stationkeeping</task_name>
+      <task_info_topic>/vrx/task/info</task_info_topic>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_topic>/vrx/release</release_topic>
+      <!-- <head_error_on>false</head_error_on> -->
+      <goal_pose>-33.72267 150.67406 2.0</goal_pose>
+      <markers>
+        <scaling>0.2 0.2 2.0</scaling>
+        <height>0.5</height>
+      </markers>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping2_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_stationkeeping0_task">
+  <world name="practice_2023_stationkeeping2_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -342,7 +342,7 @@
     </light>
 
     <include>
-      <pose>0 0 0.2 0 0 0 </pose>
+      <pose> 0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>
 
@@ -423,7 +423,8 @@
       </plugin>
     </include>
 
-    <!-- Load the plugin for the wind --> 
+    <!-- Load the plugin for the wind -->
+
     <plugin
       filename="libUSVWind.so"
       name="vrx::USVWind">
@@ -433,18 +434,17 @@
         <coeff_vector>.5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>240</wind_direction>
+      <wind_direction>265</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>0.0</wind_mean_velocity>
-      <var_wind_gain_constants>0</var_wind_gain_constants>
+      <wind_mean_velocity>7.0</wind_mean_velocity>
+      <var_wind_gain_constants>1.5</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>10</random_seed>
+      <random_seed>12</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
      </plugin>
-
 
     <!-- The wave field -->
     <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
@@ -487,7 +487,7 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.2
+            double_value: 0.8
           }
         }
         params {
@@ -564,7 +564,7 @@
       <running_state_duration>300</running_state_duration>
       <release_topic>/vrx/release</release_topic>
       <!-- <head_error_on>false</head_error_on> -->
-      <goal_pose>-33.722718 150.674031 0</goal_pose>
+      <goal_pose>-33.7226643 150.673947 -1.0</goal_pose>
       <markers>
         <scaling>0.2 0.2 2.0</scaling>
         <height>0.5</height>

--- a/vrx_gz/worlds/2023_practice/practice_2023_wayfinding0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wayfinding0_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_follow_path2_task">
+  <world name="practice_2023_wayfinding0_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -308,6 +308,7 @@
       filename="gz-sim-navsat-system"
       name="gz::sim::systems::NavSat">
     </plugin>
+
     <scene>
       <sky></sky>
       <grid>false</grid>
@@ -341,7 +342,7 @@
     </light>
 
     <include>
-      <pose> 0 0 0.2 0 0 0 </pose>
+      <pose>0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>
 
@@ -354,12 +355,6 @@
     <include>
       <name>platform</name>
       <uri>platform</uri>
-    </include>
-
-    <!-- The VRX short navigation course -->
-    <include>
-      <uri>model://short_navigation_course_2</uri>
-      <pose>-524 186 0 0 0 -1.44</pose>
     </include>
 
     <!-- The posts for securing the WAM-V -->
@@ -432,81 +427,159 @@
     <plugin
       filename="libUSVWind.so"
       name="vrx::USVWind">
-      <!-- models to be effected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
-        <coeff_vector> .5 .5 .33</coeff_vector>
+        <coeff_vector>.5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>355</wind_direction>
+      <wind_direction>240</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>9.0</wind_mean_velocity>
-      <var_wind_gain_constants>5.0</var_wind_gain_constants>
+      <wind_mean_velocity>0.0</wind_mean_velocity>
+      <var_wind_gain_constants>0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>19</random_seed>
+      <random_seed>10</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
+     </plugin>
+
+
+    <!-- The wave field -->
+    <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
+      <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
+               every="2.0">
+        params {
+          key: "amplitude"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
+          key: "angle"
+          value {
+            type: DOUBLE
+            double_value: 0.4
+          }
+        }
+        params {
+          key: "cell_count"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 300
+              y: 300
+            }
+          }
+        }
+        params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.2
+          }
+        }
+        params {
+          key: "model"
+          value {
+            type: STRING
+            string_value: "PMS"
+          }
+        }
+        params {
+          key: "number"
+          value {
+            type: INT32
+            int_value: 3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "phase"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
+          key: "scale"
+          value {
+            type: DOUBLE
+            double_value: 1.1
+          }
+        }
+        params {
+          key: "size"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 6000
+              y: 6000
+            }
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
+          key: "tau"
+          value {
+            type: DOUBLE
+            double_value: 2
+          }
+        }
+      </message>
     </plugin>
 
-    <!-- Scoring Plugin -->
+    <!-- The wayfinding scoring plugin -->
     <plugin
-      filename="libNavigationScoringPlugin.so"
-      name="vrx::NavigationScoringPlugin">
+      filename="libWayfindingScoringPlugin.so"
+      name="vrx::WayfindingScoringPlugin">
       <vehicle>wamv</vehicle>
-      <task_name>follow_path</task_name>
+      <task_name>wayfinding</task_name>
+      <waypoints>
+        <waypoint>
+          <pose>-33.722611 150.674051 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722574 150.6744381 0.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722680 150.674756 -1.0</pose>
+        </waypoint>
+      </waypoints>
+      <markers>
+        <scaling>0.2 0.2 2.0 </scaling>
+        <height>0.5 </height>
+      </markers>
+
+
       <task_info_topic>/vrx/task/info</task_info_topic>
-      <contact_debug_topic>/vrx/follow_path/debug/contact</contact_debug_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>
-      <collision_buffer>10</collision_buffer>
       <release_topic>/vrx/release</release_topic>
-
-      <course_name>short_navigation_course_2</course_name>
-      <points_per_gate_crossed>10</points_per_gate_crossed>
-      <obstacle_penalty>3.0</obstacle_penalty>
-      <bonus>1</bonus>
-      <gates>
-        <gate>
-          <left_marker>red_bound_0</left_marker>
-          <right_marker>green_bound_0</right_marker>
-        </gate>
-        <gate>
-          <left_marker>red_bound_1</left_marker>
-          <right_marker>green_bound_1</right_marker>
-        </gate>
-        <gate>
-          <left_marker>red_bound_2</left_marker>
-          <right_marker>green_bound_2</right_marker>
-        </gate>
-        <gate>
-          <left_marker>red_bound_3</left_marker>
-          <right_marker>green_bound_3</right_marker>
-        </gate>
-        <gate>
-          <left_marker>red_bound_4</left_marker>
-          <right_marker>green_bound_4</right_marker>
-        </gate>
-        <gate>
-          <left_marker>red_bound_5</left_marker>
-          <right_marker>green_bound_5</right_marker>
-        </gate>
-        <gate>
-          <left_marker>red_bound_6</left_marker>
-          <right_marker>green_bound_6</right_marker>
-        </gate>
-        <gate>
-          <left_marker>red_bound_7</left_marker>
-          <right_marker>green_bound_7</right_marker>
-        </gate>
-         <gate>
-          <left_marker>red_bound_8</left_marker>
-          <right_marker>green_bound_8</right_marker>
-        </gate>
-     </gates>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_wayfinding1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wayfinding1_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_perception0_task">
+  <world name="practice_2023_wayfinding0_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -427,144 +427,23 @@
     <plugin
       filename="libUSVWind.so"
       name="vrx::USVWind">
-      <!-- models to be effected by the wind -->
+      <!-- models to be affected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
         <coeff_vector> .5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>240</wind_direction>
+      <wind_direction>315</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>0.0</wind_mean_velocity>
-      <var_wind_gain_constants>0.0</var_wind_gain_constants>
+      <wind_mean_velocity>4.0</wind_mean_velocity>
+      <var_wind_gain_constants>2.0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>10</random_seed>
+      <random_seed>15</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
-    </plugin>
-
-
-    <!-- Include all the objects we plan to use for perception.
-       Stash them out of the field of view for now -->
-    <include>
-      <name>red_0</name>
-      <pose>-200 100 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_red</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>green_0</name>
-      <pose>-200 102 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_green</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>white_0</name>
-      <pose>-200 104 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_white</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <!-- The perception scoring plugin -->
-    <plugin
-      filename="libPerceptionScoringPlugin.so"
-      name="vrx::PerceptionScoringPlugin">
-      <!-- Parameters for ScoringPlugin base class -->
-      <vehicle>wamv</vehicle>
-      <task_name>perception</task_name>
-      <initial_state_duration>10.0</initial_state_duration>
-      <ready_state_duration>10.0</ready_state_duration>
-      <running_state_duration>300</running_state_duration>
-      <!-- Parameters for PerceptionScoringPlugin -->
-      <frame>wamv</frame>
-      <!-- Pose of each object is expressed relative to the body frame
-           of the object named in the frame field - i.e., relative to
-           the wam-v-->
-      <object_sequence>
-        <object>
-          <time>5</time>
-          <type>mb_marker_buoy_red</type>
-          <name>red_0</name>
-          <pose>7.8 2.1 0.7 0 0 0</pose>
-        </object>
-        <object>
-          <time>15</time>
-          <type>mb_marker_buoy_green</type>
-          <name>green_0</name>
-          <pose>8.3 0.1 0.7 0 0 0</pose>
-        </object>
-        <object>
-          <time>25.0</time>
-          <type>mb_marker_buoy_white</type>
-          <name>white_0</name>
-          <pose>4.9 -2.32 0.2 0 0 0</pose>
-        </object>
-      </object_sequence>
     </plugin>
 
     <!-- The wave field -->
@@ -608,7 +487,7 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.2
+            double_value: 0.5
           }
         }
         params {
@@ -671,6 +550,39 @@
           }
         }
       </message>
+    </plugin>
+
+    <!-- The wayfinding scoring plugin -->
+    <plugin
+      filename="libWayfindingScoringPlugin.so"
+      name="vrx::WayfindingScoringPlugin">
+      <vehicle>wamv</vehicle>
+      <task_name>wayfinding</task_name>
+      <waypoints>
+        <waypoint>
+          <pose>-33.722726 150.674110 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722418 150.673634 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722106 150.673663 0.5</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722006 150.674110 -3</pose>
+        </waypoint>
+      </waypoints>
+      <markers>
+        <scaling>0.2 0.2 2.0 </scaling>
+        <height>0.5 </height>
+      </markers>
+
+
+      <task_info_topic>/vrx/task/info</task_info_topic>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <release_topic>/vrx/release</release_topic>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_wayfinding2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wayfinding2_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_follow_path1_task">
+  <world name="practice_2023_wayfinding0_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -308,6 +308,7 @@
       filename="gz-sim-navsat-system"
       name="gz::sim::systems::NavSat">
     </plugin>
+
     <scene>
       <sky></sky>
       <grid>false</grid>
@@ -341,7 +342,7 @@
     </light>
 
     <include>
-      <pose> 0 0 0.2 0 0 0 </pose>
+      <pose>0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>
 
@@ -354,12 +355,6 @@
     <include>
       <name>platform</name>
       <uri>platform</uri>
-    </include>
-
-    <!-- The VRX short navigation course -->
-    <include>
-      <uri>model://short_navigation_course_1</uri>
-      <pose>-535 180 0 0 0 -1.44</pose>
     </include>
 
     <!-- The posts for securing the WAM-V -->
@@ -429,72 +424,168 @@
     </include>
 
     <!-- Load the plugin for the wind -->
+
     <plugin
       filename="libUSVWind.so"
       name="vrx::USVWind">
-      <!-- models to be effected by the wind -->
+      <!-- models to be affected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
         <coeff_vector> .5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>72</wind_direction>
+      <wind_direction>244</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>5.0</wind_mean_velocity>
-      <var_wind_gain_constants>4.0</var_wind_gain_constants>
+      <wind_mean_velocity>8.0</wind_mean_velocity>
+      <var_wind_gain_constants>2.0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>7</random_seed>
+      <random_seed>9</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
     </plugin>
+    <!-- The wave field -->
+    <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
+      <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
+               every="2.0">
+        params {
+          key: "amplitude"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
+          key: "angle"
+          value {
+            type: DOUBLE
+            double_value: 0.4
+          }
+        }
+        params {
+          key: "cell_count"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 300
+              y: 300
+            }
+          }
+        }
+        params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.8
+          }
+        }
+        params {
+          key: "model"
+          value {
+            type: STRING
+            string_value: "PMS"
+          }
+        }
+        params {
+          key: "number"
+          value {
+            type: INT32
+            int_value: 3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "phase"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
+          key: "scale"
+          value {
+            type: DOUBLE
+            double_value: 1.1
+          }
+        }
+        params {
+          key: "size"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 6000
+              y: 6000
+            }
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
+          key: "tau"
+          value {
+            type: DOUBLE
+            double_value: 2
+          }
+        }
+      </message>
+    </plugin>
 
-    <!-- Scoring Plugin -->
+    <!-- The wayfinding scoring plugin -->
     <plugin
-      filename="libNavigationScoringPlugin.so"
-      name="vrx::NavigationScoringPlugin">
+      filename="libWayfindingScoringPlugin.so"
+      name="vrx::WayfindingScoringPlugin">
       <vehicle>wamv</vehicle>
-      <task_name>follow_path</task_name>
+      <task_name>wayfinding</task_name>
+      <waypoints>
+        <waypoint>
+          <pose>-33.722462 150.674268 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722262 150.674800 -1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.7226908 150.6751165 0.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.722925 150.675304 1.0</pose>
+        </waypoint>
+        <waypoint>
+          <pose>-33.7226908 150.6755165 -2.5</pose>
+        </waypoint>
+      </waypoints>
+      <markers>
+        <scaling>0.2 0.2 2.0 </scaling>
+        <height>0.5 </height>
+      </markers>
+
+
       <task_info_topic>/vrx/task/info</task_info_topic>
-      <contact_debug_topic>/vrx/follow_path/debug/contact</contact_debug_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>
-      <collision_buffer>10</collision_buffer>
       <release_topic>/vrx/release</release_topic>
-
-      <course_name>short_navigation_course_1</course_name>
-      <points_per_gate_crossed>10</points_per_gate_crossed>
-      <bonus>1</bonus>
-      <obstacle_penalty>3.0</obstacle_penalty>
-      <gates>
-        <gate>
-          <left_marker>red_bound_0</left_marker>
-          <right_marker>green_bound_0</right_marker>
-        </gate>
-        <gate>
-          <left_marker>red_bound_1</left_marker>
-          <right_marker>green_bound_1</right_marker>
-        </gate>
-        <gate>
-          <left_marker>red_bound_2</left_marker>
-          <right_marker>green_bound_2</right_marker>
-        </gate>
-        <gate>
-          <left_marker>red_bound_3</left_marker>
-          <right_marker>green_bound_3</right_marker>
-        </gate>
-        <gate>
-          <left_marker>red_bound_4</left_marker>
-          <right_marker>green_bound_4</right_marker>
-        </gate>
-        <gate>
-          <left_marker>red_bound_5</left_marker>
-          <right_marker>green_bound_5</right_marker>
-        </gate>
-      </gates>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife0_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_acoustic_tracking0_task">
+  <world name="practice_2023_wildlife0_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -342,7 +342,7 @@
     </light>
 
     <include>
-      <pose>0 0 0.2 0 0 0 </pose>
+      <pose> 0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>
 
@@ -355,6 +355,120 @@
     <include>
       <name>platform</name>
       <uri>platform</uri>
+    </include>
+
+    <!-- The crocodile buoy -->
+    <include>
+      <pose>-520 180 0 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/crocodile</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="buoyancy_box">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.80 0.40 0.15</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+
+      <plugin filename="gz-sim-trajectory-follower-system"
+              name="gz::sim::systems::TrajectoryFollower">
+        <link_name>link</link_name>
+        <loop>true</loop>
+        <force>18</force>
+        <torque>1.5</torque>
+        <waypoints>
+          <waypoint>-523 179</waypoint>
+          <waypoint>-520 180</waypoint>
+        </waypoints>
+      </plugin>
+    </include>
+
+    <!-- The turtle buoy -->
+    <include>
+      <pose>-550 230 0 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/turtle</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="buoyancy_sphere">
+          <link_name>link</link_name>
+          <pose>0 0 0.2 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.35</radius>
+            </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+
+      <plugin filename="gz-sim-trajectory-follower-system"
+              name="gz::sim::systems::TrajectoryFollower">
+        <link_name>link</link_name>
+        <loop>true</loop>
+        <force>6</force>
+        <torque>1</torque>
+        <waypoints>
+          <waypoint>-551 233</waypoint>
+          <waypoint>-550 230</waypoint>
+        </waypoints>
+      </plugin>
+    </include>
+
+    <!-- The platypus buoy -->
+    <include>
+      <pose>-500 210 0 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/platypus</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="buoyancy_box">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.75 0.35 0.16</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+
+      <plugin filename="gz-sim-trajectory-follower-system"
+              name="gz::sim::systems::TrajectoryFollower">
+        <link_name>link</link_name>
+        <loop>true</loop>
+        <force>18</force>
+        <torque>1.5</torque>
+        <waypoints>
+          <waypoint>-496 211</waypoint>
+          <waypoint>-500 210</waypoint>
+        </waypoints>
+      </plugin>
     </include>
 
     <!-- The posts for securing the WAM-V -->
@@ -423,343 +537,10 @@
       </plugin>
     </include>
 
-    <include>
-      <name>mb_round_buoy_black_0</name>
-      <pose>-527 200 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_1</name>
-      <pose>-523 180 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_2</name>
-      <pose>-525 203 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_3</name>
-      <pose>-530 190 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_4</name>
-      <pose>-525 160 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_5</name>
-      <pose>-505 203 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_6</name>
-      <pose>-528.5 190 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_7</name>
-      <pose>-530 206 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_8</name>
-      <pose>-504 196 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_9</name>
-      <pose>-512 185 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <!-- The moving pinger -->
-    <model name="pinger">
-      <pose>-525 167 0 0 0 0</pose>
-      <link name="link">
-        <inertial>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <mass>20</mass>
-          <inertia>
-            <ixx>0.24683</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.98016</iyy>
-            <iyz>0</iyz>
-            <izz>1.14166</izz>
-          </inertia>
-        </inertial>
-        <!-- Uncomment to visualize the pinger -->
-        <!-- <visual name="visual">
-          <geometry>
-            <box>
-              <size>0.5 0.5 0.5</size>
-            </box>
-          </geometry>
-          <material>
-            <ambient>1 1 1</ambient>
-            <diffuse>1 1 1</diffuse>
-            <specular>1 1 1 1</specular>
-          </material>
-        </visual> -->
-      </link>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="buoyancy_box">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <box>
-              <size>0.75 0.35 0.16</size>
-            </box>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-
-      <plugin filename="gz-sim-trajectory-follower-system"
-              name="gz::sim::systems::TrajectoryFollower">
-        <link_name>link</link_name>
-        <loop>true</loop>
-        <force>350</force>
-        <torque>1.5</torque>
-        <waypoints>
-          <waypoint>-526 170</waypoint>
-          <waypoint>-530 210</waypoint>
-          <waypoint>-502 201</waypoint>
-        </waypoints>
-      </plugin>
-    </model>
-
-    <!-- The acoustic tracking scoring plugin -->
-    <plugin
-      filename="libAcousticTrackingScoringPlugin.so"
-      name="vrx::AcousticTrackingScoringPlugin">
-      <vehicle>wamv</vehicle>
-      <task_name>acoustic_tracking</task_name>
-      <task_info_topic>/vrx/task/info</task_info_topic>
-      <contact_debug_topic>/vrx/acoustic_tracking/debug/contact</contact_debug_topic>
-      <initial_state_duration>10</initial_state_duration>
-      <ready_state_duration>10</ready_state_duration>
-      <running_state_duration>300</running_state_duration>
-      <release_topic>/vrx/release</release_topic>      
-      <set_pinger_position_topic>/wamv/pingers/pinger/set_pinger_position</set_pinger_position_topic>
-      <pinger_model>pinger</pinger_model>
-      <pinger_depth>2.0</pinger_depth>
-    </plugin>
-
     <!-- Load the plugin for the wind -->
     <plugin
-       filename="libUSVWind.so"
+      filename="libUSVWind.so"
       name="vrx::USVWind">
-     <!-- models to be effected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
@@ -776,7 +557,7 @@
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
-    </plugin>
+     </plugin>
 
     <!-- The wave field -->
     <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
@@ -819,7 +600,7 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.3
+            double_value: 0.2
           }
         }
         params {
@@ -882,6 +663,39 @@
           }
         }
       </message>
+    </plugin>
+
+    <!-- The wildlife scoring plugin -->
+    <plugin
+      filename="libWildlifeScoringPlugin.so"
+      name="vrx::WildlifeScoringPlugin">
+
+      <!-- Common parameters -->
+      <vehicle>wamv</vehicle>
+      <task_name>wildlife</task_name>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <collision_buffer>10</collision_buffer>
+
+      <!-- wildlife specific parameters -->
+      <buoys>
+        <buoy>
+          <name>crocodile::link</name>
+          <goal>avoid</goal>
+        </buoy>
+        <buoy>
+          <name>platypus::link</name>
+          <goal>circumnavigate_clockwise</goal>
+        </buoy>
+        <buoy>
+          <name>turtle::link</name>
+          <goal>circumnavigate_counterclockwise</goal>
+        </buoy>
+      </buoys>
+      <engagement_distance>10.0</engagement_distance>
+      <time_bonus>30.0</time_bonus>
+      <topic_prefix>/vrx/wildlife/animal</topic_prefix>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife1_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_acoustic_tracking2_task">
+  <world name="practice_2023_wildlife1_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -342,7 +342,7 @@
     </light>
 
     <include>
-      <pose>0 0 0.2 0 0 0 </pose>
+      <pose> 0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>
 
@@ -355,6 +355,122 @@
     <include>
       <name>platform</name>
       <uri>platform</uri>
+    </include>
+
+    <!-- The crocodile buoy -->
+    <include>
+      <pose>-510 199 0 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/crocodile</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="buoyancy_box">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.80 0.40 0.15</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+
+      <plugin filename="gz-sim-trajectory-follower-system"
+              name="gz::sim::systems::TrajectoryFollower">
+        <link_name>link</link_name>
+        <loop>true</loop>
+        <force>18</force>
+        <torque>1.5</torque>
+        <waypoints>
+          <waypoint>-511 203</waypoint>
+          <waypoint>-510 199</waypoint>
+        </waypoints>
+      </plugin>
+    </include>
+
+    <!-- A turtle buoy -->
+    <include>
+      <name>turtle1</name>
+      <pose>-550 201 0 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/turtle</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="buoyancy_sphere">
+          <link_name>link</link_name>
+          <pose>0 0 0.2 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.35</radius>
+            </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+
+      <plugin filename="gz-sim-trajectory-follower-system"
+              name="gz::sim::systems::TrajectoryFollower">
+        <link_name>link</link_name>
+        <loop>true</loop>
+        <force>6</force>
+        <torque>1</torque>
+        <waypoints>
+          <waypoint>-551 203</waypoint>
+          <waypoint>-550 201</waypoint>
+        </waypoints>
+      </plugin>
+    </include>
+
+    <!-- A turtle buoy -->
+    <include>
+      <name>turtle2</name>
+      <pose>-470 200 0 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/turtle</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="buoyancy_sphere">
+          <link_name>link</link_name>
+          <pose>0 0 0.2 0 0 0</pose>
+          <geometry>
+            <sphere>
+              <radius>0.35</radius>
+            </sphere>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+
+      <plugin filename="gz-sim-trajectory-follower-system"
+              name="gz::sim::systems::TrajectoryFollower">
+        <link_name>link</link_name>
+        <loop>true</loop>
+        <force>6</force>
+        <torque>1</torque>
+        <waypoints>
+          <waypoint>-470 205</waypoint>
+          <waypoint>-470 200</waypoint>
+        </waypoints>
+      </plugin>
     </include>
 
     <!-- The posts for securing the WAM-V -->
@@ -423,439 +539,6 @@
       </plugin>
     </include>
 
-    <include>
-      <name>mb_round_buoy_black_0</name>
-      <pose>-527 200 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_1</name>
-      <pose>-504 180 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_2</name>
-      <pose>-525 203 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_3</name>
-      <pose>-536.5 190 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_4</name>
-      <pose>-535.5 182 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_5</name>
-      <pose>-527 183 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_6</name>
-      <pose>-505 190 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_7</name>
-      <pose>-530 206 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_8</name>
-      <pose>-520 167 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_black_9</name>
-      <pose>-531 170 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <!-- <include>
-      <name>mb_round_buoy_orange_1</name>
-      <pose>-536 167 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_orange_2</name>
-      <pose>-505 200 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_orange_3</name>
-      <pose>-536 200 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>mb_round_buoy_orange_4</name>
-      <pose>-505 167 0.0 0 0 0 </pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include> -->
-
-    <!-- The moving pinger -->
-    <model name="pinger">
-      <pose>-536 167 0 0 0 0</pose>
-      <link name="link">
-        <inertial>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <mass>20</mass>
-          <inertia>
-            <ixx>0.24683</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.98016</iyy>
-            <iyz>0</iyz>
-            <izz>1.14166</izz>
-          </inertia>
-        </inertial>
-        <!-- Uncomment to visualize the pinger -->
-        <!-- <visual name="visual">
-          <geometry>
-            <box>
-              <size>0.5 0.5 0.5</size>
-            </box>
-          </geometry>
-          <material>
-            <ambient>1 1 1</ambient>
-            <diffuse>1 1 1</diffuse>
-            <specular>1 1 1 1</specular>
-          </material>
-        </visual> -->
-      </link>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="buoyancy_box">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <box>
-              <size>0.75 0.35 0.16</size>
-            </box>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-
-      <plugin filename="gz-sim-trajectory-follower-system"
-              name="gz::sim::systems::TrajectoryFollower">
-        <link_name>link</link_name>
-        <loop>true</loop>
-        <force>350</force>
-        <torque>1.5</torque>
-        <waypoints>
-          <waypoint>-536 167</waypoint>
-          <waypoint>-536 200</waypoint>
-          <waypoint>-505 200</waypoint>
-          <waypoint>-505 167</waypoint>
-        </waypoints>
-      </plugin>
-    </model>
-
-    <!-- The acoustic tracking scoring plugin -->
-    <plugin
-      filename="libAcousticTrackingScoringPlugin.so"
-      name="vrx::AcousticTrackingScoringPlugin">
-      <vehicle>wamv</vehicle>
-      <task_name>acoustic_tracking</task_name>
-      <task_info_topic>/vrx/task/info</task_info_topic>
-      <contact_debug_topic>/vrx/acoustic_tracking/debug/contact</contact_debug_topic>
-      <initial_state_duration>10</initial_state_duration>
-      <ready_state_duration>10</ready_state_duration>
-      <running_state_duration>300</running_state_duration>
-      <release_topic>/vrx/release</release_topic>      
-      <set_pinger_position_topic>/wamv/pingers/pinger/set_pinger_position</set_pinger_position_topic>
-      <pinger_model>pinger</pinger_model>
-      <pinger_depth>2.0</pinger_depth>
-    </plugin>
-
     <!-- Load the plugin for the wind -->
     <plugin
       filename="libUSVWind.so"
@@ -867,18 +550,18 @@
         <coeff_vector> .5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>17</wind_direction>
+      <wind_direction>37</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>8.0</wind_mean_velocity>
-      <var_wind_gain_constants>4.0</var_wind_gain_constants>
+      <wind_mean_velocity>3.7</wind_mean_velocity>
+      <var_wind_gain_constants>3.0</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>19</random_seed>
+      <random_seed>12</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
     </plugin>
-        
+
     <!-- The wave field -->
     <plugin filename="libPublisherPlugin.so" name="vrx::PublisherPlugin">
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
@@ -920,7 +603,7 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.8
+            double_value: 0.5
           }
         }
         params {
@@ -983,6 +666,40 @@
           }
         }
       </message>
+    </plugin>
+
+    <!-- The wildlife scoring plugin -->
+    <plugin
+      filename="libWildlifeScoringPlugin.so"
+      name="vrx::WildlifeScoringPlugin">
+
+      <!-- Common parameters -->
+      <vehicle>wamv</vehicle>
+      <task_name>wildlife</task_name>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <collision_buffer>10</collision_buffer>
+
+      <!-- wildlife specific parameters -->
+      <buoys>
+        <buoy>
+          <name>crocodile::link</name>
+          <goal>avoid</goal>
+        </buoy>
+        <buoy>
+          <name>turtle1::link</name>
+          <goal>circumnavigate_counterclockwise</goal>
+        </buoy>
+        <buoy>
+          <name>turtle2::link</name>
+          <goal>circumnavigate_counterclockwise</goal>
+        </buoy>
+      </buoys>
+      <engagement_distance>10.0</engagement_distance>
+      <time_bonus>30.0</time_bonus>
+      <topic_prefix>/vrx/wildlife/animal</topic_prefix>
+      <publication_frequency>0.33</publication_frequency>
     </plugin>
 
   </world>

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife2_task.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <sdf version="1.9">
-  <world name="practice_2022_perception1_task">
+  <world name="practice_2023_wildlife2_task">
 
     <physics name="4ms" type="dart">
       <max_step_size>0.004</max_step_size>
@@ -342,7 +342,7 @@
     </light>
 
     <include>
-      <pose>0 0 0.2 0 0 0 </pose>
+      <pose> 0 0 0.2 0 0 0 </pose>
       <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/sydney_regatta</uri>
     </include>
 
@@ -355,6 +355,123 @@
     <include>
       <name>platform</name>
       <uri>platform</uri>
+    </include>
+
+    <!-- The crocodile buoy -->
+    <include>
+      <name>crocodile1</name>
+      <pose>-550 189 0 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/crocodile</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="buoyancy_box">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.80 0.40 0.15</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+
+      <plugin filename="gz-sim-trajectory-follower-system"
+              name="gz::sim::systems::TrajectoryFollower">
+        <link_name>link</link_name>
+        <loop>true</loop>
+        <force>18</force>
+        <torque>1.5</torque>
+        <waypoints>
+          <waypoint>-550 189</waypoint>
+          <waypoint>-520 190</waypoint>
+        </waypoints>
+      </plugin>
+    </include>
+
+    <!-- The crocodile buoy -->
+    <include>
+      <name>crocodile2</name>
+      <pose>-520 225 0 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/crocodile</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="buoyancy_box">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.80 0.40 0.15</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+
+      <plugin filename="gz-sim-trajectory-follower-system"
+              name="gz::sim::systems::TrajectoryFollower">
+        <link_name>link</link_name>
+        <loop>true</loop>
+        <force>18</force>
+        <torque>1.5</torque>
+        <waypoints>
+          <waypoint>-520 225</waypoint>
+          <waypoint>-500 224</waypoint>
+        </waypoints>
+      </plugin>
+    </include>
+
+    <!-- A platypus buoy -->
+    <include>
+      <name>platypus</name>
+      <pose>-500 260 0 0 0 0</pose>
+      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/platypus</uri>
+
+      <plugin name="vrx::PolyhedraBuoyancyDrag"
+              filename="libPolyhedraBuoyancyDrag.so">
+        <fluid_density>1000</fluid_density>
+        <fluid_level>0.0</fluid_level>
+        <linear_drag>25.0</linear_drag>
+        <angular_drag>2.0</angular_drag>
+        <buoyancy name="buoyancy_box">
+          <link_name>link</link_name>
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.75 0.35 0.16</size>
+            </box>
+          </geometry>
+        </buoyancy>
+        <wavefield>
+          <topic>/vrx/wavefield/parameters</topic>
+        </wavefield>
+      </plugin>
+
+      <plugin filename="gz-sim-trajectory-follower-system"
+              name="gz::sim::systems::TrajectoryFollower">
+        <link_name>link</link_name>
+        <loop>true</loop>
+        <force>18</force>
+        <torque>1.5</torque>
+        <waypoints>
+          <waypoint>-500 260</waypoint>
+          <waypoint>-500 270</waypoint>
+        </waypoints>
+      </plugin>
     </include>
 
     <!-- The posts for securing the WAM-V -->
@@ -423,228 +540,27 @@
       </plugin>
     </include>
 
-     <!-- Load the plugin for the wind -->
+    <!-- Load the plugin for the wind -->
     <plugin
       filename="libUSVWind.so"
       name="vrx::USVWind">
-      <!-- models to be effected by the wind -->
+      <!-- models to be affected by the wind -->
       <wind_obj>
         <name>wamv</name>
         <link_name>wamv/base_link</link_name>
         <coeff_vector> .5 .5 .33</coeff_vector>
       </wind_obj>
       <!-- Wind -->
-      <wind_direction>240</wind_direction>
+      <wind_direction>359</wind_direction>
       <!-- in degrees -->
-      <wind_mean_velocity>0.0</wind_mean_velocity>
-      <var_wind_gain_constants>0.0</var_wind_gain_constants>
+      <wind_mean_velocity>6.35</wind_mean_velocity>
+      <var_wind_gain_constants>4.1</var_wind_gain_constants>
       <var_wind_time_constants>2</var_wind_time_constants>
-      <random_seed>10</random_seed>
+      <random_seed>11</random_seed>
       <!-- set to zero/empty to randomize -->
       <update_rate>10</update_rate>
       <topic_wind_speed>/vrx/debug/wind/speed</topic_wind_speed>
       <topic_wind_direction>/vrx/debug/wind/direction</topic_wind_direction>
-    </plugin>
-
-    <!-- Include all the objects we plan to use for perception.
-       Stash them out of the field of view for now -->
-    <include>
-      <name>orange_round</name>
-      <pose>-200 100 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_orange</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>green_0</name>
-      <pose>-200 102 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_green</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>black_round_0</name>
-      <pose>-200 106 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>black_round_1</name>
-      <pose>-200 112 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_round_buoy_black</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 0 0 0 0</pose>
-          <geometry>
-            <sphere>
-              <radius>0.25</radius>
-          </sphere>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <include>
-      <name>white_0</name>
-      <pose>-200 104 1 0 0 0</pose>
-      <uri>https://fuel.gazebosim.org/1.0/openrobotics/models/mb_marker_buoy_white</uri>
-
-      <plugin name="vrx::PolyhedraBuoyancyDrag"
-              filename="libPolyhedraBuoyancyDrag.so">
-        <fluid_density>1000</fluid_density>
-        <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
-        <angular_drag>2.0</angular_drag>
-        <buoyancy name="collision_outer">
-          <link_name>link</link_name>
-          <pose>0 0 -0.3 0 0 0</pose>
-          <geometry>
-            <cylinder>
-              <radius>0.325</radius>
-              <length>0.1</length>
-            </cylinder>
-          </geometry>
-        </buoyancy>
-        <wavefield>
-          <topic>/vrx/wavefield/parameters</topic>
-        </wavefield>
-      </plugin>
-    </include>
-
-    <!-- The perception scoring plugin -->
-    <plugin
-      filename="libPerceptionScoringPlugin.so"
-      name="vrx::PerceptionScoringPlugin">
-      <!-- Parameters for ScoringPlugin base class -->
-      <vehicle>wamv</vehicle>
-      <task_name>perception</task_name>
-      <initial_state_duration>10.0</initial_state_duration>
-      <ready_state_duration>10.0</ready_state_duration>
-      <running_state_duration>300</running_state_duration>
-      <!-- Parameters for PerceptionScoringPlugin -->
-      <frame>wamv</frame>
-      <!-- Pose of each object is expressed relative to the body frame
-           of the object named in the frame field - i.e., relative to
-           the wam-v-->
-      <object_sequence>
-        <object>
-          <time>5.0</time>
-          <type>mb_round_buoy_orange</type>
-          <name>orange_round</name>
-          <pose>7.8 2.1 0.7 0 0 0</pose>
-        </object>
-        <object>
-          <time>5.0</time>
-          <type>mb_marker_buoy_green</type>
-          <name>green_0</name>
-          <pose>7.8 -2.1 0.7 0 0 0</pose>
-        </object>
-        <object>
-          <time>15.0</time>
-          <type>mb_marker_buoy_green</type>
-          <name>green_0</name>
-          <pose>8.3 1.5 0.7 0 0 0</pose>
-        </object>
-        <object>
-          <time>15.0</time>
-          <type>mb_round_buoy_orange</type>
-          <name>orange_round</name>
-          <pose>6.0 -1.0 0.7 0 0 0</pose>
-        </object>
-        <object>
-          <time>25.0</time>
-          <type>mb_round_buoy_black</type>
-          <name>black_round_0</name>
-          <pose>4.9 1.32 0.2 0 0 0</pose>
-        </object>
-        <object>
-          <time>25.0</time>
-          <type>mb_round_buoy_black</type>
-          <name>black_round_1</name>
-          <pose>4.7 0.7 0.2 0 0 0</pose>
-        </object>
-        <object>
-          <time>35.0</time>
-          <type>mb_marker_buoy_white</type>
-          <name>white_0</name>
-          <pose>4.1 -2.2 0.2 0 0 0</pose>
-        </object>
-        <object>
-          <time>35.0</time>
-          <type>mb_round_buoy_black</type>
-          <name>black_round_0</name>
-          <pose>6.1 0.2 0.2 0 0 0</pose>
-        </object>
-      </object_sequence>
     </plugin>
 
     <!-- The wave field -->
@@ -688,7 +604,7 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.5
+            double_value: 0.8
           }
         }
         params {
@@ -751,6 +667,40 @@
           }
         }
       </message>
+    </plugin>
+
+    <!-- The wildlife scoring plugin -->
+    <plugin
+      filename="libWildlifeScoringPlugin.so"
+      name="vrx::WildlifeScoringPlugin">
+
+      <!-- Common parameters -->
+      <vehicle>wamv</vehicle>
+      <task_name>wildlife</task_name>
+      <initial_state_duration>10</initial_state_duration>
+      <ready_state_duration>10</ready_state_duration>
+      <running_state_duration>300</running_state_duration>
+      <collision_buffer>10</collision_buffer>
+
+      <!-- wildlife specific parameters -->
+      <buoys>
+        <buoy>
+          <name>crocodile1::link</name>
+          <goal>avoid</goal>
+        </buoy>
+        <buoy>
+          <name>crocodile2::link</name>
+          <goal>avoid</goal>
+        </buoy>
+        <buoy>
+          <name>platypus::link</name>
+          <goal>circumnavigate_clockwise</goal>
+        </buoy>
+      </buoys>
+      <engagement_distance>10.0</engagement_distance>
+      <time_bonus>30.0</time_bonus>
+      <topic_prefix>/vrx/wildlife/animal</topic_prefix>
+      <publication_frequency>0.1</publication_frequency>
     </plugin>
 
   </world>


### PR DESCRIPTION
See #647.

After recompiling you should be able to launch the worlds with:

```
ros2 launch vrx_gz competition.launch.py world:=practice_2023_follow_path1_task
```

Verify a few worlds to make sure that they load correctly.