### PR TITLE
add command line argument for passing extra args to gz sim

### DIFF
--- a/vrx_gz/launch/competition.launch.py
+++ b/vrx_gz/launch/competition.launch.py
@@ -32,7 +32,7 @@ def launch(context, *args, **kwargs):
     robot = LaunchConfiguration('robot').perform(context)
     headless = LaunchConfiguration('headless').perform(context).lower() == 'true'
     robot_urdf = LaunchConfiguration('urdf').perform(context)
-    gz_paused = LaunchConfiguration('paused').perform(context)
+    gz_paused = LaunchConfiguration('paused').perform(context).lower() == 'true'
     extra_gz_args = LaunchConfiguration('extra_gz_args').perform(context)
 
     launch_processes = []
@@ -49,7 +49,7 @@ def launch(context, *args, **kwargs):
 
     world_name, ext = os.path.splitext(world_name)
     launch_processes.extend(vrx_gz.launch.simulation(world_name, headless, 
-                                                     paused, extra_gz_args))
+                                                     gz_paused, extra_gz_args))
     world_name_base = os.path.basename(world_name)
     launch_processes.extend(vrx_gz.launch.spawn(sim_mode, world_name_base, models, robot))
 

--- a/vrx_gz/launch/competition.launch.py
+++ b/vrx_gz/launch/competition.launch.py
@@ -32,6 +32,7 @@ def launch(context, *args, **kwargs):
     robot = LaunchConfiguration('robot').perform(context)
     headless = LaunchConfiguration('headless').perform(context).lower() == 'true'
     robot_urdf = LaunchConfiguration('urdf').perform(context)
+    gz_paused = LaunchConfiguration('paused').perform(context)
     extra_gz_args = LaunchConfiguration('extra_gz_args').perform(context)
 
     launch_processes = []
@@ -47,7 +48,8 @@ def launch(context, *args, **kwargs):
       models.append(m)
 
     world_name, ext = os.path.splitext(world_name)
-    launch_processes.extend(vrx_gz.launch.simulation(world_name, headless, extra_gz_args))
+    launch_processes.extend(vrx_gz.launch.simulation(world_name, headless, 
+                                                     paused, extra_gz_args))
     world_name_base = os.path.basename(world_name)
     launch_processes.extend(vrx_gz.launch.spawn(sim_mode, world_name_base, models, robot))
 
@@ -92,6 +94,10 @@ def generate_launch_description():
             'urdf',
             default_value='',
             description='URDF file of the wam-v model. '),
+        DeclareLaunchArgument(
+            'paused',
+            default_value='False',
+            description='True to start the simulation paused. '),
         DeclareLaunchArgument(
             'extra_gz_args',
             default_value='',

--- a/vrx_gz/launch/competition.launch.py
+++ b/vrx_gz/launch/competition.launch.py
@@ -32,6 +32,7 @@ def launch(context, *args, **kwargs):
     robot = LaunchConfiguration('robot').perform(context)
     headless = LaunchConfiguration('headless').perform(context).lower() == 'true'
     robot_urdf = LaunchConfiguration('urdf').perform(context)
+    extra_gz_args = LaunchConfiguration('extra_gz_args').perform(context)
 
     launch_processes = []
 
@@ -46,7 +47,7 @@ def launch(context, *args, **kwargs):
       models.append(m)
 
     world_name, ext = os.path.splitext(world_name)
-    launch_processes.extend(vrx_gz.launch.simulation(world_name, headless))
+    launch_processes.extend(vrx_gz.launch.simulation(world_name, headless, extra_gz_args))
     world_name_base = os.path.basename(world_name)
     launch_processes.extend(vrx_gz.launch.spawn(sim_mode, world_name_base, models, robot))
 
@@ -91,5 +92,9 @@ def generate_launch_description():
             'urdf',
             default_value='',
             description='URDF file of the wam-v model. '),
+        DeclareLaunchArgument(
+            'extra_gz_args',
+            default_value='',
+            description='Additional arguments to be passed to gz sim. '),
         OpaqueFunction(function=launch),
     ])

--- a/vrx_gz/src/vrx_gz/launch.py
+++ b/vrx_gz/src/vrx_gz/launch.py
@@ -104,8 +104,11 @@ FOLLOWPATH_WORLDS = [
   'follow_path2'
 ]
 
-def simulation(world_name, headless=False, extra_gz_args=''):
-    gz_args = ['-v 4', '-r']
+def simulation(world_name, headless=False, paused=False, extra_gz_args=''):
+    gz_args = ['-v 4']
+    if not paused:
+        gz_args.append('-r')
+
     if headless:
         gz_args.append('-s')
 

--- a/vrx_gz/src/vrx_gz/launch.py
+++ b/vrx_gz/src/vrx_gz/launch.py
@@ -104,10 +104,13 @@ FOLLOWPATH_WORLDS = [
   'follow_path2'
 ]
 
-def simulation(world_name, headless=False):
+def simulation(world_name, headless=False, extra_gz_args=''):
     gz_args = ['-v 4', '-r']
     if headless:
         gz_args.append('-s')
+
+    gz_args.append(extra_gz_args)
+
     gz_args.append(f'{world_name}.sdf')
 
     gz_sim = IncludeLaunchDescription(


### PR DESCRIPTION
This PR adds the `extra_gz_args` option to `competition.launch.py` and passes it through to `gz sim`. We had something similar in VRX classic so we could use gazebo options without having to implement command line arguments for all of them. (There might be a cleaner way to do this; if so please advise.)

The immediate reason for doing this is so we can use gz sim's recording functionality, which we need to get playback working.

### To test
Try passing some arguments through to gz sim:
```
ros2 launch vrx_gz competition.launch.py headless:=false world:=stationkeeping_task extra_gz_args:="--record_period 0.01 --record_path $HOME/.gz_sim_arg_test --log_overwrite"
```
Check that logs are written to `$HOME/.gz_sim_arg_test`.

Bonus: adding support for "paused" argument. To test:
```
ros2 launch vrx_gz competition.launch.py paused:=true world:=stationkeeping_task
```
The simulation should start in a paused state.