### PR TITLE
Update camera clip

### DIFF
--- a/vrx_urdf/wamv_gazebo/urdf/components/wamv_camera.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/wamv_camera.xacro
@@ -167,7 +167,7 @@
           </image>
           <clip>
             <near>0.05</near>
-            <far>300</far>
+            <far>400</far>
           </clip>
           <noise>
             <type>gaussian</type>


### PR DESCRIPTION
As @M1chaelM reported, the treeline might look inconsistent from the cameras.

![image](https://github.com/osrf/vrx/assets/1440739/c3db08d9-911c-4753-a985-d383f23fb447)

Increasing the clipping fixes this issue:

https://private-user-images.githubusercontent.com/1440739/262057592-e62bbc8e-3015-42c0-941d-112784203f1b.webm?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTEiLCJleHAiOjE2OTI3NDIxNjYsIm5iZiI6MTY5Mjc0MTg2NiwicGF0aCI6Ii8xNDQwNzM5LzI2MjA1NzU5Mi1lNjJiYmM4ZS0zMDE1LTQyYzAtOTQxZC0xMTI3ODQyMDNmMWIud2VibT9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFJV05KWUFYNENTVkVINTNBJTJGMjAyMzA4MjIlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjMwODIyVDIyMDQyNlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWQzYTE2NjkxMjc4YTgzOTM3YWFkNzA3NjJiNDc2NmUzYTViNzdiYjUyZjMwY2FmMTFiMGU2MTFhNGY1ODBlNGImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.0rCkr-TafcenJqiZ_KGFGYjbSosTR9t0TLqkY2XCF14

### How to test it?

Launch the simulation:

```
ros2 launch vrx_gz competition.launch.py world:=practice_2023_perception2_task
```

From the Gazebo top right menu, load the `Image Display` plugin and verify that the treeline is consistent.