### PR TITLE
Set IMU to reflect sensor position in global coordinates

### DIFF
--- a/vrx_urdf/wamv_gazebo/urdf/components/wamv_imu.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/wamv_imu.xacro
@@ -101,6 +101,9 @@
               </noise>
             </z>
           </linear_acceleration>
+          <orientation_reference_frame>
+            <localization>ENU</localization>
+          </orientation_reference_frame>
         </imu>
       </sensor>
     </gazebo>


### PR DESCRIPTION
In reference to Issue #675 

#### Issue:
IMU initializes to local reference frame on WAM-V spawn.
This can be checked by echoing IMU sensor data on spawn.

#### Fix Proposed by User:
Add the following to `wamv_imu.xacro` to link IMU to parent reference frame:
```
<orientation_reference_frame>
    <localization>ENU</localization>
</orientation_reference_frame>
```

#### Result
Launch with 
```
ros2 launch vrx_gz competition.launch.py world:=sydney_regatta
```
Confirm orientation values with 
```
ros2 topic echo /wamv/sensors/imu/imu/data
```
Change orientation values in `competition.launch.py` and re-launch. Changing spawn orientation to align with world axes shows IMU reflects orientation in global frame.

