### PR TITLE
Fix particle emitter plugin name

### DIFF
--- a/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_perception0.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_perception0.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_perception1.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_perception1.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_perception2.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_perception2.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_perception3.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_perception3.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_perception4.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_perception4.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_perception5.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_perception5.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_tracking0.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_tracking0.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_tracking1.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_tracking1.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_tracking2.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_tracking2.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_tracking3.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_tracking3.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_tracking4.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_tracking4.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_tracking5.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_acoustic_tracking5.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_follow_path0.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_follow_path0.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_follow_path1.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_follow_path1.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_follow_path2.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_follow_path2.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_follow_path3.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_follow_path3.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_follow_path4.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_follow_path4.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_follow_path5.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_follow_path5.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_perception0.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_perception0.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_perception1.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_perception1.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_perception2.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_perception2.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_perception3.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_perception3.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_perception4.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_perception4.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_perception5.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_perception5.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_scan_dock_deliver0.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_scan_dock_deliver0.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_scan_dock_deliver1.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_scan_dock_deliver1.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_scan_dock_deliver2.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_scan_dock_deliver2.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_scan_dock_deliver3.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_scan_dock_deliver3.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_scan_dock_deliver4.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_scan_dock_deliver4.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_scan_dock_deliver5.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_scan_dock_deliver5.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_stationkeeping0.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_stationkeeping0.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_stationkeeping1.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_stationkeeping1.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_stationkeeping2.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_stationkeeping2.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_stationkeeping3.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_stationkeeping3.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_stationkeeping4.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_stationkeeping4.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_stationkeeping5.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_stationkeeping5.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_wayfinding0.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_wayfinding0.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_wayfinding1.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_wayfinding1.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_wayfinding2.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_wayfinding2.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_wayfinding3.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_wayfinding3.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_wayfinding4.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_wayfinding4.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_wayfinding5.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_wayfinding5.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_wildlife0.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_wildlife0.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_wildlife1.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_wildlife1.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_wildlife2.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_wildlife2.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_wildlife3.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_wildlife3.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_wildlife4.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_wildlife4.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_phase2/phase2_2023_wildlife5.sdf
+++ b/vrx_gz/worlds/2023_phase2/phase2_2023_wildlife5.sdf
@@ -291,8 +291,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception0_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception1_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_perception2_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking0_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking1_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_acoustic_tracking2_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_follow_path0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_follow_path0_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_follow_path1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_follow_path1_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_follow_path2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_follow_path2_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_perception0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception0_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_perception1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception1_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_perception2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_perception2_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver0_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver1_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_scan_dock_deliver2_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping0_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping1_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_stationkeeping2_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_wayfinding0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wayfinding0_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_wayfinding1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wayfinding1_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_wayfinding2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wayfinding2_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife0_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife0_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife1_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife1_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/2023_practice/practice_2023_wildlife2_task.sdf
+++ b/vrx_gz/worlds/2023_practice/practice_2023_wildlife2_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/acoustic_perception_task.sdf
+++ b/vrx_gz/worlds/acoustic_perception_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/acoustic_tracking_task.sdf
+++ b/vrx_gz/worlds/acoustic_tracking_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/follow_path_task.sdf
+++ b/vrx_gz/worlds/follow_path_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/gymkhana_task.sdf
+++ b/vrx_gz/worlds/gymkhana_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/navigation_task.sdf
+++ b/vrx_gz/worlds/navigation_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/nbpark.sdf
+++ b/vrx_gz/worlds/nbpark.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/perception_task.sdf
+++ b/vrx_gz/worlds/perception_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/scan_dock_deliver_task.sdf
+++ b/vrx_gz/worlds/scan_dock_deliver_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/stationkeeping_task.sdf
+++ b/vrx_gz/worlds/stationkeeping_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/sydney_regatta.sdf
+++ b/vrx_gz/worlds/sydney_regatta.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/wayfinding_task.sdf
+++ b/vrx_gz/worlds/wayfinding_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"

--- a/vrx_gz/worlds/wildlife_task.sdf
+++ b/vrx_gz/worlds/wildlife_task.sdf
@@ -293,8 +293,8 @@
       name="gz::sim::systems::ForceTorque">
     </plugin>
     <plugin
-      filename="gz-sim-particle-emitter2-system"
-      name="gz::sim::systems::ParticleEmitter2">
+      filename="gz-sim-particle-emitter-system"
+      name="gz::sim::systems::ParticleEmitter">
     </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"


### PR DESCRIPTION
Don't know where the particle emitter 2 name came from but Gazebo was complaining about that invalid plugin. Fixed in all references to existing name.