### PR TITLE
Create competition_mode argument

### DIFF
--- a/vrx_gz/launch/competition.launch.py
+++ b/vrx_gz/launch/competition.launch.py
@@ -33,6 +33,7 @@ def launch(context, *args, **kwargs):
     headless = LaunchConfiguration('headless').perform(context).lower() == 'true'
     robot_urdf = LaunchConfiguration('urdf').perform(context)
     gz_paused = LaunchConfiguration('paused').perform(context).lower() == 'true'
+    competition_mode = LaunchConfiguration('competition_mode').perform(context).lower() == 'true'
     extra_gz_args = LaunchConfiguration('extra_gz_args').perform(context)
 
     launch_processes = []
@@ -54,7 +55,7 @@ def launch(context, *args, **kwargs):
     launch_processes.extend(vrx_gz.launch.spawn(sim_mode, world_name_base, models, robot))
 
     if (sim_mode == 'bridge' or sim_mode == 'full') and bridge_competition_topics:
-        launch_processes.extend(vrx_gz.launch.competition_bridges(world_name_base))
+        launch_processes.extend(vrx_gz.launch.competition_bridges(world_name_base, competition_mode))
 
     return launch_processes
 
@@ -98,6 +99,10 @@ def generate_launch_description():
             'paused',
             default_value='False',
             description='True to start the simulation paused. '),
+        DeclareLaunchArgument(
+            'competition_mode',
+            default_value='False',
+            description='True to disable debug topics. '),
         DeclareLaunchArgument(
             'extra_gz_args',
             default_value='',

--- a/vrx_gz/src/vrx_gz/launch.py
+++ b/vrx_gz/src/vrx_gz/launch.py
@@ -147,13 +147,17 @@ def simulation(world_name, headless=False, paused=False, extra_gz_args=''):
     return [gz_sim, monitor_sim_proc, sim_exit_event_handler]
 
 
-def competition_bridges(world_name):
+def competition_bridges(world_name, competition_mode=False):
     bridges = [
         vrx_gz.bridges.clock(),
         vrx_gz.bridges.task_info(),
-        vrx_gz.bridges.usv_wind_speed(),
-        vrx_gz.bridges.usv_wind_direction()
     ]
+
+    if not competition_mode:
+        bridges.extend([
+          vrx_gz.bridges.usv_wind_speed(),
+          vrx_gz.bridges.usv_wind_direction()
+        ])
 
     task_bridges = []
     if world_name in PERCEPTION_WORLDS:

--- a/vrx_gz/src/vrx_gz/launch.py
+++ b/vrx_gz/src/vrx_gz/launch.py
@@ -169,7 +169,7 @@ def competition_bridges(world_name, competition_mode=False):
             vrx_gz.bridges.stationkeeping_goal(),
         ]
         if not competition_mode:
-            vrx_gz.bridges.extend([
+            task_bridges.extend([
                 vrx_gz.bridges.stationkeeping_mean_pose_error(),
                 vrx_gz.bridges.stationkeeping_pose_error(),
             ])

--- a/vrx_gz/src/vrx_gz/launch.py
+++ b/vrx_gz/src/vrx_gz/launch.py
@@ -155,8 +155,8 @@ def competition_bridges(world_name, competition_mode=False):
 
     if not competition_mode:
         bridges.extend([
-          vrx_gz.bridges.usv_wind_speed(),
-          vrx_gz.bridges.usv_wind_direction()
+            vrx_gz.bridges.usv_wind_speed(),
+            vrx_gz.bridges.usv_wind_direction()
         ])
 
     task_bridges = []
@@ -167,21 +167,30 @@ def competition_bridges(world_name, competition_mode=False):
     elif world_name in STATIONKEEPING_WORLDS:
         task_bridges = [
             vrx_gz.bridges.stationkeeping_goal(),
-            vrx_gz.bridges.stationkeeping_mean_pose_error(),
-            vrx_gz.bridges.stationkeeping_pose_error(),
         ]
+        if not competition_mode:
+            vrx_gz.bridges.extend([
+                vrx_gz.bridges.stationkeeping_mean_pose_error(),
+                vrx_gz.bridges.stationkeeping_pose_error(),
+            ])
     elif world_name in WAYFINDING_WORLDS:
         task_bridges = [
             vrx_gz.bridges.wayfinding_waypoints(),
-            vrx_gz.bridges.wayfinding_mean_error(),
-            vrx_gz.bridges.wayfinding_min_errors(),
         ]
+        if not competition_mode:
+            task_bridges.extend([
+                vrx_gz.bridges.wayfinding_mean_error(),
+                vrx_gz.bridges.wayfinding_min_errors(),
+            ])
     elif world_name in GYMKHANA_WORLDS:
         task_bridges = [
             vrx_gz.bridges.gymkhana_blackbox_goal(),
-            vrx_gz.bridges.gymkhana_blackbox_mean_pose_error(),
-            vrx_gz.bridges.gymkhana_blackbox_pose_error(),
         ]
+        if not competition_mode:
+            task_bridges.extend([
+                vrx_gz.bridges.gymkhana_blackbox_mean_pose_error(),
+                vrx_gz.bridges.gymkhana_blackbox_pose_error(),
+            ])
     elif world_name in WILDLIFE_WORLDS:
         task_bridges = [
             vrx_gz.bridges.animal_pose('/vrx/wildlife/animal0/pose'),


### PR DESCRIPTION
Fix issue #693.

This patch allows us to pass an extra `competition_mode` command line argument to enable/disable certain ROS 2 topics. As an example, I disabled the wind debug topics when `competition_mode` is enabled.

### How to test it?

Run the simulation as usual:

```
ros2 launch vrx_gz competition.launch.py world:=practice_2023_stationkeeping2_task
```

Verify that the ROS 2 wind debug topics are available:

```
ros2 topic list

...
/vrx/debug/wind/direction
/vrx/debug/wind/speed
...
```

Now, stop the simulation and run it again in competition mode:
```
ros2 launch vrx_gz competition.launch.py world:=practice_2023_stationkeeping2_task competition_mode:=true
```

And verify again the ROS 2 debug wind topics:
```
ros2 topic list
```

You shouldn't see them now.