### PR TITLE
Fix issue #641

### DIFF
--- a/vrx_gz/src/vrx_gz/bridges.py
+++ b/vrx_gz/src/vrx_gz/bridges.py
@@ -46,22 +46,6 @@ def cmd_vel(model_name):
         ros_type='geometry_msgs/msg/Twist',
         direction=BridgeDirection.ROS_TO_GZ)
 
-def acoustic_pinger(model_name):
-    return Bridge(
-        gz_topic=f'{model_name}/pingers/pinger/range_bearing',
-        ros_topic=f'pingers/pinger/range_bearing',
-        gz_type='ignition.msgs.Param',
-        ros_type='ros_gz_interfaces/msg/ParamVec',
-        direction=BridgeDirection.GZ_TO_ROS)
-
-def set_acoustic_pinger(model_name):
-    return Bridge(
-        gz_topic=f'{model_name}/pingers/pinger/set_pinger_position',
-        ros_topic=f'pingers/pinger/set_pinger_position',
-        gz_type='ignition.msgs.Vector3d',
-        ros_type='geometry_msgs/msg/Vector3',
-        direction=BridgeDirection.ROS_TO_GZ)
-
 def comms_tx(model_name):
     return Bridge(
         gz_topic='/broker/msgs',

--- a/vrx_gz/src/vrx_gz/model.py
+++ b/vrx_gz/src/vrx_gz/model.py
@@ -87,11 +87,7 @@ class Model:
                 vrx_gz.bridges.cmd_vel(self.model_name)
             ])
         elif self.is_USV():
-            bridges.extend([
-                # Acoustic pinger
-                vrx_gz.bridges.acoustic_pinger(self.model_name),
-                vrx_gz.bridges.set_acoustic_pinger(self.model_name),
-            ])
+            pass
 
         return [bridges, nodes, custom_launches]
 

--- a/vrx_gz/src/vrx_gz/payload_bridges.py
+++ b/vrx_gz/src/vrx_gz/payload_bridges.py
@@ -156,6 +156,22 @@ def thrust_joint_pos(model_name, side):
         ros_type='std_msgs/msg/Float64',
         direction=BridgeDirection.ROS_TO_GZ)
 
+def acoustic_pinger(model_name):
+    return Bridge(
+        gz_topic=f'{model_name}/pingers/pinger/range_bearing',
+        ros_topic=f'pingers/pinger/range_bearing',
+        gz_type='ignition.msgs.Param',
+        ros_type='ros_gz_interfaces/msg/ParamVec',
+        direction=BridgeDirection.GZ_TO_ROS)
+
+def set_acoustic_pinger(model_name):
+    return Bridge(
+        gz_topic=f'{model_name}/pingers/pinger/set_pinger_position',
+        ros_topic=f'pingers/pinger/set_pinger_position',
+        gz_type='ignition.msgs.Vector3d',
+        ros_type='geometry_msgs/msg/Vector3',
+        direction=BridgeDirection.ROS_TO_GZ)
+
 def payload_bridges(world_name, model_name, link_name, sensor_name, sensor_type):
     bridges = []
     if sensor_type == sdf.Sensortype.CAMERA:
@@ -202,6 +218,11 @@ def payload_bridges(world_name, model_name, link_name, sensor_name, sensor_type)
     elif 'thruster_rotate_' in sensor_name:
         bridges = [
             thrust_joint_pos(model_name, sensor_type),
+        ]
+    elif 'AcousticPinger' in sensor_name:
+        bridges = [
+            acoustic_pinger(model_name),
+            set_acoustic_pinger(model_name),
         ]
 
     return bridges

--- a/vrx_urdf/wamv_gazebo/urdf/components/wamv_pinger.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/wamv_pinger.xacro
@@ -4,13 +4,19 @@
     <link name="${namespace}/${name}">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <sphere radius="0.01" />
+        </geometry>
       </visual>
       <inertial>
         <mass value="0.1"/>
         <inertia ixx="0.00000542" ixy="0.0" ixz="0.0" iyy="0.00002104" iyz="0.0" izz="0.00002604"/>
       </inertial>
     </link>
-    <joint name="${namespace}/${name}_pinger_joint" type="fixed">
+    <joint name="${namespace}/${name}_pinger_joint" type="revolute">
+      <axis xyz="0 0 1"/>
+      <limit effort="1000.0" lower="0.0" upper="0" velocity="0"/>
+      <origin xyz="0 0 0" rpy="0 0 0" />
       <parent link="${namespace}/base_link"/>
       <child link="${namespace}/${name}"/>
     </joint>


### PR DESCRIPTION
See issue #641.

The problem was our well known Gazebo "feature" that eliminates fixed joints when converting from `URDF` to `SDF`. Then, the pinger link disappeared. I converted the fixed joint into a revolute joint with no movement to bypass the problem.

### How to test it?

* Launch the simulation as usual:
```
ros2 launch vrx_gz competition.launch.py world:=sydney_regatta
```

* Look at the WAMV in the entity tree and verify that there is a "pinger" listed. If you select the pinger link, you should observe a tiny sphere between the two pontoons as I enabled a small visual for reference.

* Additionally, if you comment out the line `221` in `wamv_gazebo.urdf.xacro`:
```
<xacro:wamv_pinger name="pinger" position="-528 191 -2.0" />
```
You shouldn't see the pinger link in the WAMV entity tree and the functionality of the pinger won't be available (`gz topic -l` shouldn't report the topic `/wamv/pingers/pinger/range_bearing`).

