### PR TITLE
Inject custom vendor packages for Harmonic to avoid Python ABI problems

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,5 +1,5 @@
-# Ubuntu 24.04 
-FROM osrf/ros:jazzy-desktop-full AS vrx-base
+# Ubuntu 24.04
+FROM ros:jazzy-ros-base AS vrx-base
 
 # Workaround from https://discourse.ros.org/t/ros-signing-key-migration-guide/43937
 RUN rm -f /etc/apt/sources.list.d/ros2-latest.list \
@@ -31,9 +31,51 @@ RUN echo $TZ > /etc/timezone && \
 RUN curl -s https://packages.osrfoundation.org/gazebo.gpg -o /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
 
-# Install some 'standard' ROS packages and utilities.
+# Install gz-harmonic
 RUN apt update \
     && apt install -y --no-install-recommends \
        gz-harmonic \
+       equivs \
     && rm -rf /var/lib/apt/lists/* \
     && apt clean -qq
+
+# Solution for problem https://github.com/osrf/vrx/issues/839
+# Create fake providers for the ROS Gazebo vendor packages of the Gz libraries
+# that support Python bindings and use a colcon workspace to inject
+# the real ROS packages.
+
+# Create the dummy package control file for ROS Jazzy Gazebo vendor packages
+COPY <<EOF /tmp/fake-ros-jazzy-gz-vendor
+Package: fake-ros-jazzy-gz-vendor
+Version: 999.999
+Architecture: all
+Description: Fake ROS Jazzy Gazebo vendor packages for containers
+ This package provides dummy implementations to satisfy
+ ROS Jazzy Gazebo vendor package dependencies without actual functionality.
+Provides: ros-jazzy-gz-math-vendor, ros-jazzy-gz-msgs-vendor, ros-jazzy-gz-transport-vendor, ros-jazzy-gz-sim-vendor, ros-jazzy-sdformat-vendor
+EOF
+
+# Build and install the dummy package
+RUN cd /tmp \
+    && cat fake-ros-jazzy-gz-vendor \
+    && equivs-build fake-ros-jazzy-gz-vendor \
+    && dpkg -i fake-ros-jazzy-gz-vendor_*_all.deb \
+    && rm -f /tmp/fake-ros-jazzy-gz-vendor /tmp/fake-ros-jazzy-gz-vendor_*_all.deb
+
+ADD gz.repos /tmp/gz.repos
+
+RUN mkdir -p /opt/ros_gz_ws/src \
+    && cd /opt/ros_gz_ws \
+    && vcs import src < /tmp/gz.repos \
+    && apt update \
+    && rosdep install -r --from-paths . --ignore-src --rosdistro jazzy -y --skip-keys="gz_math_vendor gz_msgs_vendor gz_sim_vendor gz_transport_vendor sdformat_vendor" \
+    && . /opt/ros/jazzy/setup.sh \
+    && colcon build --merge-install --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+# Source for interactive shells (both login and non-login)
+RUN echo "source /opt/ros_gz_ws/install/setup.bash" > /etc/profile.d/ros_gz_pythons.sh \
+    && echo "export GZ_CONFIG_PATH=\$GZ_CONFIG_PATH:/usr/share/gz/" > /etc/profile.d/ros_gz_pythons.sh \
+    && chmod +x /etc/profile.d/ros_gz_pythons.sh \
+    && echo "source /etc/profile.d/ros_gz_pythons.sh" >> /etc/bash.bashrc
+# Source for non-interactive shells
+ENV BASH_ENV=/etc/profile.d/ros_gz_pythons.sh

--- a/docker/gz.repos
+++ b/docker/gz.repos
@@ -1,0 +1,21 @@
+repositories:
+  gz_libs/gz_math_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_math_vendor.git
+    version: jazzy
+  gz_libs/gz_msgs_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_msgs_vendor.git
+    version: jazzy
+  gz_libs/gz_sim_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_sim_vendor.git
+    version: jazzy
+  gz_libs/gz_transport_vendor:
+    type: git
+    url: https://github.com/gazebo-release/gz_transport_vendor.git
+    version: jazzy
+  gz_libs/sdformat_vendor:
+    type: git
+    url: https://github.com/gazebo-release/sdformat_vendor.git
+    version: jazzy


### PR DESCRIPTION
Closes: #839 

To avoid the installation of the ros-jazzy-gz-*-vendor (being * the Gz packages with Python wrappers)  / ros-jazzy-sdformat-vendor packages the PR does the following:

 * The PR changes the Dockerfile.base not to be based in desktop-full but in ros-base
 * Create a fake debian package that `Provides:` the vendor packages for the Gazebo libraries that have Python bindings. This way the .deb package dependency chain can continue working without the risk of installing the vendor packages and rosdep can still be used.
 * To replace the real ROS Gazebo vendor packages "provided" by the fake .deb package, stablish a colcon workspace with a gz.repos file that builds from source the packages. The Gazebo vendor packages can use the system installation of Gazebo libraries if present so no real compilation is done and the .deb packages are being used.
 * Inject for interactive and non-interactive logins the variables that allows the transparent interaction for the user sourcing the colcon workspace and making the `gz` tool from ROS to work also with system packages.
