### PR TITLE
Fix score in follow-the-path task

### DIFF
--- a/vrx_gz/src/NavigationScoringPlugin.cc
+++ b/vrx_gz/src/NavigationScoringPlugin.cc
@@ -367,11 +367,6 @@ void NavigationScoringPlugin::Configure(const sim::Entity &_entity,
     return;
   }
 
-  // Set default score in case of timeout.
-  double timeoutScore = 200;
-  gzmsg << "Setting timeoutScore = " << timeoutScore << std::endl;
-  this->ScoringPlugin::SetTimeoutScore(timeoutScore);
-
   gzmsg << "Task [" << this->TaskName() << "]" << std::endl;
 }
 
@@ -532,13 +527,6 @@ void NavigationScoringPlugin::PreUpdate( const sim::UpdateInfo &_info,
 
     gate.state = currentState;
   }
-}
-
-//////////////////////////////////////////////////
-void NavigationScoringPlugin::Fail()
-{
-  ScoringPlugin::SetScore(ScoringPlugin::TimeoutScore());
-  ScoringPlugin::Finish();
 }
 
 GZ_ADD_PLUGIN(vrx::NavigationScoringPlugin,

--- a/vrx_gz/src/NavigationScoringPlugin.hh
+++ b/vrx_gz/src/NavigationScoringPlugin.hh
@@ -104,9 +104,6 @@ namespace vrx
     public: void PreUpdate(const gz::sim::UpdateInfo &_info,
                            gz::sim::EntityComponentManager &_ecm) override;
 
-    /// \brief Set the score to 0 and change to state to "finish".
-    protected: void Fail();
-
     /// \brief Private data pointer.
     GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };


### PR DESCRIPTION
While running phase 2 I noticed an issue in the scoring of the follow-the-path task.

If the course isn't completed, the score is overwritten with the timeout score, that was initialized to `200`. Now that the task grants points each time the vehicles crosses a gate, we shouldn't do anything special if the task timeouts. The score should be preserved.

How to test it?

Launch a follow-the-path task:

```
ros2 launch vrx_gz competition.launch.py world:=practice_2023_follow_path0_task
```

And then:

```
ros2 topic echo /vrx/task/info
```

If you don't cross any gates, the score should be `0` instead of `200`.