### PR TITLE
support full paths to world files

### DIFF
--- a/vrx_gz/launch/competition.launch.py
+++ b/vrx_gz/launch/competition.launch.py
@@ -17,6 +17,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import OpaqueFunction
 from launch.substitutions import LaunchConfiguration
+import os
 
 import vrx_gz.launch
 from vrx_gz.model import Model
@@ -44,8 +45,10 @@ def launch(context, *args, **kwargs):
           m.set_urdf(robot_urdf)
       models.append(m)
 
+    world_name, ext = os.path.splitext(world_name)
     launch_processes.extend(vrx_gz.launch.simulation(world_name, headless))
-    launch_processes.extend(vrx_gz.launch.spawn(sim_mode, world_name, models, robot))
+    world_name_base = os.path.basename(world_name)
+    launch_processes.extend(vrx_gz.launch.spawn(sim_mode, world_name_base, models, robot))
 
     if (sim_mode == 'bridge' or sim_mode == 'full') and bridge_competition_topics:
         launch_processes.extend(vrx_gz.launch.competition_bridges(world_name))

--- a/vrx_gz/src/vrx_gz/launch.py
+++ b/vrx_gz/src/vrx_gz/launch.py
@@ -38,7 +38,10 @@ PERCEPTION_WORLDS = [
   'perception_task',
   'practice_2023_perception0_task',
   'practice_2023_perception1_task',
-  'practice_2023_perception2_task'
+  'practice_2023_perception2_task',
+  'perception0',
+  'perception1',
+  'perception2'
 ]
 
 STATIONKEEPING_WORLDS = [
@@ -46,6 +49,9 @@ STATIONKEEPING_WORLDS = [
   'practice_2023_stationkeeping0_task',
   'practice_2023_stationkeeping1_task',
   'practice_2023_stationkeeping2_task',
+  'stationkeeping0',
+  'stationkeeping1',
+  'stationkeeping2'
 ]
 
 WAYFINDING_WORLDS = [
@@ -53,34 +59,49 @@ WAYFINDING_WORLDS = [
   'practice_2023_wayfinding0_task',
   'practice_2023_wayfinding1_task',
   'practice_2023_wayfinding2_task',
+  'wayfinding0',
+  'wayfinding1',
+  'wayfinding2'
 ]
 
 WILDLIFE_WORLDS = [
   'wildlife_task',
   'practice_2023_wildlife0_task',
   'practice_2023_wildlife1_task',
-  'practice_2023_wildlife2_task'
+  'practice_2023_wildlife2_task',
+  'wildlife0',
+  'wildlife1',
+  'wildlife2'
 ]
 
 SCAN_DOCK_DELIVER_WORLDS = [
   'scan_dock_deliver_task',
   'practice_2023_scan_dock_deliver0_task',
   'practice_2023_scan_dock_deliver1_task',
-  'practice_2023_scan_dock_deliver2_task'
+  'practice_2023_scan_dock_deliver2_task',
+  'scan_dock_deliver0',
+  'scan_dock_deliver1',
+  'scan_dock_deliver2'
 ]
 
 ACOUSTIC_TRACKING_WORLDS = [
   'acoustic_tracking_task',
   'practice_2023_acoustic_tracking0_task',
   'practice_2023_acoustic_tracking1_task',
-  'practice_2023_acoustic_tracking2_task'
+  'practice_2023_acoustic_tracking2_task',
+  'acoustic_tracking0',
+  'acoustic_tracking1',
+  'acoustic_tracking2'
 ]
 
 FOLLOWPATH_WORLDS = [
   'follow_path_task',
   'practice_2023_follow_path0_task',
   'practice_2023_follow_path1_task',
-  'practice_2023_follow_path2_task'
+  'practice_2023_follow_path2_task',
+  'follow_path0',
+  'follow_path1',
+  'follow_path2'
 ]
 
 def simulation(world_name, headless=False):


### PR DESCRIPTION
This provides the quickest fix to issue #680 by extracting a normalized world name from any incoming path, and adding a few likely names to our list of worlds that we recognize and create bridges for. It doesn't fix the deeper conceptual problems described in #680.

## To test:
Run a task using an absolute path:
```
ros2 launch vrx_gz competition.launch.py world:=`pwd`/src/vrx/vrx_gz/worlds/stationkeeping_task.sdf
```
in another terminal run
```
ros2 topic list
```
and verify that you see the correct list of topics. Next, rename one of our task worlds to one of the generic names we use in our testing, and check the topics again to verify that it still works:
```
cp `pwd`/src/vrx/vrx_gz/worlds/stationkeeping_task.sdf stationkeeping0.sdf
ros2 launch vrx_gz competition.launch.py world:=`pwd`/stationkeeping0.sdf
```

Bonus: Gazebo will no longer crash if the user accidentally includes the world file extension.