### PR TITLE
Reduce oscillations of buoys in perception task

### DIFF
--- a/vrx_gz/worlds/2023_practice/practice_2023_perception1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception1_task.sdf
@@ -457,14 +457,14 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>75.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
           <pose>0 0 0 0 0 0</pose>
           <geometry>
             <sphere>
-              <radius>0.25</radius>
+              <radius>0.21</radius>
           </sphere>
           </geometry>
         </buoyancy>
@@ -510,14 +510,14 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>75.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
           <pose>0 0 0 0 0 0</pose>
           <geometry>
             <sphere>
-              <radius>0.25</radius>
+              <radius>0.21</radius>
           </sphere>
           </geometry>
         </buoyancy>
@@ -536,14 +536,14 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>75.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
           <pose>0 0 0 0 0 0</pose>
           <geometry>
             <sphere>
-              <radius>0.25</radius>
+              <radius>0.21</radius>
           </sphere>
           </geometry>
         </buoyancy>
@@ -624,25 +624,25 @@
           <time>25.0</time>
           <type>mb_round_buoy_black</type>
           <name>black_round_0</name>
-          <pose>4.9 1.32 0.2 0 0 0</pose>
+          <pose>4.9 1.32 0.7 0 0 0</pose>
         </object>
         <object>
           <time>25.0</time>
           <type>mb_round_buoy_black</type>
           <name>black_round_1</name>
-          <pose>4.7 0.7 0.2 0 0 0</pose>
+          <pose>4.7 0.7 0.7 0 0 0</pose>
         </object>
         <object>
           <time>35.0</time>
           <type>mb_marker_buoy_white</type>
           <name>white_0</name>
-          <pose>4.1 -2.2 0.2 0 0 0</pose>
+          <pose>4.1 -2.2 0.7 0 0 0</pose>
         </object>
         <object>
           <time>35.0</time>
           <type>mb_round_buoy_black</type>
           <name>black_round_0</name>
-          <pose>6.1 0.2 0.2 0 0 0</pose>
+          <pose>6.1 0.2 0.7 0 0 0</pose>
         </object>
       </object_sequence>
     </plugin>

--- a/vrx_gz/worlds/2023_practice/practice_2023_perception2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception2_task.sdf
@@ -457,14 +457,14 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>75.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
           <pose>0 0 0 0 0 0</pose>
           <geometry>
             <sphere>
-              <radius>0.25</radius>
+              <radius>0.21</radius>
           </sphere>
           </geometry>
         </buoyancy>
@@ -483,14 +483,14 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>75.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
           <pose>0 0 0 0 0 0</pose>
           <geometry>
             <sphere>
-              <radius>0.25</radius>
+              <radius>0.21</radius>
           </sphere>
           </geometry>
         </buoyancy>
@@ -509,7 +509,7 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>50.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
@@ -536,7 +536,7 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>50.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
@@ -563,14 +563,14 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>75.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
           <pose>0 0 0 0 0 0</pose>
           <geometry>
             <sphere>
-              <radius>0.25</radius>
+              <radius>0.21</radius>
           </sphere>
           </geometry>
         </buoyancy>
@@ -589,14 +589,14 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>75.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
           <pose>0 0 0 0 0 0</pose>
           <geometry>
             <sphere>
-              <radius>0.25</radius>
+              <radius>0.21</radius>
           </sphere>
           </geometry>
         </buoyancy>
@@ -615,7 +615,7 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>50.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
@@ -642,7 +642,7 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>50.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
@@ -669,7 +669,7 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>50.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
@@ -696,7 +696,7 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>50.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
@@ -723,7 +723,7 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>50.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
@@ -750,7 +750,7 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>50.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
@@ -777,7 +777,7 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>50.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
@@ -804,7 +804,7 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>50.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
@@ -831,7 +831,7 @@
               filename="libPolyhedraBuoyancyDrag.so">
         <fluid_density>1000</fluid_density>
         <fluid_level>0.0</fluid_level>
-        <linear_drag>25.0</linear_drag>
+        <linear_drag>50.0</linear_drag>
         <angular_drag>2.0</angular_drag>
         <buoyancy name="collision_outer">
           <link_name>link</link_name>
@@ -917,37 +917,37 @@
           <time>25.0</time>
           <type>mb_marker_buoy_black</type>
           <name>black_0</name>
-          <pose>10 0.15 0.3 0 0 0</pose>
+          <pose>10 0.15 0.7 0 0 0</pose>
         </object>
         <object>
           <time>25.0</time>
           <type>mb_marker_buoy_green</type>
           <name>green_0</name>
-          <pose>16.5 0.7 0.3 0 0 0</pose>
+          <pose>16.5 0.7 0.7 0 0 0</pose>
         </object>
         <object>
           <time>25.0</time>
           <type>mb_marker_buoy_red</type>
           <name>red_0</name>
-          <pose>7.63 1.85 0.3 0 0 0</pose>
+          <pose>7.63 1.85 0.7 0 0 0</pose>
         </object>
         <object>
           <time>25.0</time>
           <type>mb_marker_buoy_green</type>
           <name>green_1</name>
-          <pose>12.4 2.37 0.3 0 0 0</pose>
+          <pose>12.4 2.37 0.7 0 0 0</pose>
         </object>
         <object>
           <time>25.0</time>
           <type>mb_marker_buoy_black</type>
           <name>black_1</name>
-          <pose>5.4 2.1 0.3 0 0 0</pose>
+          <pose>5.4 2.1 0.7 0 0 0</pose>
         </object>
         <object>
           <time>25.0</time>
           <type>mb_marker_buoy_red</type>
           <name>red_1</name>
-          <pose>4.4 -0.43 0.3 0 0 0</pose>
+          <pose>4.4 -0.43 0.7 0 0 0</pose>
         </object>
         <object>
           <time>35.0</time>


### PR DESCRIPTION
aims to close #689 

Summary:
A detailed analysis of the various parameters can be found in the discussion of the associated issue.
The following updates have been done:
1. Round Buoys:
    geometry radius updated to 0.21(for both *perception_task1* and *perception_task2*)
    updated drag coefficient to 75(for both *perception_task1* and *perception_task2*)
    updated spawning z=0.7 in *perception_task1* 
2. Marker Buoys
   Updated spawning z=0.7 for both (*perception_task1* and *perception_task2*)
   Updated linear drag coefficient to 50 in *perception_task2* to reduce the magnitude of oscillations a little.

Test:
Run `2023_practice/practice_2023_perception1_task` and `2023_practice/practice_2023_perception2_task` worlds
 
Results:

https://github.com/osrf/vrx/assets/64950661/d2787769-611b-406a-bdbf-f6d7c27625b7



https://github.com/osrf/vrx/assets/64950661/41444310-c9e1-4a15-bd4e-e3a0bea7767e

