### PR TITLE
In the vrx simulation, the ocean is currently detected by the lidar. …

### DIFF
--- a/vrx_urdf/wamv_gazebo/urdf/components/wamv_3d_lidar.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/wamv_3d_lidar.xacro
@@ -162,6 +162,7 @@
       <sensor type="gpu_ray" name="${name}_sensor">
         <update_rate>${update_rate}</update_rate>
         <ray>
+          <visibility_mask>7</visibility_mask>
           <scan>
             <horizontal>
               <samples>${samples/resolution}</samples>


### PR DESCRIPTION
… where it is expected that the majority of lidar hits are absorbed by water.  Generally only wakes and waves will cause hits.

This patch adds a visibility_filter tag to the 3d lidar that will filter water hits, more closely matching the expected behaviour in the field.  The corresponding tag is already present in the water mesh.