### PR TITLE
Update README: new Gazebo and ROS versions supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,35 @@ This repository is the home to the source code and software documentation for th
 * For RobotX competitors this simulation environment is intended as a first step toward developing tools prototyping solutions in advance of physical on-water testing.
 * We also welcome users with simulation needs beyond RobotX. As we continue to improve the environment, we hope to offer support to a wide range of potential applications.
 
-## Now supporting Gazebo Sim and ROS 2 by default
-We're happy to announce with release 2.0 VRX has transitioned from Gazebo Classic to the newer Gazebo simulator (formerly [Ignition Gazebo](https://www.openrobotics.org/blog/2022/4/6/a-new-era-for-gazebo)). 
-* Gazebo Garden and ROS 2 are now default prerequisites for VRX.
-* This is the recommended configuration for new users.
-* Users who wish to continue running Gazebo Classic and ROS 1 can still do so using the `gazebo_classic` branch of this repository. 
-  * Tutorials for VRX Classic will remain available on our Wiki.
-  * VRX Classic will transition from an officially supported branch to a community supported branch by Spring 2023.
+## A new modernization development: Gazebo Harmonic and ROS 2 Jazzy
+
+> [!NOTE]
+> This developement effort was executed by the
+> [Honu Robotics](https://.honurobotics.com) team, thanks to the sponsorship
+> of [RoboNation](https://robonation.org/).
+
+We are happy to announce that the repository has been ported to use supported
+versions of Gazebo and ROS 2:
+  * Code is now working with Gazebo Harmonic and ROS 2 Jazzy
+  * This is the recommended configuration for new users.
+  * Users who wish to continue running Gazebo Garden and ROS 2 Humble can still do so using the `humble` branch of this repository.
 
 ## The VRX Competition
-The VRX environment is also the "virtual venue" for the [VRX Competition](https://github.com/osrf/vrx/wiki). Please see our Wiki for tutorials and links to registration and documentation relevant to the virtual competition. 
+The VRX environment is also the "virtual venue" for the [VRX Competition](https://github.com/osrf/vrx/wiki). Please see our Wiki for tutorials and links to registration and documentation relevant to the virtual competition.
 
-![VRX](images/sydney_regatta_gzsim.png)
-![Ubuntu CI](https://github.com/osrf/vrx/workflows/Ubuntu%20CI/badge.svg)
+[![VRX](images/sydney_regatta_gzsim.png)](https://vimeo.com/851696025 "Gazebo Virtual RobotX v. 2.3 - Click to Watch!")
+![ROS 2 CI](https://github.com/osrf/vrx/workflows/ROS%202%20CI/badge.svg)
 
 ## Getting Started
 
  * Watch the [Release 2.3 Highlight Video](https://vimeo.com/851696025).
  * The [VRX Wiki](https://github.com/osrf/vrx/wiki) provides documentation and tutorials.
  * The instructions assume a basic familiarity with the ROS environment and Gazebo.  If these tools are new to you, we recommend starting with the excellent [ROS Tutorials](http://wiki.ros.org/ROS/Tutorials)
- * For technical problems, please use the [project issue tracker](https://github.com/osrf/vrx/issues) to describe your problem or request support. 
+ * For technical problems, please use the [project issue tracker](https://github.com/osrf/vrx/issues) to describe your problem or request support.
 
 ## Reference
 
-If you use the VRX simulation in your work, please cite our summary publication, [Toward Maritime Robotic Simulation in Gazebo](https://wiki.nps.edu/display/BB/Publications?preview=/1173263776/1173263778/PID6131719.pdf): 
+If you use the VRX simulation in your work, please cite our summary publication, [Toward Maritime Robotic Simulation in Gazebo](https://wiki.nps.edu/display/BB/Publications?preview=/1173263776/1173263778/PID6131719.pdf):
 
 ```
 @InProceedings{bingham19toward,
@@ -47,10 +52,15 @@ If you have any questions about these topics, or would like to work on other asp
 
 ## Contributors
 
+> [!NOTE]
+> The [Honu Robotics](https://.honurobotics.com) team, thanks to the
+> sponsorship of [RoboNation](https://robonation.org/) is currently the
+> maintainer of this repository.
+
 We continue to receive important improvements from the community.  We have done our best to document this on our [Contributors Wiki](https://github.com/osrf/vrx/wiki/Contributors).
 
 ## Contacts
 
- * Carlos Agüero <caguero@openrobotics.org>
+ * Carlos Agüero <caguero@honurobotics.com>
+ * Brian Bingham <bbingham@honurobotics.com>
  * Michael McCarrin <mrmccarr@nps.edu>
- * Brian Bingham <bbingham@nps.edu>


### PR DESCRIPTION
Update README to reflect the changes done in #794 and give credit to Honu/RoboNation for doing the latest development in this area.

:warning: before merging, we will need to deploy the branching model based on ROS 2 release names and create the `humble` branch from the `garden` branch and branch out `main` to be named `jazzy`.