### PR TITLE
Fix GPS/IMU update rates

### DIFF
--- a/vrx_urdf/wamv_gazebo/urdf/components/wamv_gps.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/wamv_gps.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="wamv_gps" params="name:=gps x:=0.3 y:=0 z:=1.3
-				       R:=0 P:=0 Y:=0 update_rate:=15">
+				       R:=0 P:=0 Y:=0 update_rate:=20">
     <link name="${namespace}/${name}_link">
       <visual name="${name}_visual">
         <geometry>
@@ -38,7 +38,7 @@
     <gazebo reference="${namespace}/${name}_link">
       <sensor name="navsat" type="navsat">
         <always_on>1</always_on>
-        <update_rate>15</update_rate>
+        <update_rate>${update_rate}</update_rate>
         <!--<topic>${namespace}/${sensor_namespace}gps/gps/fix</topic>-->
       </sensor>
     </gazebo>

--- a/vrx_urdf/wamv_gazebo/urdf/components/wamv_imu.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/wamv_imu.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="wamv_imu" params="name:=imu x:=0.3 y:=0.5 z:=1.3 R:=0 P:=0 Y:=0 update_rate:=15">
+  <xacro:macro name="wamv_imu" params="name:=imu x:=0.3 y:=0.5 z:=1.3 R:=0 P:=0 Y:=0 update_rate:=100">
     <link name="${namespace}/${name}_link">
       <visual name="${name}_visual">>
         <geometry>


### PR DESCRIPTION
See issue #722 .

### How to test it?

Launch the simulation:

```
ros2 launch vrx_gz competition.launch.py world:=sydney_regatta
```

And verify the publication rates:
```
ros2 topic hz /wamv/sensors/gps/gps/fix
ros2 topic hz /wamv/sensors/imu/imu/data
```

They should be closed to 20Hz and 100Hz respectively. Take into account that if the real time factor is lower than `100%`, the values reported from `topic hz` should be proportionally lower.