### PR TITLE
Add Configuration File Roboboat Teleop

### DIFF
--- a/vrx_gz/config/roboboat.yaml
+++ b/vrx_gz/config/roboboat.yaml
@@ -1,0 +1,98 @@
+# Copyright 2022 Open Source Robotics Foundation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Teleop configuration for WAM-V Controller joystick using the d-pad
+# configuration.
+# Left thumb-stick up/down for left thruster thrust.
+# Left thumb-stick left/right for left thruster rotation.
+# Right thumb-stick up/down for right thruster thrust.
+# Right thumb-stick left/right for right thruster rotation.
+# "A" button for firing the ball shooter.
+#
+# Image from: https://github.com/turtlebot/turtlebot4_robot/blob/galactic/turtlebot4_bringup/config/turtlebot4_controller.config.yaml
+#
+#          L1                                       R1
+#          L2                                       R2
+#       _=====_                                  _=====_
+#      / _____ \                                / _____ \
+#    +.-'_____'-.------------------------------.-'_____'-.+
+#   /   |     |  '.   (BACK)       (START)   .'  |  _  |   \
+#  / ___| /|\ |___ \                        / ___| /Y\ |___ \
+# / |      |      | ;                      ; | _         _ ||
+# | | <---   ---> | |                      | ||X|       (B)||
+# | |___   |   ___| ;                      ; |___       ___||
+# |\    | \|/ |    /  _      ____      _   \    | (A) |    /|
+# | \   |_____|  .','" "',          ,'" "', '.  |_____|  .' |
+# |  '-.______.-' /       \        /       \  '-._____.-'   |
+# |               |  LJ   |--------|  RJ   |                |
+# |              /\       /        \       /\               |
+# |             /  '.___.'          '.___.'  \              |
+# |            /                              \             |
+#  \          /                                \           /
+#   \________/                                  \_________/
+#
+#          ^ x
+#          |
+#          |
+#  y <-----+      Accelerometer axes
+#           \
+#            \
+#             > z (out)
+#
+# BUTTON         Value
+#   X              0
+#   A              1
+#   B              2
+#   Y              3
+#   L1             4
+#   R1             5
+#   L2             6
+#   R2             7
+#  Back            8
+#  Start           9
+#   L3             10
+#   R3             11
+#
+#    AXIS        Value
+# Left Horiz.      0
+# Left Vert.       1
+# Right Horiz.     2
+# Right Vert.      3
+# D-pad Horiz.     4
+# D-pad Vert.      5
+
+joy_teleop:
+  ros__parameters:
+
+    left_thrust:
+      type: topic
+      interface_type: std_msgs/msg/Float64
+      topic_name: /model/roboboat01/joint/left_engine_propeller_joint/cmd_thrust
+      deadman_buttons: [4]
+      axis_mappings:
+        data:
+          axis: 1
+          scale: 150.0
+          offset: 0
+
+    right_thrust:
+      type: topic
+      interface_type: std_msgs/msg/Float64
+      topic_name: /model/roboboat01/joint/right_engine_propeller_joint/cmd_thrust
+      deadman_buttons: [4]
+      axis_mappings:
+        data:
+          axis: 3
+          scale: 150.0
+          offset: 0


### PR DESCRIPTION
### What it Does
Maps joysticks on gamepad to each thruster on roboboat resulting in a differential drive system. Scaling is decreased in comparison to WAM-V config.

### How to Test
See the [tutorial](https://github.com/osrf/vrx/wiki/teleop_roboboat_tutorial) for how it is used and testing. 

#### Side Note to Reviewer
I've had past issues with my gamepad axes not matching intended command direction. This config matches the WAM-V config for direction/axis, so should be fine, but verification is appreciated.