### PR TITLE
Adjust practice worlds to make use of new wavefield model envelope

### DIFF
--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception0_task.sdf
@@ -492,14 +492,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.3
+            double_value: 0.0
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 4
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception1_task.sdf
@@ -485,6 +485,7 @@
             type: VECTOR3D
             vector3d_value {
               x: 1
+              y: 1
             }
           }
         }
@@ -492,14 +493,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.5
+            double_value: 0.6
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 6
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception2_task.sdf
@@ -484,7 +484,7 @@
           value {
             type: VECTOR3D
             vector3d_value {
-              x: 1
+              y: 1
             }
           }
         }

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking0_task.sdf
@@ -795,14 +795,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.3
+            double_value: 0.0
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 4
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking1_task.sdf
@@ -991,6 +991,7 @@
             type: VECTOR3D
             vector3d_value {
               x: 1
+              y: 1
             }
           }
         }
@@ -998,14 +999,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.5
+            double_value: 0.6
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 6
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking2_task.sdf
@@ -889,6 +889,7 @@
             type: VECTOR3D
             vector3d_value {
               x: 1
+              y: 1
             }
           }
         }
@@ -896,14 +897,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 2.0
+            double_value: 0.8
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 2.0
+            double_value: 6.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_follow_path0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_follow_path0_task.sdf
@@ -502,7 +502,7 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.3
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_follow_path0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_follow_path0_task.sdf
@@ -509,7 +509,7 @@
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 4
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_follow_path1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_follow_path1_task.sdf
@@ -507,6 +507,7 @@
             type: VECTOR3D
             vector3d_value {
               x: 1
+              y: 1
             }
           }
         }
@@ -514,14 +515,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.5
+            double_value: 0.6
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 6
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_perception0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception0_task.sdf
@@ -584,14 +584,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.2
+            double_value: 0.0
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 4
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_perception1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception1_task.sdf
@@ -657,6 +657,7 @@
             type: VECTOR3D
             vector3d_value {
               x: 1
+              y: 1
             }
           }
         }
@@ -664,14 +665,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.5
+            double_value: 0.6
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 6
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver0_task.sdf
@@ -509,14 +509,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.2
+            double_value: 0.0
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 4
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver1_task.sdf
@@ -503,6 +503,7 @@
             type: VECTOR3D
             vector3d_value {
               x: 1
+              y: 1
             }
           }
         }
@@ -510,14 +511,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.5
+            double_value: 0.6
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 6
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping0_task.sdf
@@ -463,14 +463,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.2
+            double_value: 0.0
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 4
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping1_task.sdf
@@ -456,6 +456,7 @@
             type: VECTOR3D
             vector3d_value {
               x: 1
+              y: 1
             }
           }
         }
@@ -463,14 +464,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.5
+            double_value: 0.6
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 6
           }
         }
       </message>

--- a/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping2_task.sdf
@@ -455,7 +455,7 @@
           value {
             type: VECTOR3D
             vector3d_value {
-              x: 1
+              y: 1
             }
           }
         }
@@ -463,14 +463,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 2.0
+            double_value: 0.8
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 2.0
+            double_value: 6.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wayfinding0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wayfinding0_task.sdf
@@ -463,14 +463,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.2
+            double_value: 0.0
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 4
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wayfinding1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wayfinding1_task.sdf
@@ -456,6 +456,7 @@
             type: VECTOR3D
             vector3d_value {
               x: 1
+              y: 1
             }
           }
         }
@@ -463,14 +464,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.5
+            double_value: 0.6
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 6
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wayfinding2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wayfinding2_task.sdf
@@ -456,6 +456,7 @@
             type: VECTOR3D
             vector3d_value {
               x: 1
+              y: 1
             }
           }
         }
@@ -463,14 +464,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 2.0
+            double_value: 0.8
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 2.0
+            double_value: 6.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife0_task.sdf
@@ -576,14 +576,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.2
+            double_value: 0.0
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 4
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife1_task.sdf
@@ -572,6 +572,7 @@
             type: VECTOR3D
             vector3d_value {
               x: 1
+              y: 1
             }
           }
         }
@@ -579,14 +580,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 0.5
+            double_value: 0.6
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 5
+            double_value: 6
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife2_task.sdf
@@ -580,14 +580,14 @@
           key: "gain"
           value {
             type: DOUBLE
-            double_value: 2.0
+            double_value: 0.8
           }
         }
         params {
           key: "period"
           value {
             type: DOUBLE
-            double_value: 2.0
+            double_value: 6.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife2_task.sdf
@@ -572,7 +572,7 @@
           value {
             type: VECTOR3D
             vector3d_value {
-              x: 1
+              x: -1
             }
           }
         }


### PR DESCRIPTION
This PR adjusts the wavefield parameters for the practice worlds to cover a broader spectrum of possibilities using our recently updated wavefield envelope (see #684). The changes introduced to the worlds are as follows:
* I updated all easy (0) worlds so they have no waves at all.
* I changed all intermediate (1) worlds to use period 6, gain 0.6, which produces mild swells. I also varied the direction of the wavefield so teams will not expect it to always stay the same.
* I changed the wavefield of some of the hard (2) worlds so they are not all the same. Specifically, I left the period of 2 and gain of 2.0 for tasks that rely on perception. For other tasks, such as stationkeeping and wayfinding I used period 6, gain 0.8 to produce medium swells. I also introduced some simple variations to the direction of the wavefield.

## To test:
* The easy worlds can probably be verified with a spot check and visual inspection of the code.
* Try to run a few of the intermediate worlds to make sure the wave effects are reasonable and nothing is too challenging. Please also look to make sure I set all the parameters to the values given above.
* For the hard worlds, please run each and verify that they are challenging but not so extreme as to be unsolvable, and not broken (i.e. no weird physical effects).