### PR TITLE
Use sequential order for VRX images in the release script

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -30,11 +30,13 @@ jobs:
         id: docker-build-push
         run: |
           cd docker
-          # Define image types in an array
+          # Define image types in an array, order matters due to inter-dependencies
           IMAGE_TYPES=("base" "builder" "devel")
 
-          # Build images
-          docker compose -f docker-compose.yml build ${IMAGE_TYPES[@]}
+          # Build images sequentially (builder and devel depend on base)
+          for type in "${IMAGE_TYPES[@]}"; do
+            docker compose -f docker-compose.yml build ${type}
+          done
 
           # Tag and push images
           for type in "${IMAGE_TYPES[@]}"; do


### PR DESCRIPTION
Tested in my local fork, the build job passed until the end of build & push https://github.com/j-rivero/vrx/actions/runs/19708093557/job/56460932542?pr=1 (failure is expected due to the lack of a tag).

After merging this, we will need a new tag for triggering the release again, maybe something like `v3.1.1`?