### PR TITLE
Updated code to use angle as input for wavefield parameter direction

### DIFF
--- a/vrx_gz/src/Wavefield.cc
+++ b/vrx_gz/src/Wavefield.cc
@@ -516,9 +516,6 @@ void Wavefield::Load(const msgs::Param &_msg)
 
   this->data->FillParameters();
   this->data->Recalculate();
-
-  this->DebugPrint();
-
   this->data->active = true;
 }
 

--- a/vrx_gz/src/Wavefield.hh
+++ b/vrx_gz/src/Wavefield.hh
@@ -107,8 +107,8 @@ namespace vrx
   /// * `<phase>` (double, default: 0.0)
   ///   The phase of the mean wave.
   ///
-  /// * `<direction>` (Vector2D, default: (1 0))
-  ///   A two component vector specifiying the direction of the mean wave.
+  /// * `<direction>` (double, default: 0.0)
+  ///   An angle defining mean wave direction (theta_m)
   ///
   /// * `<model>` (string, default: default)
   ///   The model used to generate component waves.
@@ -135,7 +135,7 @@ namespace vrx
   ///     <number>3</number>
   ///     <scale>1.5</scale>
   ///     <gain>0.1</gain>
-  ///     <direction>1 0</direction>
+  ///     <direction>0.0</direction>
   ///     <angle>0.4</angle>
   ///     <tau>2.0</tau>
   ///     <amplitude>0.0</amplitude>
@@ -212,9 +212,8 @@ namespace vrx
     /// \brief Amplitude multiplier for PMS.
     public: float Gain() const;
 
-    /// \brief A two component vector specifiying the direction
-    /// of the mean wave.
-    public: gz::math::Vector2d Direction() const;
+    /// \brief A double specifiying the mean wave direction.
+    public: double Direction() const;
 
     /// \brief Set the number of wave components (3 max).
     ///
@@ -266,8 +265,8 @@ namespace vrx
 
     /// \brief Set the mean wave direction.
     ///
