### PR TITLE
Initialize acoustic perception score

### DIFF
--- a/vrx_gz/src/AcousticPerceptionScoringPlugin.cc
+++ b/vrx_gz/src/AcousticPerceptionScoringPlugin.cc
@@ -86,8 +86,6 @@ void AcousticPerceptionScoringPlugin::Configure(const sim::Entity &_entity,
       gzerr << "Error creating visual marker" << std::endl;
     }
   }
-
-  this->SetScore(this->RemainingTime().count());
 }
 
 //////////////////////////////////////////////////
@@ -99,6 +97,8 @@ void AcousticPerceptionScoringPlugin::PreUpdate( const sim::UpdateInfo &_info,
     return;
 
   ScoringPlugin::PreUpdate(_info, _ecm);
+
+  this->SetScore(this->ElapsedTime().count());
 
   // The vehicle might not be ready yet, let's try to get it.
   if (!this->dataPtr->vehicleEntity)
@@ -117,10 +117,7 @@ void AcousticPerceptionScoringPlugin::PreUpdate( const sim::UpdateInfo &_info,
   double distance = vehiclePose.Pos().Distance(this->dataPtr->pingerPosition);
 
   if (distance <= this->dataPtr->goalTolerance)
-  {
-    this->SetScore(this->ElapsedTime().count());
     this->Finish();
-  }
 }
 
 GZ_ADD_PLUGIN(vrx::AcousticPerceptionScoringPlugin,

--- a/vrx_gz/src/AcousticPerceptionScoringPlugin.cc
+++ b/vrx_gz/src/AcousticPerceptionScoringPlugin.cc
@@ -86,6 +86,8 @@ void AcousticPerceptionScoringPlugin::Configure(const sim::Entity &_entity,
       gzerr << "Error creating visual marker" << std::endl;
     }
   }
+
+  this->SetScore(this->remainingTime().count());
 }
 
 //////////////////////////////////////////////////

--- a/vrx_gz/src/AcousticPerceptionScoringPlugin.cc
+++ b/vrx_gz/src/AcousticPerceptionScoringPlugin.cc
@@ -87,7 +87,7 @@ void AcousticPerceptionScoringPlugin::Configure(const sim::Entity &_entity,
     }
   }
 
-  this->SetScore(this->remainingTime().count());
+  this->SetScore(this->RemainingTime().count());
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
This is a bug fix for the acoustic perception task. While running phase 2, I noticed an issue with the scoring. The score should be equal to the elapsed time needed to reach the pinger. However, if the team doesn't reach the pinger, the plugin was reporting a score of `0`. Keep in mind that the lower the score the better. Instead, in that case the score should equal to the total running time (e.g. `300`).

How to test it?

Run this task and let it timeout while watching the score.

```
ros2 launch vrx_gz competition.launch.py world:=practice_2023_acoustic_perception0_task
```

And then:

```
ros2 topic echo /vrx/task/info
```
