### PR TITLE
enable competition bridges when world uses absolute paths

### DIFF
--- a/vrx_gz/launch/competition.launch.py
+++ b/vrx_gz/launch/competition.launch.py
@@ -51,7 +51,7 @@ def launch(context, *args, **kwargs):
     launch_processes.extend(vrx_gz.launch.spawn(sim_mode, world_name_base, models, robot))
 
     if (sim_mode == 'bridge' or sim_mode == 'full') and bridge_competition_topics:
-        launch_processes.extend(vrx_gz.launch.competition_bridges(world_name))
+        launch_processes.extend(vrx_gz.launch.competition_bridges(world_name_base))
 
     return launch_processes
 


### PR DESCRIPTION
A simple fix to address problems with task-specific bridges failing, described in #680 and https://github.com/osrf/vrx-docker/pull/60

### To test
First observe that task specific bridges are currently failing if the competition world is specified using an absolute path:
```
cd vrx_ws
cp src/vrx/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping0_task.sdf stationkeeping0.sdf
ros2 launch vrx_gz competition.launch.py world:=`pwd`/stationkeeping0
```
Note that `gz topic -l` shows
```
/vrx/stationkeeping/goal
/vrx/stationkeeping/mean_pose_error
/vrx/stationkeeping/pose_error
```
but `ros2 topic list` does not.

Now checkout this branch, build again, and re-run the launch command above. Verify that the competition topics now show up.