### PR TITLE
add .cc to WaypointMarkers in CMakeLists.txt

### DIFF
--- a/vrx_gz/CMakeLists.txt
+++ b/vrx_gz/CMakeLists.txt
@@ -84,7 +84,7 @@ install(
 # Stationkeeping scoring plugin
 add_library(StationkeepingScoringPlugin SHARED
   src/StationkeepingScoringPlugin.cc
-  src/WaypointMarkers
+  src/WaypointMarkers.cc
 )
 target_link_libraries(StationkeepingScoringPlugin PUBLIC
   gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}


### PR DESCRIPTION
This addresses issue #670 and produces a nice clean build with no errors or warnings.

To test, use our new and improved [installation tutorial](https://github.com/osrf/vrx/wiki/installation_tutorial). It is not necessary to have a completely fresh system, but you will need to install the Gazebo prelease repo and the binary for `ros_gz`. Then make a new workspace and build VRX. It should build pretty quickly and with no errors.