### PR TITLE
update order of wavefield parameters message

### DIFF
--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception0_task.sdf
@@ -480,6 +480,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -504,22 +534,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.3
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -531,13 +545,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -562,13 +569,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception1_task.sdf
@@ -480,6 +480,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.5
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -504,22 +534,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.5
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -531,13 +545,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -562,13 +569,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception2_task.sdf
@@ -480,6 +480,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.8
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -504,22 +534,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.8
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -531,13 +545,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -562,13 +569,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking0_task.sdf
@@ -783,6 +783,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -807,22 +837,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.3
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -834,13 +848,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -865,13 +872,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking1_task.sdf
@@ -986,6 +986,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.5
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -1010,22 +1040,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.5
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -1037,13 +1051,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -1068,13 +1075,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking2_task.sdf
@@ -884,6 +884,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.8
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -908,22 +938,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.8
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -935,13 +949,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -966,13 +973,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_perception0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception0_task.sdf
@@ -572,6 +572,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.2
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -596,22 +626,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.2
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -623,13 +637,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -654,13 +661,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_perception1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception1_task.sdf
@@ -652,6 +652,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.5
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -676,22 +706,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.5
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -703,13 +717,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -734,13 +741,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_perception2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception2_task.sdf
@@ -981,6 +981,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.8
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -1005,22 +1035,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.8
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -1032,13 +1046,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -1063,13 +1070,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver0_task.sdf
@@ -497,6 +497,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.2
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -521,22 +551,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.2
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -548,13 +562,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -579,13 +586,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver1_task.sdf
@@ -498,6 +498,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.5
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -522,22 +552,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.5
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -549,13 +563,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -580,13 +587,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver2_task.sdf
@@ -499,6 +499,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.8
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -523,22 +553,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.8
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -550,13 +564,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -581,13 +588,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping0_task.sdf
@@ -451,6 +451,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.2
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -475,22 +505,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.2
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -502,13 +516,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -533,13 +540,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping1_task.sdf
@@ -451,6 +451,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.5
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -475,22 +505,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.5
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -502,13 +516,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -533,13 +540,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping2_task.sdf
@@ -451,6 +451,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.8
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -475,22 +505,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.8
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -502,13 +516,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -533,13 +540,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wayfinding0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wayfinding0_task.sdf
@@ -451,6 +451,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.2
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -475,22 +505,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.2
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -502,13 +516,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -533,13 +540,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wayfinding1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wayfinding1_task.sdf
@@ -451,6 +451,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.5
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -475,22 +505,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.5
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -502,13 +516,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -533,13 +540,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wayfinding2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wayfinding2_task.sdf
@@ -451,6 +451,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.8
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -475,22 +505,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.8
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -502,13 +516,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -533,13 +540,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife0_task.sdf
@@ -564,6 +564,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.2
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -588,22 +618,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.2
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -615,13 +629,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -646,13 +653,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife1_task.sdf
@@ -567,6 +567,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.5
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -591,22 +621,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.5
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -618,13 +632,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -649,13 +656,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife2_task.sdf
@@ -568,6 +568,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.8
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -592,22 +622,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.8
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -619,13 +633,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -650,13 +657,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/acoustic_perception_task.sdf
+++ b/vrx_gz/worlds/acoustic_perception_task.sdf
@@ -479,6 +479,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -503,22 +533,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.3
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -530,13 +544,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -561,13 +568,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/acoustic_tracking_task.sdf
+++ b/vrx_gz/worlds/acoustic_tracking_task.sdf
@@ -782,6 +782,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -806,22 +836,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.3
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -833,13 +847,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -864,13 +871,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/follow_path_task.sdf
+++ b/vrx_gz/worlds/follow_path_task.sdf
@@ -489,6 +489,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -513,22 +543,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.3
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -540,13 +554,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -571,13 +578,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/gymkhana_task.sdf
+++ b/vrx_gz/worlds/gymkhana_task.sdf
@@ -523,6 +523,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -547,22 +577,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.3
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -574,13 +588,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -605,13 +612,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/navigation_task.sdf
+++ b/vrx_gz/worlds/navigation_task.sdf
@@ -461,6 +461,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -485,22 +515,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.3
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -512,13 +526,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -543,13 +550,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/nbpark.sdf
+++ b/vrx_gz/worlds/nbpark.sdf
@@ -418,6 +418,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -442,22 +472,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.3
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -469,13 +483,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -500,13 +507,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/perception_task.sdf
+++ b/vrx_gz/worlds/perception_task.sdf
@@ -570,6 +570,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -594,22 +624,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.3
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -621,13 +635,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -652,13 +659,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/scan_dock_deliver_task.sdf
+++ b/vrx_gz/worlds/scan_dock_deliver_task.sdf
@@ -583,6 +583,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -607,22 +637,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.3
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -634,13 +648,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -665,13 +672,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/stationkeeping_task.sdf
+++ b/vrx_gz/worlds/stationkeeping_task.sdf
@@ -629,6 +629,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -653,22 +683,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.3
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -680,13 +694,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -711,13 +718,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/sydney_regatta.sdf
+++ b/vrx_gz/worlds/sydney_regatta.sdf
@@ -605,6 +605,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -629,22 +659,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.3
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -656,13 +670,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -687,13 +694,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/wayfinding_task.sdf
+++ b/vrx_gz/worlds/wayfinding_task.sdf
@@ -639,6 +639,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -663,22 +693,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.3
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -690,13 +704,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -721,13 +728,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {

--- a/vrx_gz/worlds/wildlife_task.sdf
+++ b/vrx_gz/worlds/wildlife_task.sdf
@@ -597,6 +597,36 @@
       <message type="gz.msgs.Param" topic="/vrx/wavefield/parameters"
                every="2.0">
         params {
+          key: "direction"
+          value {
+            type: VECTOR3D
+            vector3d_value {
+              x: 1
+            }
+          }
+        }
+        params {
+          key: "gain"
+          value {
+            type: DOUBLE
+            double_value: 0.3
+          }
+        }
+        params {
+          key: "period"
+          value {
+            type: DOUBLE
+            double_value: 5
+          }
+        }
+        params {
+          key: "steepness"
+          value {
+            type: DOUBLE
+            double_value: 0
+          }
+        }
+        params {
           key: "amplitude"
           value {
             type: DOUBLE
@@ -621,22 +651,6 @@
           }
         }
         params {
-          key: "direction"
-          value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
-          }
-        }
-        params {
-          key: "gain"
-          value {
-            type: DOUBLE
-            double_value: 0.3
-          }
-        }
-        params {
           key: "model"
           value {
             type: STRING
@@ -648,13 +662,6 @@
           value {
             type: INT32
             int_value: 3
-          }
-        }
-        params {
-          key: "period"
-          value {
-            type: DOUBLE
-            double_value: 5
           }
         }
         params {
@@ -679,13 +686,6 @@
               x: 6000
               y: 6000
             }
-          }
-        }
-        params {
-          key: "steepness"
-          value {
-            type: DOUBLE
-            double_value: 0
           }
         }
         params {


### PR DESCRIPTION
Aims to close #651 and #650

## Sub-Tasks
-  [x] Update the order inside the wavefield parameter message published with the `.sdf` file
-  [ ] Update the steepness parameter to have trochoidal shaped waves

## Test it
Launching one of the  2023 practice worlds with a considerable gain parameter(like say 0.8) would work
```
ros2 launch vrx_gz competition.launch.py world:=2023_practice/practice_2023_stationkeeping2_task
```

