### PR TITLE
Make IMU, GPS, pinger and ball shooter joints fixed

### DIFF
--- a/vrx_urdf/wamv_gazebo/urdf/components/ball_shooter.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/ball_shooter.xacro
@@ -47,16 +47,12 @@
       </inertial>
     </link>
 
-    <joint name="${namespace}/${name}_base_joint" type="revolute">
-      <axis xyz="0 0 1"/>
-      <limit effort="1000.0" lower="0.0" upper="0" velocity="0"/>
+    <joint name="${namespace}/${name}_base_joint" type="fixed">
       <origin xyz="${x} ${y} ${z}" rpy="0 0 ${yaw}"/>
       <parent link="${namespace}/base_link"/>
       <child link="${namespace}/${name}_base_link"/>
     </joint>
-    <joint name="${namespace}/${name}_launcher_joint" type="revolute">
-      <axis xyz="0 0 1"/>
-      <limit effort="1000.0" lower="0.0" upper="0" velocity="0"/>
+    <joint name="${namespace}/${name}_launcher_joint" type="fixed">
       <origin xyz="-0.0204 0 0.107877" rpy="0 ${pitch} 0"/>
       <parent link="${namespace}/${name}_base_link"/>
       <child link="${namespace}/${name}_launcher_link"/>

--- a/vrx_urdf/wamv_gazebo/urdf/components/ball_shooter.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/ball_shooter.xacro
@@ -52,12 +52,17 @@
       <parent link="${namespace}/base_link"/>
       <child link="${namespace}/${name}_base_link"/>
     </joint>
+
+    <gazebo reference="${namespace}/${name}_base_joint">
+      <preserveFixedJoint>true</preserveFixedJoint>
+    </gazebo>
+
     <joint name="${namespace}/${name}_launcher_joint" type="fixed">
       <origin xyz="-0.0204 0 0.107877" rpy="0 ${pitch} 0"/>
       <parent link="${namespace}/${name}_base_link"/>
       <child link="${namespace}/${name}_launcher_link"/>
     </joint>
-    
+
     <gazebo reference="${namespace}/${name}_launcher_joint">
       <preserveFixedJoint>true</preserveFixedJoint>
     </gazebo>

--- a/vrx_urdf/wamv_gazebo/urdf/components/ball_shooter.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/ball_shooter.xacro
@@ -57,7 +57,11 @@
       <parent link="${namespace}/${name}_base_link"/>
       <child link="${namespace}/${name}_launcher_link"/>
     </joint>
-
+    
+    <gazebo reference="${namespace}/${name}_launcher_joint">
+      <preserveFixedJoint>true</preserveFixedJoint>
+    </gazebo>
+    
     <gazebo reference="${namespace}/${name}_base_link">
       <visual>
         <material>

--- a/vrx_urdf/wamv_gazebo/urdf/components/wamv_gps.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/wamv_gps.xacro
@@ -31,8 +31,9 @@
       <parent link="${namespace}/base_link" />
       <child link="${namespace}/${name}_link" />
     </joint>
-
-
+    <gazebo reference="${namespace}/${name}_joint">
+      <preserveFixedJoint>true</preserveFixedJoint>
+    </gazebo>
     <gazebo reference="${namespace}/${name}_link">
       <sensor name="navsat" type="navsat">
         <always_on>1</always_on>

--- a/vrx_urdf/wamv_gazebo/urdf/components/wamv_gps.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/wamv_gps.xacro
@@ -26,9 +26,7 @@
 		 iyy="0.006458" iyz="0.0" izz="0.01125"/>
       </inertial>
     </link>
-    <joint name="${namespace}/${name}_joint" type="revolute">
-      <axis xyz="0 0 1"/>
-      <limit effort="1000.0" lower="0.0" upper="0" velocity="0"/>
+    <joint name="${namespace}/${name}_joint" type="fixed">
       <origin xyz="${x} ${y} ${z}" rpy="${R} ${P} ${Y}" />
       <parent link="${namespace}/base_link" />
       <child link="${namespace}/${name}_link" />
@@ -44,5 +42,3 @@
     </gazebo>
   </xacro:macro>
 </robot>
-
-

--- a/vrx_urdf/wamv_gazebo/urdf/components/wamv_imu.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/wamv_imu.xacro
@@ -20,9 +20,7 @@
         <inertia ixx="0.00000542" ixy="0.0" ixz="0.0" iyy="0.00002104" iyz="0.0" izz="0.00002604"/>
       </inertial>
     </link>
-    <joint name="${namespace}/${name}_joint" type="revolute">
-      <axis xyz="0 0 1"/>
-      <limit effort="1000.0" lower="0.0" upper="0" velocity="0"/>
+    <joint name="${namespace}/${name}_joint" type="fixed">
       <origin xyz="${x} ${y} ${z}" rpy="${R} ${P} ${Y}"/>
       <parent link="${namespace}/base_link"/>
       <child link="${namespace}/${name}_link"/>

--- a/vrx_urdf/wamv_gazebo/urdf/components/wamv_imu.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/wamv_imu.xacro
@@ -25,6 +25,9 @@
       <parent link="${namespace}/base_link"/>
       <child link="${namespace}/${name}_link"/>
     </joint>
+    <gazebo reference="${namespace}/${name}_joint">
+      <preserveFixedJoint>true</preserveFixedJoint>
+    </gazebo>
     <gazebo reference="${namespace}/${name}_link">
       <sensor type="imu" name="${name}_sensor">
         <update_rate>${update_rate}</update_rate>

--- a/vrx_urdf/wamv_gazebo/urdf/components/wamv_pinger.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/wamv_pinger.xacro
@@ -18,7 +18,9 @@
       <parent link="${namespace}/base_link"/>
       <child link="${namespace}/${sensor_name}"/>
     </joint>
-
+    <gazebo reference="${namespace}/${sensor_name}_pinger_joint">
+      <preserveFixedJoint>true</preserveFixedJoint>
+    </gazebo>
     <gazebo>
       <plugin
         filename="libAcousticPingerPlugin.so"

--- a/vrx_urdf/wamv_gazebo/urdf/components/wamv_pinger.xacro
+++ b/vrx_urdf/wamv_gazebo/urdf/components/wamv_pinger.xacro
@@ -13,9 +13,7 @@
         <inertia ixx="0.00000542" ixy="0.0" ixz="0.0" iyy="0.00002104" iyz="0.0" izz="0.00002604"/>
       </inertial>
     </link>
-    <joint name="${namespace}/${sensor_name}_pinger_joint" type="revolute">
-      <axis xyz="0 0 1"/>
-      <limit effort="1000.0" lower="0.0" upper="0" velocity="0"/>
+    <joint name="${namespace}/${sensor_name}_pinger_joint" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 0" />
       <parent link="${namespace}/base_link"/>
       <child link="${namespace}/${sensor_name}"/>


### PR DESCRIPTION
This is a proposed fix for the issue #866.
I'm new to VRX, but as far as I understand, the ball shooter is not supposed to be actuated. Actually, the current joints configuration is wrong anyway, it has two joints both rotating around Z, the second joint should rotate around Y, I suppose. It's obvious that IMU, GPS and acoustic sensors should be fixed. It looks like all of this is just a kind of a copy-paste mistake.
So my suggestion is to make all the following joints fixed:
- wamv/ball_shooter_base_joint
- wamv/ball_shooter_launcher_joint
- wamv/gps_wamv_joint
- wamv/imu_wamv_joint
- wamv/receiver_pinger_joint

