### PR TITLE
Handle the new ROS image with key updated

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## VRX 3
 
+### VRX 3.0.2
+
+1. Handle the new ROS image with key updated
+    * [Pull Request 827](https://github.com/osrf/vrx/pull/827)
+
 ### VRX 3.0.1
 
 1.  Use a workaround to avoid ROS 2 key deprecation

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -2,17 +2,19 @@
 FROM osrf/ros:jazzy-desktop-full AS vrx-base
 
 # Workaround from https://discourse.ros.org/t/ros-signing-key-migration-guide/43937
-RUN rm /etc/apt/sources.list.d/ros2-latest.list \
-  && rm /usr/share/keyrings/ros2-latest-archive-keyring.gpg
+RUN rm -f /etc/apt/sources.list.d/ros2-latest.list \
+  && rm -f /usr/share/keyrings/ros2-latest-archive-keyring.gpg
 
-RUN apt-get update \
-  && apt-get install -y ca-certificates curl
-
-RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
-    curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
-    && apt-get update \
-    && apt-get install /tmp/ros2-apt-source.deb \
-    && rm -f /tmp/ros2-apt-source.deb
+# Only install ros2-apt-source if it's not already installed
+RUN if ! dpkg -l | grep -q ros2-apt-source; then \
+    apt-get update && \
+    apt-get install -y ca-certificates curl && \
+    export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') && \
+    curl -L -s -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" && \
+    apt-get update && \
+    apt-get install /tmp/ros2-apt-source.deb && \
+    rm -f /tmp/ros2-apt-source.deb; \
+  fi
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
10 hours the ros:jazzy-desktop-full image was updated with the recommended setup for the new key. That removed the previous configuration making our changes in #825 to be broken.

This PR adds some checks so older images of  ros:jazzy-desktop-full and the new one can be handle transparently.