### PR TITLE
fix wind plugin pause

### DIFF
--- a/vrx_gz/src/USVWind.cc
+++ b/vrx_gz/src/USVWind.cc
@@ -259,7 +259,8 @@ void USVWind::PreUpdate(
     sim::EntityComponentManager &_ecm)
 {
   GZ_PROFILE("USVWind::PreUpdate");
-
+  if (_info.paused)
+    return;
   auto time = std::chrono::duration<double>(_info.simTime);
   if (this->dataPtr->previousTime == std::chrono::duration<double>(0))
   {


### PR DESCRIPTION
Test: run VRX normally.  Echo one of the wind topics, eg:
```
gz topic --echo --topic /vrx/debug/wind/speed
```
Pause the simulation.  You should see the topic stop publishing.  Unpause, watch the messages scroll.