-    /// \param[in] _direction The direction parameter, a two component vector.
-    public: void SetDirection(const gz::math::Vector2d &_direction);
+    /// \param[in] _direction The direction parameter, a double.
+    public: void SetDirection(double _direction);
 
     /// \brief Access the component angular frequencies.
     public: const std::vector<double> &AngularFrequency_V() const;

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception0_task.sdf
@@ -482,10 +482,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception1_task.sdf
@@ -482,11 +482,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-              y: 1
-            }
+            type: DOUBLE
+            double_value: 0.7853982
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception2_task.sdf
@@ -482,10 +482,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              y: 1
-            }
+            type: DOUBLE
+            double_value: 1.570797
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking0_task.sdf
@@ -785,10 +785,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking1_task.sdf
@@ -988,11 +988,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-              y: 1
-            }
+            type: DOUBLE
+            double_value: 0.7853982
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking2_task.sdf
@@ -886,11 +886,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-              y: 1
-            }
+            type: DOUBLE
+            double_value: 0.7853982
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_follow_path0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_follow_path0_task.sdf
@@ -492,10 +492,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_follow_path1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_follow_path1_task.sdf
@@ -504,11 +504,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-              y: 1
-            }
+            type: DOUBLE
+            double_value: 0.7853982
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_follow_path2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_follow_path2_task.sdf
@@ -516,10 +516,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_perception0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception0_task.sdf
@@ -574,10 +574,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_perception1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception1_task.sdf
@@ -654,11 +654,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-              y: 1
-            }
+            type: DOUBLE
+            double_value: 0.7853982
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_perception2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception2_task.sdf
@@ -983,10 +983,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver0_task.sdf
@@ -499,10 +499,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver1_task.sdf
@@ -500,11 +500,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-              y: 1
-            }
+            type: DOUBLE
+            double_value: 0.7853982
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver2_task.sdf
@@ -501,10 +501,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping0_task.sdf
@@ -453,10 +453,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping1_task.sdf
@@ -453,11 +453,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-              y: 1
-            }
+            type: DOUBLE
+            double_value: 0.7853982
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping2_task.sdf
@@ -453,10 +453,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              y: 1
-            }
+            type: DOUBLE
+            double_value: 1.570797
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wayfinding0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wayfinding0_task.sdf
@@ -453,10 +453,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wayfinding1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wayfinding1_task.sdf
@@ -453,11 +453,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-              y: 1
-            }
+            type: DOUBLE
+            double_value: 0.7853982
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wayfinding2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wayfinding2_task.sdf
@@ -453,11 +453,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-              y: 1
-            }
+            type: DOUBLE
+            double_value: 0.7853982
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife0_task.sdf
@@ -566,10 +566,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife1_task.sdf
@@ -569,11 +569,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-              y: 1
-            }
+            type: DOUBLE
+            double_value: 0.7853982
           }
         }
         params {

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife2_task.sdf
@@ -570,10 +570,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: -1
-            }
+            type: DOUBLE
+            double_value: 3.141593
           }
         }
         params {

--- a/vrx_gz/worlds/acoustic_perception_task.sdf
+++ b/vrx_gz/worlds/acoustic_perception_task.sdf
@@ -481,10 +481,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/acoustic_tracking_task.sdf
+++ b/vrx_gz/worlds/acoustic_tracking_task.sdf
@@ -784,10 +784,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/follow_path_task.sdf
+++ b/vrx_gz/worlds/follow_path_task.sdf
@@ -491,10 +491,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/gymkhana_task.sdf
+++ b/vrx_gz/worlds/gymkhana_task.sdf
@@ -525,10 +525,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/navigation_task.sdf
+++ b/vrx_gz/worlds/navigation_task.sdf
@@ -463,10 +463,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/nbpark.sdf
+++ b/vrx_gz/worlds/nbpark.sdf
@@ -420,10 +420,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/perception_task.sdf
+++ b/vrx_gz/worlds/perception_task.sdf
@@ -572,10 +572,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/scan_dock_deliver_task.sdf
+++ b/vrx_gz/worlds/scan_dock_deliver_task.sdf
@@ -585,10 +585,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/stationkeeping_task.sdf
+++ b/vrx_gz/worlds/stationkeeping_task.sdf
@@ -631,10 +631,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/sydney_regatta.sdf
+++ b/vrx_gz/worlds/sydney_regatta.sdf
@@ -607,10 +607,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/wayfinding_task.sdf
+++ b/vrx_gz/worlds/wayfinding_task.sdf
@@ -641,10 +641,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {

--- a/vrx_gz/worlds/wildlife_task.sdf
+++ b/vrx_gz/worlds/wildlife_task.sdf
@@ -599,10 +599,8 @@
         params {
           key: "direction"
           value {
-            type: VECTOR3D
-            vector3d_value {
-              x: 1
-            }
+            type: DOUBLE
+            double_value: 0.0
           }
         }
         params {


### PR DESCRIPTION
aims to address comments in #651 

Summary:
Previously, the direction 2D vector was normalized and then used as angles.
Updated code directly takes an angle as input and is used further.

Test:
the results are evident with `practice_2023_stationkeeping0_task.sdf`,  `practice_2023_stationkeeping1_task.sdf` and `practice_2023_stationkeeping2_task.sdf`. The direction is more evident when we view the worlds from the top view

Result:
`practice_2023_stationkeeping0_task.sdf`: mean wave direction angle=0.0

![Screenshot from 2023-07-25 21-26-14](https://github.com/osrf/vrx/assets/64950661/9682c966-9e12-4d46-b345-e1b9ca3dd6b4)

`practice_2023_stationkeeping1_task.sdf`: mean wave direction angle=45 degrees

![Screenshot from 2023-07-25 21-27-11](https://github.com/osrf/vrx/assets/64950661/ded4a91c-f727-435a-97a1-243042e0b3f4)

`practice_2023_stationkeeping2_task.sdf`: mean wave direction angle=90 degrees

![Screenshot from 2023-07-25 21-28-14](https://github.com/osrf/vrx/assets/64950661/8c515251-14bd-409c-b83f-0cdfa6000b86)

