### PR TITLE
gz_waves: core - Part 1/4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,118 @@
+# AGENTS.md
+
+Operational guide for AI agents working in this repository. Read this first, then
+the deeper design docs it points to. This file applies to the whole repo; if a
+subdirectory adds its own `AGENTS.md`, the closest one to the file you are
+editing wins.
+
+VRX (Virtual RobotX) is a Gazebo + ROS 2 maritime simulation. The substantive
+subsystem today is the **wave-simulation stack** (`gz_waves*` packages); more
+subsystems will be added over time.
+
+## Project layout
+
+| Path | What |
+|------|------|
+| `gz_waves/` | Engine-agnostic wave **core** (the `IWaveField` contract, engine registry, `Wavefield` ECM component, `Eval` facade, `WavesSystemBase`). |
+| `gz_waves_provider_gerstner/`, `gz_waves_provider_fft/` | Wave **engines** (a backend + its server source plugin + a GUI registrar). |
+| `gz_waves_rendering/` | Provider-agnostic **renderer** (`WaterVisual`) + the Ogre2 C-ABI bridge + the `water_surface` model. |
+| `gz_waves_buoyancy/` | A wave-field **consumer** (`WaveBuoyancy`). |
+| `vrx_gazebo/` | Worlds (`open_water.sdf`) + resource-path hooks. |
+| `vrx_bringup/` | ROS 2 launch + `ros_gz_bridge` config. |
+| `WAVES_DESIGN.md` | Full design + contributor reference for the wave stack. |
+
+## Setup & build
+
+ROS 2 Rolling + Gazebo Jetty (+ matching `ros_gz`). The workspace is `~/vrx_ws`,
+this repo is `~/vrx_ws/src/vrx`.
+
+```bash
+cd ~/vrx_ws
+colcon build --symlink-install
+source install/setup.bash
+```
+
+The FFT wave engine depends on **EncinoWaves**, an external system library
+(installed separately, not vendored). It must be discoverable via
+`CMAKE_PREFIX_PATH` (e.g. installed under `~/.local`) or
+`gz_waves_provider_fft` will fail to configure.
+
+## Run
+
+```bash
+ros2 launch vrx_bringup simulation.launch.xml          # boots open_water.sdf with a moving ocean
+gz sim -r src/vrx/vrx_gazebo/worlds/open_water.sdf      # world directly
+```
+
+## Test — run before declaring work done
+
+```bash
+colcon test --packages-select <pkg> && colcon test-result --verbose
+# or run a gtest binary directly:
+./build/gz_waves/wave_core_test
+./build/gz_waves_provider_gerstner/gerstner_test
+./build/gz_waves_provider_fft/fft_test
+```
+
+Render-path changes cannot be verified headless — they need a real `gz sim -r`
+on a GPU. State plainly when a change is build-only and GUI-unverified.
+
+## Code style (Gazebo house style)
+
+Match the surrounding code. For C++:
+
+- **`_`-prefix every function/method parameter** (`void Foo(int _x)`); loop and
+  local variables are exempt.
+- A **50-slash separator** `//////////////////////////////////////////////////`
+  before each out-of-line function/method definition **and** before each
+  `TEST`/`TEST_F`.
+- **Per-member access specifiers** — prefix every member/method with
+  `public:` / `private:` / `protected:` (Gazebo style, not one block per group).
+- **Doxygen** on declarations: `\brief` above each class/struct member (not a
+  trailing `///<`), `\param`/`\return` on functions, `// Documentation inherited`
+  on overrides.
+- **Copyright header**: new files use the **Honu Robotics** Apache-2.0 header;
+  when editing an existing file, keep its existing header.
+
+## Commit & PR conventions
+
+- Branch off the default branch; do not commit directly to it.
+- Recommended one-line, imperative commit subject (`package: do the thing`).
+- Sign off (`git commit --signoff`) and end the message with the trailer:
+  `Co-Authored-By:`
+
+## Critical invariants (do not regress these)
+
+These are non-obvious and have each caused real bugs. See `WAVES_DESIGN.md` for
+the full rationale (section refs below).
+
+- **Core and renderer stay engine-agnostic.** `gz_waves` and
+  `gz_waves_rendering` must not build-depend on, link, or include any concrete
+  engine. Adding an engine must not modify them. (§2, §7)
+- **The engine is never serialized.** Replication carries the *recipe* only;
+  each consumer rebuilds its engine via `CreateWaveSimulation`. (§3.4)
+- **`WaterVisual` owns a private engine.** Never alias the component's
+  `simulation` into the renderer — the render thread and ECM thread race it and
+  it segfaults. Build a private, mutex-guarded instance. (§5.1, N2)
+- **GUI registrars load at the `<visual>` level.** gz-sim's GuiRunner loads
+  system plugins only at `<visual>`; model/link/world-level never reach the GUI
+  process → flat/white ocean. Put `gz-sim-waves-<engine>-gui` next to
+  `WaterVisual` in the `water_surface` model's `<visual>`. (§5.2)
+- **Ogre stays behind the dlopen'd C-ABI bridge.** Never link
+  `gz-rendering-ogre2` into `WaterVisual` — the resulting `DT_NEEDED` breaks
+  gz-rendering's own engine loader (default-material plane / RTF collapse). (§5.3, N4)
+- **Consumers query via `Eval` free functions**, never via `IWaveField`
+  directly; the engine type stays opaque. (§3.5, N3)
+
+## Adding a new wave engine
+
+A new engine is one self-contained `gz_waves_provider_<name>` package (engine +
+source system + GUI registrar); the core, renderer, and consumers need **zero
+changes**. Follow the step-by-step recipe in **`WAVES_DESIGN.md` §9**, using
+`gz_waves_provider_gerstner/` as the template.
+
+## Deeper docs
+
+- `WAVES_DESIGN.md` — wave-stack requirements, architecture, per-package detail,
+  and the "add a new engine" guide.
+- `README.md` — user-facing build/run summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ subdirectory adds its own `AGENTS.md`, the closest one to the file you are
 editing wins.
 
 VRX (Virtual RobotX) is a Gazebo + ROS 2 maritime simulation. The substantive
-subsystem today is the **wave-simulation stack** (`gz_waves*` packages); more
+subsystem today is the **wave simulation packages** (`gz_waves*`); more
 subsystems will be added over time.
 
 ## Project layout
@@ -14,12 +14,12 @@ subsystems will be added over time.
 | Path | What |
 |------|------|
 | `gz_waves/` | Engine-agnostic wave **core** (the `IWaveField` contract, engine registry, `Wavefield` ECM component, `Eval` facade, `WavesSystemBase`). |
-| `gz_waves_provider_gerstner/`, `gz_waves_provider_fft/` | Wave **engines** (a backend + its server source plugin + a GUI registrar). |
-| `gz_waves_rendering/` | Provider-agnostic **renderer** (`WaterVisual`) + the Ogre2 C-ABI bridge + the `water_surface` model. |
+| `gz_waves_provider_gerstner/`, `gz_waves_provider_fft/` | Wave field **engines** (an `IWaveField` implementation + its server source plugin + a GUI registrar). |
+| `gz_waves_rendering/` | Engine-agnostic **renderer** (`WaterVisual`) + the Ogre2 C-ABI bridge + the `water_surface` model. |
 | `gz_waves_buoyancy/` | A wave-field **consumer** (`WaveBuoyancy`). |
 | `vrx_gazebo/` | Worlds (`open_water.sdf`) + resource-path hooks. |
 | `vrx_bringup/` | ROS 2 launch + `ros_gz_bridge` config. |
-| `WAVES_DESIGN.md` | Full design + contributor reference for the wave stack. |
+| `WAVES_DESIGN.md` | Full design + contributor reference for the wave packages. |
 
 ## Setup & build
 
@@ -113,6 +113,6 @@ changes**. Follow the step-by-step recipe in **`WAVES_DESIGN.md` §9**, using
 
 ## Deeper docs
 
-- `WAVES_DESIGN.md` — wave-stack requirements, architecture, per-package detail,
+- `WAVES_DESIGN.md` — wave-package requirements, architecture, per-package detail,
   and the "add a new engine" guide.
 - `README.md` — user-facing build/run summary.

--- a/WAVES_DESIGN.md
+++ b/WAVES_DESIGN.md
@@ -1,0 +1,645 @@
+# VRX Wave Simulation — Design & Contributor Reference
+
+This document is the single reference for the VRX wave-simulation stack. It
+captures the **requirements**, the **architecture and design decisions**, the
+**per-package implementation details**, and a step-by-step **guide to
+contributing a new wave engine** (a new "wave rendering model").
+
+The stack is made of these packages:
+
+| Package | Role |
+|---------|------|
+| `gz_waves` | Engine-agnostic **core**: the `IWaveField` contract, the engine registry, the `Wavefield` ECM component, the `Eval` query facade, and `WavesSystemBase` (the source-plugin base). |
+| `gz_waves_provider_gerstner` | Analytic **Gerstner** engine + source system + GUI registrar. |
+| `gz_waves_provider_fft` | **FFT** spectral engine (EncinoWaves) + source system + GUI registrar. |
+| `gz_waves_rendering` | Provider-agnostic **WaterVisual** renderer + the Ogre2 C-ABI bridge + the `water_surface` model; wires a runnable demo world. |
+
+These are the packages this document covers. The wave field is designed to drive
+any number of **consumers** (vessel buoyancy/hydrodynamics, the renderer, future
+sensors); `WaveBuoyancy` is used throughout as the illustrative consumer.
+
+All new source files carry the **Honu Robotics** Apache-2.0 copyright header.
+
+---
+
+## 1. Requirements
+
+### Functional
+
+- **R1 — Multiple selectable wave models.** Support more than one wave-field
+  backend (analytic Gerstner, spectral FFT) chosen per world, with room to add
+  more without touching existing packages.
+- **R2 — One physical wave field, many consumers.** A single authoritative wave
+  field drives every consumer — vessel buoyancy/hydrodynamics, the rendered
+  surface, future sensors — so they stay mutually consistent.
+- **R3 — Visualization.** The wave surface is rendered (displaced + shaded mesh)
+  in the Gazebo GUI, matching the simulated field.
+- **R4 — One-knob sea control.** A single `<sea_state>` (WMO code 0–9) sets a
+  realistic sea, with an explicit manual mode (`<period>` + `<gain>`) for
+  fine control.
+- **R5 — Runtime reconfiguration.** Wave parameters are changeable at runtime via
+  a transport service, without restarting the simulation.
+- **R6 — Determinism.** Given the same parameters and seed, the FFT field is
+  reproducible run-to-run (and across the server/GUI split).
+- **R7 — Runnable out of the box.** `ros2 launch vrx_bringup simulation.launch.xml`
+  brings up a moving ocean with no extra arguments.
+
+### Non-functional
+
+- **N1 — Engine-agnostic core and renderer.** Neither the core nor the renderer
+  may build-depend on any concrete engine; adding an engine must not modify them.
+- **N2 — Thread safety in the GUI.** The renderer runs across the ECM thread and
+  the render thread (and gz-sim's GuiRunner double-loads GUI systems); the wave
+  engine it drives must never be raced.
+- **N3 — Engine encapsulation.** Consumers query the field through a stable,
+  null-safe API and never include a concrete engine's headers.
+- **N4 — Render-engine isolation.** Ogre Next symbols must not leak into the
+  WaterVisual plugin's link map (they break gz-rendering's own engine loader).
+- **N5 — Seamless tiling.** The rendered surface tiles across its periodic domain
+  with no visible seams.
+- **N6 — House style + tests.** Gazebo code conventions throughout, with unit
+  tests covering each package.
+
+---
+
+## 2. Architecture overview
+
+Three decoupled layers communicate **only** through one ECM component,
+`components::Wavefield`, attached to the world entity. The component carries the
+**recipe** (algorithm token + parameters + a generation counter) and, on the
+server, a live `shared_ptr<IWaveField>`. Only the recipe is replicated to the
+GUI; each process/consumer rebuilds its own engine from it.
+
+```
+            ┌──────────────────────── server process ─────────────────────────┐
+   SDF ───> gz-sim-waves-<engine>-system        (a WavesSystemBase subclass)    │
+            │   • parses <wave>, reads world <gravity>                          │
+            │   • builds engine via MakeEngine()  ─────────┐                    │
+            │   • advertises .../wave/set_parameters        v                   │
+            │                                  components::Wavefield            │
+            │                                  { algorithm, params,             │
+            │                                    generation, updateRate,        │
+            │                                    shared_ptr<IWaveField> }        │
+            │            ┌──────────────────────────┴───────────────┐          │
+            │     WaveBuoyancy (consumer)                  state replication     │
+            │     via Eval free functions                          │           │
+            └───────────────────────────────────────────────────────┼──────────┘
+                                                                     v  (recipe only;
+            ┌──────────────────────── GUI process ───────────────────┴──────────┐
+            │  gz-sim-waves-<engine>-gui  → RegisterWaveEngineFactory(token,fn)   │
+            │  WaterVisual                                                        │
+            │    └─ CreateWaveSimulation(algorithm, params) → private IWaveField  │
+            │         └─ Field() → HeightMapTexture                               │
+            │              └─ C-ABI → libwaves-ogre2-bridge.so → Ogre Next GPU    │
+            └─────────────────────────────────────────────────────────────────────┘
+```
+
+**Data flow.** A source system *produces* the component; consumers (buoyancy,
+the visual) *read* it. The engine pointer is process-local: it is **never
+serialized** — replication carries the recipe, and each consumer reconstructs
+its engine through the registry. This is what keeps the core and the renderer
+engine-agnostic (N1, N3).
+
+---
+
+## 3. The core contract (`gz_waves`)
+
+### 3.1 `IWaveField` — the backend interface
+
+`include/gz/sim/waves/WaveSimulation.hh`. A concrete engine implements:
+
+| Method | Purpose |
+|--------|---------|
+| `double Elevation(double _x, double _y, double _t) const` | Surface elevation η [m] above still water. |
+| `gz::math::Vector3d ParticleVelocity(double _x, double _y, double _t) const` | Water-particle velocity [m/s] (drag hydrodynamics). |
+| `gz::math::Vector3d Normal(double _x, double _y, double _t) const` | Outward unit surface normal. |
+| `double Jacobian(double _x, double _y, double _t) const` | Horizontal-displacement Jacobian; low values ⇒ folding/whitecaps. |
+| `void SetParameters(const WaveParameters &_params)` | (Re)build all internal state from the recipe. |
+| `void Update(double _simTime)` | Advance time-dependent state (no-op default for stateless backends). |
+| `std::string_view Kind() const` | Backend token, e.g. `"gerstner"`, `"fft"`. |
+| `std::optional<TileSize> Bounds() const` | Periodic extent (grid backends); `nullopt` for unbounded analytic ones. |
+| `const WaveField2D *Field() const` | The renderable grid (see below); `nullptr` if the backend has none. |
+
+**`WaveField2D` — the rendering contract.** A POD view the renderer consumes
+without knowing the backend:
+
+```cpp
+struct WaveField2D {
+  std::size_t   n{0};        // grid resolution N (N×N)
+  double        tile{0.0};   // tile extent [m]; cell spacing = tile / N
+  const double *dz{nullptr}; // vertical displacement η [m]  (required)
+  const double *dx{nullptr}; // horizontal chop x [m]        (null ⇒ 0)
+  const double *dy{nullptr}; // horizontal chop y [m]        (null ⇒ 0)
+  const double *foam{nullptr}; // folding metric: 1 flat, <1 folding (null ⇒ none)
+};
+```
+
+Arrays are **column-major N×N**, periodic over `tile`, owned by the engine, and
+valid until the next `SetParameters`; `Update` refreshes their contents in place.
+`TileSize` is `{double x, double y}` (a centred, periodic tile).
+
+### 3.2 Engine registry — token → factory
+
+```cpp
+using WaveEngineFactory = std::function<std::shared_ptr<IWaveField>()>;
+void RegisterWaveEngineFactory(const std::string &_token, WaveEngineFactory _factory);
+std::shared_ptr<IWaveField> CreateWaveSimulation(
+    const std::string &_algorithm, const WaveParameters &_params);
+```
+
+A process-wide, mutex-guarded map. `CreateWaveSimulation` looks up `_algorithm`,
+builds a fresh engine, calls `SetParameters(_params)`, and returns it — or
+returns `nullptr` (with a logged error) for an unknown token or a null-returning
+factory. This indirection is what lets a consumer build an engine it doesn't
+link against (the renderer's whole premise).
+
+### 3.3 `WaveParameters` — the recipe
+
+`include/gz/sim/waves/Wavefield.hh`. One struct shared by all engines; each
+engine reads the subset it understands.
+
+*Shared:* `model{"PMS"}`, `number{3}`, `period{5.0}`, `direction{0.0}`,
+`angle{0.4}`, `scale{1.1}`, `steepness{0.0}`, `phase{0.0}`, `tau{2.0}`,
+`gain{1.0}`, `gravity{9.8}` (populated from world `<gravity>`), `seaState{-1}`.
+*Gerstner-only:* `amplitude{0.0}` (CWR model).
+*FFT-only:* `tileSize{200.0}`, `gridSize{128}`, `seed{0}`, `choppiness{-1.0}`,
+`spectrum{"tma"}`, `spreading{"hasselmann"}`, `dispersion{"capillary"}`,
+`depth{100.0}`, `fetch{300.0}`, `swell{0.0}`, `troughDamping{0.0}`, and the
+band-pass filter set (`filterMinWavelength`, `filterMaxWavelength`,
+`filterSoftWidth`, `filterMin{0.0}`, `filterInvert{false}`).
+
+### 3.4 `Wavefield` ECM component
+
+`components::Wavefield` wraps `waves::WavefieldData`:
+
+```cpp
+struct WavefieldData {
+  std::string                 algorithm{"gerstner"}; // engine token
+  WaveParameters              params;                // the recipe
+  std::shared_ptr<IWaveField> simulation;            // the live engine (process-local)
+  std::uint64_t               generation{0};         // bumped on every reconfigure
+  double                      updateRate{30.0};      // server Update() throttle [Hz]
+};
+```
+
+Serialization writes only `algorithm`, `generation`, every `params` field, and
+`updateRate`; `operator>>` leaves `simulation == nullptr`. **Consequence:** a
+replicated copy is recipe-only — consumers rebuild the engine via
+`CreateWaveSimulation`, and compare `generation` to cheaply detect changes.
+
+### 3.5 `Eval` facade — null-safe queries
+
+`include/gz/sim/waves/Eval.hh`. Free functions consumers use **instead of**
+touching `IWaveField`, so the engine type stays opaque (N3):
+
+- `Advance(WavefieldData&, double _t)` — drives `Update` if an engine is present.
+- `SurfaceElevation`, `ParticleVelocity`, `Normal`, `Jacobian`,
+  `FoamMask(..., _threshold = 0.6)` — each takes `(const WavefieldData&, _x, _y, _t)`.
+
+When `simulation` is null they return **still-water** defaults (elevation 0,
+velocity 0, normal +Z, Jacobian 1, foam 0), so a consumer that runs before the
+field exists degrades gracefully.
+
+### 3.6 Sea-state helpers
+
+`SeaStateSpec { significantWaveHeight, peakPeriod, windSpeed }`,
+`SeaStateFromCode(int _code, SeaStateSpec &_out, double _g)`,
+`WaveParameters WithSeaState(const WaveParameters &_p)`, and
+`StartupRamp(double _t, double _tau)` ( `1 - exp(-t/τ)`, or 1 when `τ ≤ 0`).
+
+**`<sea_state>` precedence (R4):** when `seaState ≥ 0`, `WithSeaState` overrides
+`period` (← peak period) and `gain` (← 1.0, physical Hs); `0` is flat water;
+`-1` (default/omitted) means manual via `<period>` + `<gain>`. Every other knob
+is independent and applies in both modes.
+
+### 3.7 `WavesSystemBase` — the source-plugin base
+
+`include/gz/sim/systems/WavesSystemBase.hh`. A `System` +
+`ISystemConfigure`/`ISystemPreUpdate`/`ISystemReset` that does all the
+producer plumbing so each engine's plugin is tiny. Subclasses override two
+protected virtuals:
+
+```cpp
+protected: virtual std::string EngineToken() const = 0;                 // "fft", "gerstner", …
+protected: virtual std::shared_ptr<waves::IWaveField>
+             MakeEngine(const waves::WaveParameters &_params) const = 0; // build + SetParameters
+```
+
+The base: parses `<update_rate>` + the `<wave>` block, reads world `<gravity>`,
+builds the engine, writes the `Wavefield` component (with `generation = 1`), and
+advertises **`/world/<name>/wave/set_parameters`** (a `gz.msgs.Param` →
+`gz.msgs.Boolean` service). `PreUpdate` drains queued parameter updates
+(bumping `generation`), re-points the engine if an ECM deserialize cleared it,
+and throttles `Update()` to `updateRate`. The service applies on the ECM thread
+(updates are queued from the transport thread), so runtime reconfiguration (R5)
+is race-free.
+
+**One parameter table, four uses.** A single `GZ_WAVES_PARAM_TABLE` (in
+`Wavefield.hh`) lists every `WaveParameters` field once and drives all four
+sites that must agree: the struct defaults, the serialization order, the SDF
+`<wave>` parsing, and the `set_parameters` service keys. Adding a parameter is a
+one-line table edit — no risk of the four falling out of sync. (`gravity` is the
+deliberate exception: it is sourced from the world's `<gravity>`, not SDF or the
+service, and streamed explicitly so it still round-trips.)
+
+*Tests:* `wave_core_test.cc` covers Eval, the registry, `Wavefield`
+serialization, the sea-state helpers, and the full Configure/PreUpdate/Reset +
+`set_parameters` path through a real `EntityComponentManager`, using a stub
+engine (no engine dependency, no cycle).
+
+---
+
+## 4. Gerstner engine (`gz_waves_provider_gerstner`)
+
+- **Engine** `GerstnerWaveSimulation` (`MakeGerstnerWaveField()` factory): a
+  closed-form sum of up to N Gerstner components; deterministic; spatially
+  unbounded (`Bounds()` ⇒ `nullopt`). It also samples itself onto an N×N tile
+  each `Update` and exposes it via `Field()` so it renders through the same path
+  as the FFT engine.
+- **Seamless tiling (N5).** The render tile is sized to the longest component
+  wavelength, then **every component's wave vector is quantized to the tile
+  lattice** (`k` snapped to integer multiples of `k0 = 2π/tile`), so each
+  component completes a whole number of cycles over the tile and the surface
+  tiles with no edge seams. `ω` and the steepness clamp are recomputed from the
+  snapped wavenumber.
+- **Source system** `gz-sim-waves-gerstner-system` (`GerstnerWaves : WavesSystemBase`):
+  `EngineToken()` ⇒ `"gerstner"`, `MakeEngine()` ⇒ builds + configures the engine.
+  Its doc block documents the Gerstner SDF surface: `<model>` (PMS/CWR),
+  `<number>`, `<period>`, `<amplitude>` (CWR), `<direction>`, `<angle>`,
+  `<scale>`, `<steepness>`, `<phase>`, `<tau>`, `<gain>`, `<sea_state>`.
+- **GUI registrar** `gz-sim-waves-gerstner-gui` (see §6.2).
+- **Robustness.** A non-positive `<period>` is rejected (logs via `gzerr` and
+  leaves the field flat) rather than dividing by zero into `NaN`/`Inf` through
+  `2π/period` and the `1/ω⁵` spectrum tail.
+- *Tests:* `gerstner_test.cc` covers elevation, normals, particle velocity,
+  dispersion, sea-state scaling, serialization round-trip, the ramp, and the
+  period guard.
+
+---
+
+## 5. Rendering (`gz_waves_rendering`)
+
+### 5.1 `WaterVisual` — the renderer
+
+A `System` + `ISystemConfigure`/`ISystemPreUpdate`, loaded as
+`gz-sim-water-visual-system` (class `gz::sim::systems::WaterVisual`). It reads
+the `Wavefield` component from the world entity; if the component hasn't
+replicated yet it does a one-shot **pull-on-ready** request to
+`/world/<name>/state` and seeds the recipe from that snapshot, so a GUI that
+joins late still gets the field.
+
+**Thread-safety design (N2) — the central decision.** `WaterVisual` builds and
+**owns a private** engine via `CreateWaveSimulation(data->algorithm, data->params)`;
+it deliberately does **not** alias the component's `simulation`. From the code:
+
+> *"We deliberately do NOT alias `data.simulation`: that is a process-global
+> engine shared by every consumer (gz-sim's GuiRunner loads this system twice,
+> and the deserialize path drives the same instance on another thread). The
+> per-instance `mutex_` below cannot serialise a shared instance, so sharing it
+> races `OnSceneUpdate`'s `Update()`/`Field()` on the render thread against this
+> thread — the cause of the intermittent `PreUpdate` segfault. A private
+> instance is touched only by `PreUpdate` + `OnSceneUpdate`, both under
+> `mutex_`, so it is fully serialised."*
+
+It rebuilds the private engine when `data.generation` changes, and each render
+frame pulls the grid via `Field()` and uploads it. (Because the engine produces
+column-major Eigen data while the Ogre bridge wants row-major, `HeightMapTexture`
+reflows each grid once on upload.)
+
+### 5.2 Provider-agnostic, via per-engine GUI registrars
+
+`gz_waves_rendering` depends on **`gz_waves` only** — no engine `find_package`,
+no engine link, no engine `<depend>` (N1). The factory registration that lets
+`WaterVisual` rebuild an engine in the GUI lives in **per-engine GUI plugins**
+shipped by the provider packages. The `water_surface` model loads them in the
+**same `<visual>`** as `WaterVisual`:
+
+```xml
+<plugin filename="gz-sim-water-visual-system" name="gz::sim::systems::WaterVisual"> … </plugin>
+<plugin filename="gz-sim-waves-gerstner-gui"  name="gz::sim::systems::GerstnerWavesGui"/>
+<plugin filename="gz-sim-waves-fft-gui"       name="gz::sim::systems::FftWavesGui"/>
+```
+
+They **must** sit at the `<visual>` level: gz-sim's GuiRunner loads SDF system
+plugins only at the visual level — model/link-level plugins never reach the GUI
+process (loading them there yields a flat/white ocean because the factory is
+never registered). One registrar per engine the world might select; adding an
+engine never edits the rendering package.
+
+### 5.3 Ogre2 C-ABI bridge (N4)
+
+All Ogre Next access is isolated in a **separate** `libwaves-ogre2-bridge.so`,
+loaded on demand via `dlopen`. Linking it directly would put
+`libgz-rendering-ogre2.so` in WaterVisual's `DT_NEEDED`, which collides with
+gz-rendering's own engine-plugin loader (same SONAME already in process ⇒ the
+engine never initialises and the GUI shows a default-material plane). The seam
+is a small C-ABI: `waves_ogre2_heightmap_create` / `_upload` / `_ready` /
+`_set_tex_filtering` / `_destroy`. `HeightMapTexture` (a pimpl) calls it; the
+bridge packs (η, Dx, Dy, foam) into an `RGBA32F` GPU texture bound to the
+material's `heightMap` sampler.
+
+### 5.4 Targets, model, world
+
+CMake builds `waves-ogre2-bridge` and `gz-sim-water-visual-system` (the latter
+links `${CMAKE_DL_LIBS}`, not the bridge), and probes the Ogre Next header path
+to match the resolved `gz-rendering::ogre2`. The `water_surface` model ships the
+mesh (`water.dae`), the shaders (`fft_water_vs_330.glsl`, `water_fs_330.glsl`),
+and the normal/skybox textures. `vrx_gazebo/worlds/open_water.sdf` is wired as a
+self-contained ocean so `ros2 launch vrx_bringup simulation.launch.xml` renders
+moving waves with no extra setup (R3, R7).
+
+---
+
+## 6. FFT engine (`gz_waves_provider_fft`)
+
+### 6.1 Engine + system
+
+- **Engine** `FFTWaveSimulation` (`MakeFFTWaveField()`): an inverse-FFT of an
+  empirically-modelled directional spectrum from the external **EncinoWaves**
+  library (Horvath 2015, Apache-2.0). `Update` propagates the spectrum and runs
+  the IFFT once per tick (cached by time, so multiple consumers share one FFT);
+  output is calibrated so the RMS matches the Pierson–Moskowitz `Hs`. Periodic
+  over `tileSize`; `Elevation` bilinearly samples the grid; `Field()` exposes
+  height + x/y displacement + a folding (foam) metric.
+- **Particle velocity** is computed by **time finite-difference**: EncinoWaves
+  exposes no analytic velocity field, so each `Update` also propagates a scratch
+  state a small `dt` ahead and differences the displacement grids
+  (∂Dx/∂t, ∂Dy/∂t, ∂η/∂t), which `ParticleVelocity` then bilinearly samples.
+- **Selectable spectral models** (SDF string → Encino enum): spectrum
+  `pms`/`pm`, `jonswap`, `tma`; spreading `poscos2`/`poscossqr`, `mitsuyasu`,
+  `hasselmann`, `donelanbanner`/`donelan`; dispersion `deep`,
+  `finite`/`finite_depth`, `capillary`. A smooth band-pass (or notch) filter is
+  enabled by the `<filter_*>` wavelength parameters (see §8).
+- **Source system** `gz-sim-waves-fft-system` (`FftWaves : WavesSystemBase`):
+  `EngineToken()` ⇒ `"fft"`. Its doc block carries the full FFT SDF table and the
+  `<sea_state>` precedence section (see §3.6 / §8). Note `<direction>` is parsed
+  but not yet applied (EncinoWaves assumes wind along +X).
+- *Tests:* `fft_test.cc` covers finiteness/bounds, ramp-up, foam from the
+  Jacobian, band-pass reshaping, spectrum selection, time evolution, `Field()`
+  views, determinism vs. seed, periodicity, unit normals, particle velocity, and
+  sea-state Hs.
+
+### 6.2 GUI registrar pattern (both engines)
+
+A GUI registrar (`gz-sim-waves-<engine>-gui`) is a **bare `System` with no
+`ISystem` interface and no SDF**. It registers its factory from a **file-scope
+static initializer** that runs the moment the GUI `dlopen`s the library:
+
+```cpp
+namespace {
+const bool kFftGuiRegistered = []{
+  gz::sim::waves::RegisterWaveEngineFactory("fft", &gz::sim::waves::MakeFFTWaveField);
+  return true;
+}();
+}  // namespace
+GZ_ADD_PLUGIN(gz::sim::systems::FftWavesGui, gz::sim::System)
+```
+
+The empty `System` body exists only so gz-sim has a plugin to load (which
+triggers the `dlopen`). Carrying no `Configure`/SDF deliberately avoids gz-sim's
+empty-plugin SDF re-parse warning.
+
+### 6.3 EncinoWaves dependency
+
+`gz_waves_provider_fft` does `find_package(EncinoWaves REQUIRED)` and links
+`EncinoWaves::EncinoWaves` (pulling in Eigen3 / TBB / Imath). EncinoWaves is an
+external **system** package (installed from `HonuRobotics/encinowaves`, not
+vendored); it has no rosdep key, so `package.xml` lists its transitive system
+deps (`libtbb-dev`, `libimath-dev`) rather than EncinoWaves itself.
+
+---
+
+## 7. Cross-cutting design decisions (rationale)
+
+| Decision | Why |
+|----------|-----|
+| **One ECM component as the only coupling.** | Producers and consumers never link each other; the field is shared and consistent (R2, N1). |
+| **Recipe-only serialization; engine never replicated.** | The engine is process-local state; replicating a recipe + rebuilding via the registry keeps consumers engine-agnostic and decouples server/GUI (N1, N3, R6). |
+| **Token → factory registry.** | Lets the renderer build an engine it does not link; new engines self-register (N1). |
+| **Per-engine GUI registrar at the `<visual>` level.** | The renderer stays core-only; the engine dependency lives in the registrar. Visual-level is the only level the GuiRunner loads systems at. |
+| **WaterVisual owns a private engine.** | The component's engine is shared/multi-threaded in the GUI; a private, mutex-guarded instance removes the render-vs-ECM race (N2). |
+| **Ogre behind a dlopen'd C-ABI.** | Keeps `libgz-rendering-ogre2` out of WaterVisual's `DT_NEEDED` so gz-rendering's own engine loader still works (N4). |
+| **`Eval` free functions, null-safe.** | Consumers never touch `IWaveField`; pre-field ticks degrade to still water (N3). |
+| **Gerstner wave-vector quantization.** | Makes every component periodic over the tile ⇒ seamless tiling (N5). |
+| **`generation` counter.** | Cheap change detection so consumers rebuild only on actual reconfiguration. |
+| **`WavesSystemBase` holds the plumbing.** | Each engine's source plugin is two small overrides; the SDF parse + service + throttle live once. |
+
+---
+
+## 8. Configuration reference
+
+### Selecting the engine
+
+In the world, load **one** source system and the matching GUI registrar:
+
+```xml
+<!-- server: pick the engine -->
+<plugin filename="gz-sim-waves-fft-system" name="gz::sim::systems::FftWaves">
+  <update_rate>30</update_rate>
+  <wave>
+    <sea_state>5</sea_state>   <!-- one-knob; or comment it for manual mode -->
+  </wave>
+</plugin>
+```
+
+The `water_surface` model already loads both GUI registrars, so either engine
+renders. `open_water.sdf` ships the alternative engine as a commented `<plugin>`
+block — swap by commenting one and uncommenting the other.
+
+### Shared `<wave>` parameters (both engines)
+
+`<sea_state>` (int 0–9, default −1/off — overrides `<period>`+`<gain>`),
+`<period>` [s], `<gain>`, `<direction>` [rad], `<tau>` [s], plus `<update_rate>`
+[Hz] at plugin level. (Gerstner additionally: `<model>`, `<number>`,
+`<amplitude>`, `<angle>`, `<scale>`, `<steepness>`, `<phase>`.)
+
+### FFT-specific `<wave>` parameters
+
+| Tag | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `<tile_size>` | double [m] | 200.0 | Periodic tile extent per axis. |
+| `<grid_size>` | uint | 128 | Grid samples/axis (power of two). |
+| `<seed>` | uint | 0 | Spectrum RNG seed. |
+| `<choppiness>` | double | −1.0 | Tessendorf horizontal-displacement multiplier (~[−2, 0]). |
+| `<spectrum>` | string | `tma` | `pms`, `jonswap`, `tma`. |
+| `<spreading>` | string | `hasselmann` | `poscos2`, `mitsuyasu`, `hasselmann`, `donelanbanner`. |
+| `<dispersion>` | string | `capillary` | `deep`, `finite`, `capillary`. |
+| `<depth>` | double [m] | 100 | Dispersion input. |
+| `<fetch>` | double [km] | 300 | Spectrum input. |
+| `<swell>` | double | 0 | Swell elongation. |
+| `<trough_damping>` | double [0,1] | 0 | Breaking-wave trough damping. |
+| `<filter_min_wl>` / `<filter_max_wl>` / `<filter_soft>` / `<filter_min>` / `<filter_invert>` | — | 0 / 0 / 0 / 0 / false | Band-pass (or notch) on wavelength. |
+
+### Runtime reconfiguration
+
+Call `/world/<name>/wave/set_parameters` (`gz.msgs.Param` → `gz.msgs.Boolean`)
+with any of the parameter keys (snake_case for multi-word). The change bumps
+`generation`; consumers (incl. WaterVisual) rebuild automatically.
+
+---
+
+## 9. How to contribute a new wave model (engine)
+
+A "new wave rendering model" is a new **wave engine** (an `IWaveField`
+backend). The renderer, the buoyancy consumer, and the core need **zero
+changes** — you add one self-contained provider package, mirroring
+`gz_waves_provider_gerstner` (the deliberately-minimal template). The same
+package contributes its server source plugin, its GUI registrar, and its world
+wiring.
+
+### Step 1 — Create the package
+
+```
+gz_waves_provider_<name>/
+  CMakeLists.txt
+  package.xml
+  include/gz/sim/waves/<Name>WaveSimulation.hh
+  src/<Name>WaveSimulation.cc     # the IWaveField engine + factory
+  src/<Name>WavesSystem.cc        # gz-sim-waves-<name>-system  (server source)
+  src/<Name>WavesGui.cc           # gz-sim-waves-<name>-gui      (GUI registrar)
+  test/<name>_test.cc
+```
+
+Use the Honu Robotics Apache-2.0 header on every file.
+
+### Step 2 — Implement `IWaveField` + a factory
+
+Subclass `IWaveField` (`#include "gz/sim/waves/WaveSimulation.hh"`) and implement
+`Elevation`, `ParticleVelocity`, `Normal`, `Jacobian`, `SetParameters`, `Kind()`
+(return your token), and — to be renderable — `Update` + `Field()`. To render,
+`SetParameters` should allocate column-major N×N buffers and bind them into a
+`WaveField2D field_`; `Update` fills them for the given time; `Field()` returns
+`&field_`. Read whatever subset of `WaveParameters` you need (apply
+`WithSeaState`/`StartupRamp` for consistent sea-state and ramp behavior). Export
+the factory:
+
+```cpp
+std::shared_ptr<IWaveField> Make<Name>WaveField();   // default-constructed engine
+```
+
+### Step 3 — Source system (server)
+
+```cpp
+#include "gz/sim/systems/WavesSystemBase.hh"
+#include "gz/sim/waves/<Name>WaveSimulation.hh"
+#include <gz/plugin/Register.hh>
+
+namespace gz::sim::systems {
+class <Name>Waves : public WavesSystemBase {
+  // Documentation inherited
+  protected: std::string EngineToken() const override { return "<name>"; }
+  // Documentation inherited
+  protected: std::shared_ptr<waves::IWaveField>
+    MakeEngine(const waves::WaveParameters &_params) const override {
+      auto e = waves::Make<Name>WaveField();
+      e->SetParameters(_params);
+      return e;
+    }
+};
+}  // namespace gz::sim::systems
+GZ_ADD_PLUGIN(gz::sim::systems::<Name>Waves, gz::sim::System,
+              gz::sim::systems::<Name>Waves::ISystemConfigure,
+              gz::sim::systems::<Name>Waves::ISystemPreUpdate,
+              gz::sim::systems::<Name>Waves::ISystemReset)
+GZ_ADD_PLUGIN_ALIAS(gz::sim::systems::<Name>Waves, "gz::sim::systems::<Name>Waves")
+```
+
+Document your SDF parameter surface in the class doc comment (and the
+`<sea_state>` precedence note), the way the FFT/Gerstner systems do.
+
+### Step 4 — GUI registrar
+
+A bare `System`, **no** `ISystem`, **no** SDF; register the factory from a
+file-scope static initializer (so it runs at `dlopen`):
+
+```cpp
+#include "gz/sim/System.hh"
+#include "gz/sim/waves/<Name>WaveSimulation.hh"
+#include "gz/sim/waves/WaveSimulation.hh"
+#include <gz/plugin/Register.hh>
+
+namespace gz::sim::systems { class <Name>WavesGui : public System {}; }
+namespace {
+const bool k<Name>GuiRegistered = []{
+  gz::sim::waves::RegisterWaveEngineFactory(
+      "<name>", &gz::sim::waves::Make<Name>WaveField);
+  return true;
+}();
+}  // namespace
+GZ_ADD_PLUGIN(gz::sim::systems::<Name>WavesGui, gz::sim::System)
+GZ_ADD_PLUGIN_ALIAS(gz::sim::systems::<Name>WavesGui, "gz::sim::systems::<Name>WavesGui")
+```
+
+### Step 5 — CMake + package.xml (mirror Gerstner)
+
+Build **three** libraries — the engine (exported, no `GZ_ADD_PLUGIN`), the
+`-system` plugin, and the `-gui` plugin — each linking
+`gz_waves::gz_waves gz-waves-provider-<name> gz-sim::core gz-plugin::register`
+(the engine links its own math deps PUBLIC). `package.xml` depends on
+`gz_waves`, `gz_sim_vendor`, `gz_plugin_vendor` (+ any math/3rd-party deps your
+engine needs). See `gz_waves_provider_gerstner/CMakeLists.txt` verbatim as the
+template — copy it and rename.
+
+### Step 6 — Tests
+
+Add `<name>_test.cc`: link `gz_waves::gz_waves` + your engine library, and check
+the registry route (`CreateWaveSimulation("<name>", …)` → `Kind() == "<name>"`),
+`SetParameters`/sampling, serialization round-trip, and any engine-specific math.
+
+### Step 7 — Wire it into a world
+
+Add the GUI registrar next to `WaterVisual` in the `water_surface` model's
+`<visual>` (so the renderer can rebuild it):
+
+```xml
+<plugin filename="gz-sim-waves-<name>-gui" name="gz::sim::systems::<Name>WavesGui"/>
+```
+
+Select it in the world by loading `gz-sim-waves-<name>-system` as the wave
+source. Done — `WaterVisual`, buoyancy, and the core are untouched.
+
+### Checklist
+
+- [ ] `IWaveField` fully implemented; `Field()` returns a valid column-major,
+      periodic grid (if renderable).
+- [ ] `Make<Name>WaveField()` exported; `Kind()`/`EngineToken()` agree on the token.
+- [ ] Three libraries build; engine carries **no** `GZ_ADD_PLUGIN`.
+- [ ] GUI registrar is interface-less + SDF-less (no re-parse warning).
+- [ ] GUI registrar added to the `water_surface` `<visual>`.
+- [ ] Tests pass; the engine renders in `gz sim -r` (waves move, seamless tiling).
+- [ ] Gazebo house style: `_`-prefixed parameters, `//////` separators before
+      each out-of-line definition/test, per-member access specifiers, Doxygen
+      `\brief`/`\param`/`\return`, Honu Robotics copyright header.
+
+---
+
+## 10. Build, run, test
+
+```bash
+# Build (EncinoWaves must be installed and on CMAKE_PREFIX_PATH for the FFT package)
+cd ~/vrx_ws
+colcon build --merge-install
+
+# Run (FFT or Gerstner per open_water.sdf)
+source install/setup.bash
+ros2 launch vrx_bringup simulation.launch.xml
+#   or directly:  gz sim -r src/vrx/vrx_gazebo/worlds/open_water.sdf
+
+# Tests
+./build/gz_waves/wave_core_test
+./build/gz_waves_provider_gerstner/gerstner_test
+./build/gz_waves_provider_fft/fft_test
+```
+
+---
+
+## 11. Status notes
+
+- `<direction>` is parsed by the FFT system but not yet applied (EncinoWaves
+  assumes wind along +X).
+- Foam/whitecaps are effectively **FFT-only**. The renderer derives foam from
+  the engine's folding (Jacobian) metric; the analytic Gerstner engine's
+  Jacobian barely leaves 1.0, so it carries no usable folding signal and the
+  shader's foam pass is skipped for it.
+- The wave-coupled `test_buoy` demo vessel and the `WaveBuoyancy` consumer ship
+  with `gz_waves_buoyancy`, which also adds the buoy to `open_water.sdf`.

--- a/WAVES_DESIGN.md
+++ b/WAVES_DESIGN.md
@@ -1,22 +1,68 @@
 # VRX Wave Simulation — Design & Contributor Reference
 
-This document is the single reference for the VRX wave-simulation stack. It
-captures the **requirements**, the **architecture and design decisions**, the
-**per-package implementation details**, and a step-by-step **guide to
-contributing a new wave engine** (a new "wave rendering model").
+This document is the single reference for the VRX wave simulation packages
+(`gz_waves*`): the layer that connects a pluggable wave field engine to Gazebo
+physics and rendering. It captures the **requirements**, the **architecture and
+design decisions**, the **per-package implementation details**, and a
+step-by-step **guide to contributing a new wave field engine**.
 
-The stack is made of these packages:
+## Terminology
+
+The wave literature, and our own earlier notes, use several near-synonyms
+loosely ("backend", "wave model", "wave rendering model", "generator"). This
+document fixes the following vocabulary and uses it consistently:
+
+| Term | Meaning |
+|------|---------|
+| **wave field** | The *output*: the water-surface state (elevation η, particle velocity, surface normal, and the folding/Jacobian metric) over space and time. It is what consumers read; it is **not** the thing that produces it. |
+| **wave field engine (WFE)** | A concrete `IWaveField` implementation that *produces* a wave field (e.g. the analytic Gerstner engine, the spectral FFT engine). Supersedes the looser "backend" and "wave (rendering) model"; "rendering model" especially misleads, since an engine drives physics too, not just the visual. |
+| **provider** | The package that ships a WFE plus its server/GUI plumbing (`gz_waves_provider_*`). |
+| **consumer** | Anything that *reads* the wave field through the core API (vessel buoyancy/hydrodynamics, the renderer, future sensors). `WaveBuoyancy` is the illustrative consumer used throughout. |
+
+**What defines a WFE.** A wave field engine synthesizes the surface as a sum of
+components, η(x, t) = Σ aₙ cos(kₙ·x − ωₙ t + φₙ). Per the VRX waves roadmap
+(`vrx4_waves_roadmap.md`), the method is defined by **five independent choices**,
+three of them statistical:
+
+| Choice | Determines | Options |
+|--------|------------|---------|
+| **Inverse transform** | how the spectrum becomes the field | direct summation (sum of cosines) vs. FFT / IFFT |
+| **Wave kinematics** | the shape of each component | linear / Airy (vertical only) vs. Gerstner / trochoidal (adds horizontal chop) |
+| **Amplitude sampling** *(statistical)* | the amplitudes aₙ | deterministic vs. random (Rayleigh / Gaussian) |
+| **Frequency sampling** *(statistical)* | the frequencies ωₙ | deterministic (evenly spaced) vs. random (drawn within bands) |
+| **Phase sampling** *(statistical)* | the phases φₙ | deterministic vs. random (uniform) |
+
+The choices are independent, though the roadmap notes only a handful of
+combinations are physically sensible (e.g. the fully deterministic legacy sea, or
+the random amplitude Gaussian sea that EncinoWaves draws). The engines shipped
+today are two points in this space, and their package names are a **pragmatic
+shorthand for each engine's dominant distinguishing choice**, not a claim that the
+choices are coupled:
+
+- `gz_waves_provider_gerstner`: direct summation, Gerstner kinematics, fully
+  deterministic amplitude, frequency, and phase. Implemented in this repository.
+- `gz_waves_provider_fft`: IFFT, Gerstner chop, random amplitude, evenly spaced
+  frequency, random phase (the Gaussian sea). The transform, spectra, sampling,
+  and kinematics all live in the **external EncinoWaves library**; the VRX package
+  is a thin wrapper (§6).
+
+The `IWaveField` contract itself is **agnostic** to all five choices: a new engine
+(in this repo or wrapping an external library) may implement any sensible
+combination. (Whether the package *names* should move from this shorthand toward
+the roadmap's design-choice vocabulary is an open design question.)
+
+## Packages
+
+All `gz_waves*` packages live in **this repository** (vrx). **EncinoWaves is the
+one external dependency**: its own repository, installed separately, **not**
+vendored.
 
 | Package | Role |
 |---------|------|
 | `gz_waves` | Engine-agnostic **core**: the `IWaveField` contract, the engine registry, the `Wavefield` ECM component, the `Eval` query facade, and `WavesSystemBase` (the source-plugin base). |
-| `gz_waves_provider_gerstner` | Analytic **Gerstner** engine + source system + GUI registrar. |
-| `gz_waves_provider_fft` | **FFT** spectral engine (EncinoWaves) + source system + GUI registrar. |
-| `gz_waves_rendering` | Provider-agnostic **WaterVisual** renderer + the Ogre2 C-ABI bridge + the `water_surface` model; wires a runnable demo world. |
-
-These are the packages this document covers. The wave field is designed to drive
-any number of **consumers** (vessel buoyancy/hydrodynamics, the renderer, future
-sensors); `WaveBuoyancy` is used throughout as the illustrative consumer.
+| `gz_waves_provider_gerstner` | Analytic **Gerstner** WFE + source system + GUI registrar. |
+| `gz_waves_provider_fft` | Spectral **FFT** WFE (wraps EncinoWaves) + source system + GUI registrar. |
+| `gz_waves_rendering` | Engine-agnostic **WaterVisual** renderer + the Ogre2 C-ABI bridge + the `water_surface` model; wires a runnable demo world. |
 
 All new source files carry the **Honu Robotics** Apache-2.0 copyright header.
 
@@ -26,8 +72,8 @@ All new source files carry the **Honu Robotics** Apache-2.0 copyright header.
 
 ### Functional
 
-- **R1 — Multiple selectable wave models.** Support more than one wave-field
-  backend (analytic Gerstner, spectral FFT) chosen per world, with room to add
+- **R1 — Multiple selectable wave field engines.** Support more than one WFE
+  (analytic Gerstner, spectral FFT) chosen per world, with room to add
   more without touching existing packages.
 - **R2 — One physical wave field, many consumers.** A single authoritative wave
   field drives every consumer — vessel buoyancy/hydrodynamics, the rendered
@@ -104,7 +150,7 @@ engine-agnostic (N1, N3).
 
 ## 3. The core contract (`gz_waves`)
 
-### 3.1 `IWaveField` — the backend interface
+### 3.1 `IWaveField` — the wave field engine interface
 
 `include/gz/sim/waves/WaveSimulation.hh`. A concrete engine implements:
 
@@ -115,13 +161,13 @@ engine-agnostic (N1, N3).
 | `gz::math::Vector3d Normal(double _x, double _y, double _t) const` | Outward unit surface normal. |
 | `double Jacobian(double _x, double _y, double _t) const` | Horizontal-displacement Jacobian; low values ⇒ folding/whitecaps. |
 | `void SetParameters(const WaveParameters &_params)` | (Re)build all internal state from the recipe. |
-| `void Update(double _simTime)` | Advance time-dependent state (no-op default for stateless backends). |
-| `std::string_view Kind() const` | Backend token, e.g. `"gerstner"`, `"fft"`. |
-| `std::optional<TileSize> Bounds() const` | Periodic extent (grid backends); `nullopt` for unbounded analytic ones. |
-| `const WaveField2D *Field() const` | The renderable grid (see below); `nullptr` if the backend has none. |
+| `void Update(double _simTime)` | Advance time-dependent state (no-op default for stateless engines). |
+| `std::string_view Kind() const` | Engine token, e.g. `"gerstner"`, `"fft"`. |
+| `std::optional<TileSize> Bounds() const` | Periodic extent (grid engines); `nullopt` for unbounded analytic ones. |
+| `const WaveField2D *Field() const` | The renderable grid (see below); `nullptr` if the engine has none. |
 
-**`WaveField2D` — the rendering contract.** A POD view the renderer consumes
-without knowing the backend:
+**`WaveField2D` — the rendering contract.** A Plain Old Data (POD) view the
+renderer consumes without knowing the engine:
 
 ```cpp
 struct WaveField2D {
@@ -306,7 +352,7 @@ frame pulls the grid via `Field()` and uploads it. (Because the engine produces
 column-major Eigen data while the Ogre bridge wants row-major, `HeightMapTexture`
 reflows each grid once on upload.)
 
-### 5.2 Provider-agnostic, via per-engine GUI registrars
+### 5.2 Engine-agnostic, via per-engine GUI registrars
 
 `gz_waves_rendering` depends on **`gz_waves` only** — no engine `find_package`,
 no engine link, no engine `<depend>` (N1). The factory registration that lets
@@ -354,6 +400,18 @@ moving waves with no extra setup (R3, R7).
 
 ### 6.1 Engine + system
 
+**VRX vs. EncinoWaves.** For the FFT engine the external **EncinoWaves** library
+owns the wave-field *generation* across all five WFE choices: the inverse
+transform (IFFT), the spectra/spreading/dispersion models, the random amplitude
+and uniform phase sampling (with an evenly spaced frequency grid), and the
+horizontal-displacement (Gerstner "chop") kinematics. VRX's `gz_waves_provider_fft` is a **thin wrapper**: it configures
+EncinoWaves from the `<wave>` recipe, samples the grid, computes particle
+velocity by finite difference (below), calibrates RMS to the target `Hs`, and
+exposes the result through `Field()`/`Elevation()`. The contrast with the
+in-repo Gerstner engine, whose kinematics live in VRX, is deliberate, and
+illustrates that the `IWaveField` boundary lets an engine externalize as much or
+as little of the generation as it likes.
+
 - **Engine** `FFTWaveSimulation` (`MakeFFTWaveField()`): an inverse-FFT of an
   empirically-modelled directional spectrum from the external **EncinoWaves**
   library (Horvath 2015, Apache-2.0). `Update` propagates the spectrum and runs
@@ -379,7 +437,7 @@ moving waves with no extra setup (R3, R7).
   views, determinism vs. seed, periodicity, unit normals, particle velocity, and
   sea-state Hs.
 
-### 6.2 GUI registrar pattern (both engines)
+### 6.2 GUI registrar pattern (per engine)
 
 A GUI registrar (`gz-sim-waves-<engine>-gui`) is a **bare `System` with no
 `ISystem` interface and no SDF**. It registers its factory from a **file-scope
@@ -442,11 +500,12 @@ In the world, load **one** source system and the matching GUI registrar:
 </plugin>
 ```
 
-The `water_surface` model already loads both GUI registrars, so either engine
-renders. `open_water.sdf` ships the alternative engine as a commented `<plugin>`
-block — swap by commenting one and uncommenting the other.
+The `water_surface` model already loads a GUI registrar for each engine, so
+whichever engine the world selects renders. `open_water.sdf` ships the
+alternative engines as commented `<plugin>` blocks — switch by commenting the
+active block and uncommenting the one you want.
 
-### Shared `<wave>` parameters (both engines)
+### Shared `<wave>` parameters (all engines)
 
 `<sea_state>` (int 0–9, default −1/off — overrides `<period>`+`<gain>`),
 `<period>` [s], `<gain>`, `<direction>` [rad], `<tau>` [s], plus `<update_rate>`
@@ -478,10 +537,10 @@ with any of the parameter keys (snake_case for multi-word). The change bumps
 
 ---
 
-## 9. How to contribute a new wave model (engine)
+## 9. How to contribute a new wave field engine
 
-A "new wave rendering model" is a new **wave engine** (an `IWaveField`
-backend). The renderer, the buoyancy consumer, and the core need **zero
+A new wave field engine is a fresh `IWaveField` implementation. The renderer,
+the buoyancy consumer, and the core need **zero
 changes** — you add one self-contained provider package, mirroring
 `gz_waves_provider_gerstner` (the deliberately-minimal template). The same
 package contributes its server source plugin, its GUI registrar, and its world

--- a/gz_waves/CMakeLists.txt
+++ b/gz_waves/CMakeLists.txt
@@ -20,7 +20,6 @@ find_package(gz_common_vendor REQUIRED)
 find_package(gz-common REQUIRED)
 find_package(gz_plugin_vendor REQUIRED)
 find_package(gz-plugin REQUIRED COMPONENTS register)
-find_package(Eigen3 REQUIRED)
 
 # --------------------------------------------------------------------------
 # Core wave library: the IWaveField interface, the WavesSystemBase plumbing, the
@@ -43,7 +42,7 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
     gz-sim::core
-    Eigen3::Eigen
+    gz-math::gz-math
   PRIVATE
     gz-common::gz-common
 )
@@ -77,7 +76,7 @@ ament_environment_hooks("hooks/hook.sh.in")
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_include_directories(include)
-ament_export_dependencies(gz_sim_vendor gz_math_vendor Eigen3)
+ament_export_dependencies(gz_sim_vendor gz_math_vendor)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/gz_waves/CMakeLists.txt
+++ b/gz_waves/CMakeLists.txt
@@ -1,0 +1,101 @@
+cmake_minimum_required(VERSION 3.16)
+project(gz_waves)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(gz_sim_vendor REQUIRED)
+find_package(gz-sim REQUIRED)
+find_package(gz_math_vendor REQUIRED)
+find_package(gz-math REQUIRED)
+find_package(gz_common_vendor REQUIRED)
+find_package(gz-common REQUIRED)
+find_package(gz_plugin_vendor REQUIRED)
+find_package(gz-plugin REQUIRED COMPONENTS register)
+find_package(Eigen3 REQUIRED)
+
+# --------------------------------------------------------------------------
+# Core wave library: the IWaveField interface, the WavesSystemBase plumbing, the
+# token -> factory registry (CreateWaveSimulation / RegisterWaveEngineFactory),
+# and the Wavefield component. It links NO concrete engine — engines are plain
+# libraries in their own packages, linked by the per-engine system plugins and
+# the water visual — so the core stays backend-agnostic.
+# --------------------------------------------------------------------------
+add_library(${PROJECT_NAME} SHARED
+  src/WaveSimulation.cc
+  src/components.cc
+  src/Eval.cc
+  src/systems/WavesSystemBase.cc
+)
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+    gz-sim::core
+    Eigen3::Eigen
+  PRIVATE
+    gz-common::gz-common
+)
+
+# The core ships only the wave-field contract. Everything else lives in its own
+# package: the engines (gz_waves_provider_{gerstner,fft}) as plain libraries each
+# paired with a gz-sim-waves-<engine>-system source plugin, and the consumers of
+# the field — buoyancy (gz_waves_buoyancy) and the water visual
+# (gz_waves_rendering). None is built here.
+
+# --------------------------------------------------------------------------
+# Headers and shared assets (shaders, textures, mesh).
+# --------------------------------------------------------------------------
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+# GZ_SIM_SYSTEM_PLUGIN_PATH hook so gz-sim finds the Waves / WaveBuoyancy
+# system plugins (and the dlopen'd provider libs) by filename in install/lib.
+ament_environment_hooks("hooks/hook.dsv.in")
+ament_environment_hooks("hooks/hook.sh.in")
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_include_directories(include)
+ament_export_dependencies(gz_sim_vendor gz_math_vendor Eigen3)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  # Disable Google-style linters; this code follows the Gazebo (Allman) style
+  # to match the upstream gz-sim source it will be merged into.
+  set(ament_cmake_cpplint_FOUND TRUE)
+  set(ament_cmake_uncrustify_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+
+  # The core can't link a *real* engine (dependency cycle), but a test can supply
+  # a stub IWaveField + stub WavesSystemBase and drive the whole contract — Eval,
+  # the factory registry, Wavefield serialization, the sea-state helpers, and the
+  # source-system plumbing (Configure / PreUpdate / Reset / set_parameters) —
+  # through a real EntityComponentManager. No provider dependency, no cycle.
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(wave_core_test test/wave_core_test.cc)
+  target_link_libraries(wave_core_test ${PROJECT_NAME} gz-sim::core)
+endif()
+
+ament_package()

--- a/gz_waves/README.md
+++ b/gz_waves/README.md
@@ -1,0 +1,26 @@
+# gz_waves
+
+The core of VRX's wave simulation: the engine-agnostic wave-field **contract**
+shared by the wave engines and their consumers. It builds standalone and depends
+on no particular wave backend.
+
+It provides:
+
+- **`IWaveField`** — the abstract wave-field interface (surface elevation,
+  normal, particle velocity, Jacobian, …) that every wave engine implements.
+- **An engine registry** (`RegisterWaveEngineFactory` / `CreateWaveSimulation`)
+  — a process-wide token→factory map, so an engine can be reached by name
+  without the core linking it.
+- **`WaveParameters`** and the **`Wavefield` ECM component** (+ serialization) —
+  the shared recipe and the world-entity channel that carries it (and the live
+  engine) to every consumer.
+- **`Eval`** — the null-safe free-function query API consumers use; the engine
+  interface stays opaque behind it.
+- **`WavesSystemBase`** — the base class each per-engine *source* system plugin
+  builds on.
+
+Wave **engines** — each a gz-sim system plugin you select by filename in the
+world SDF (there is no `<algorithm>` tag; the plugin you load *is* the backend) —
+and **consumers** (buoyancy, the water visual, any wave-aware plugin) live in
+their own packages that depend on this one. It all shares a single Apache-2
+codebase intended for upstreaming to `gz-sim`.

--- a/gz_waves/hooks/hook.dsv.in
+++ b/gz_waves/hooks/hook.dsv.in
@@ -1,0 +1,2 @@
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;@CMAKE_INSTALL_PREFIX@/share/@PROJECT_NAME@/models
+prepend-non-duplicate;GZ_SIM_SYSTEM_PLUGIN_PATH;@CMAKE_INSTALL_PREFIX@/lib

--- a/gz_waves/hooks/hook.sh.in
+++ b/gz_waves/hooks/hook.sh.in
@@ -1,0 +1,2 @@
+_colcon_prepend_unique_value GZ_SIM_RESOURCE_PATH @CMAKE_INSTALL_PREFIX@/share/@PROJECT_NAME@/models
+_colcon_prepend_unique_value GZ_SIM_SYSTEM_PLUGIN_PATH @CMAKE_INSTALL_PREFIX@/lib

--- a/gz_waves/include/gz/sim/components/Wavefield.hh
+++ b/gz_waves/include/gz/sim/components/Wavefield.hh
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 Honu Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef GZ_SIM_COMPONENTS_WAVEFIELD_HH_
+#define GZ_SIM_COMPONENTS_WAVEFIELD_HH_
+
+#include <gz/sim/components/Component.hh>
+#include <gz/sim/components/Factory.hh>
+#include <gz/sim/config.hh>
+
+#include "gz/sim/waves/Wavefield.hh"
+
+namespace gz::sim
+{
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+namespace components
+{
+  /// \brief A world-attached ECM component holding the current wave field
+  /// state. Written by the wave source system; read by buoyancy,
+  /// hydrodynamics, the water visual, and any wave-aware plugin.
+  using Wavefield = Component<waves::WavefieldData, class WavefieldTag>;
+
+  GZ_SIM_REGISTER_COMPONENT("gz_sim_components.Wavefield", Wavefield)
+}
+}
+}  // namespace gz::sim
+
+#endif  // GZ_SIM_COMPONENTS_WAVEFIELD_HH_

--- a/gz_waves/include/gz/sim/systems/WavesSystemBase.hh
+++ b/gz_waves/include/gz/sim/systems/WavesSystemBase.hh
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 Honu Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef GZ_SIM_SYSTEMS_WAVESSYSTEMBASE_HH_
+#define GZ_SIM_SYSTEMS_WAVESSYSTEMBASE_HH_
+
+#include <memory>
+#include <string>
+
+#include <gz/sim/System.hh>
+#include <gz/utils/ImplPtr.hh>
+
+namespace gz::sim::waves
+{
+  class IWaveField;
+  struct WaveParameters;
+}
+
+namespace gz::sim::systems
+{
+  /// \brief Shared base for the per-engine wave systems
+  /// (`gz-sim-waves-fft-system`, `gz-sim-waves-gerstner-system`). It owns all
+  /// the ECM / source plumbing — parsing the `<wave>` block, building the
+  /// engine, writing the `Wavefield` component on the world entity, throttling
+  /// `Update`, and re-marking the component for GUI replication — and defers
+  /// only the *choice* of engine to the concrete subclass.
+  ///
+  /// A subclass is a complete loadable System: it inherits the Configure /
+  /// PreUpdate behaviour and supplies just two things — the engine's token (for
+  /// the GUI to reconstruct the matching backend) and a factory that builds and
+  /// configures that backend. Because the subclass links its engine directly,
+  /// no runtime plugin loader is involved on the server side.
+  ///
+  /// In `PreUpdate` the component is periodically re-marked as changed for the
+  /// first few seconds of simulation so SceneBroadcaster keeps re-broadcasting
+  /// it until the GUI process has registered the component type (the GUI loads
+  /// our plugin libraries lazily, and a one-time replication at world load
+  /// tends to arrive before our type is registered there).
+  ///
+  /// SDF is parsed in `ParseSdf`: `<update_rate>` at plugin level and a
+  /// `<wave>` block of parameters (backed by `waves::WaveParameters` in
+  /// `gz_waves/include/gz/sim/waves/Wavefield.hh`). The base parses every known
+  /// tag, but **each concrete engine system documents — and uses — its own
+  /// parameter surface**: see FftWaves (`gz-sim-waves-fft-system`) and
+  /// GerstnerWaves (`gz-sim-waves-gerstner-system`). The same tag names are also
+  /// accepted by the `/world/<name>/wave/set_parameters` service
+  /// (`gz.msgs.Param`) for live changes.
+  class WavesSystemBase : public System,
+                          public ISystemConfigure,
+                          public ISystemPreUpdate,
+                          public ISystemReset
+  {
+    /// \brief Constructor.
+    public: WavesSystemBase();
+    /// \brief Destructor.
+    public: ~WavesSystemBase() override;
+
+    // Documentation inherited
+    public: void Configure(
+      const Entity &_entity,
+      const std::shared_ptr<const sdf::Element> &_sdf,
+      EntityComponentManager &_ecm,
+      EventManager &_eventMgr) override;
+
+    // Documentation inherited
+    public: void PreUpdate(
+      const UpdateInfo &_info,
+      EntityComponentManager &_ecm) override;
+
+    /// \brief On reset, rewind the update throttle so the wave field advances
+    /// from t = 0 again. Sim time rewinds on a reset but the cached timestamps
+    /// would not, which keeps the throttle false until time catches back up —
+    /// freezing the field (and anything riding it).
+    public: void Reset(
+      const UpdateInfo &_info,
+      EntityComponentManager &_ecm) override;
+
+    /// \brief Token recorded in the `Wavefield` component (e.g. "fft",
+    /// "gerstner") so the GUI can reconstruct the matching engine on
+    /// deserialization.
+    /// \return The engine's registration token.
+    protected: virtual std::string EngineToken() const = 0;
+
+    /// \brief Build and fully configure (i.e. call `SetParameters`) the engine
+    /// for this system from `_params`. Runs once, on the server, in Configure.
+    /// \param[in] _params Wave parameters to build and configure the engine with.
+    /// \return The configured engine instance.
+    protected: virtual std::shared_ptr<waves::IWaveField> MakeEngine(
+      const waves::WaveParameters &_params) const = 0;
+
+    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
+  };
+}  // namespace gz::sim::systems
+
+#endif  // GZ_SIM_SYSTEMS_WAVESSYSTEMBASE_HH_

--- a/gz_waves/include/gz/sim/systems/WavesSystemBase.hh
+++ b/gz_waves/include/gz/sim/systems/WavesSystemBase.hh
@@ -28,9 +28,9 @@ namespace gz::sim::systems
   /// \brief Shared base for the per-engine wave systems
   /// (`gz-sim-waves-fft-system`, `gz-sim-waves-gerstner-system`). It owns all
   /// the ECM / source plumbing — parsing the `<wave>` block, building the
-  /// engine, writing the `Wavefield` component on the world entity, throttling
-  /// `Update`, and re-marking the component for GUI replication — and defers
-  /// only the *choice* of engine to the concrete subclass.
+  /// engine, writing the `Wavefield` component on the world entity, and
+  /// throttling `Update` — and defers only the *choice* of engine to the
+  /// concrete subclass.
   ///
   /// A subclass is a complete loadable System: it inherits the Configure /
   /// PreUpdate behaviour and supplies just two things — the engine's token (for
@@ -38,11 +38,11 @@ namespace gz::sim::systems
   /// configures that backend. Because the subclass links its engine directly,
   /// no runtime plugin loader is involved on the server side.
   ///
-  /// In `PreUpdate` the component is periodically re-marked as changed for the
-  /// first few seconds of simulation so SceneBroadcaster keeps re-broadcasting
-  /// it until the GUI process has registered the component type (the GUI loads
-  /// our plugin libraries lazily, and a one-time replication at world load
-  /// tends to arrive before our type is registered there).
+  /// The `Wavefield` component is written once in `Configure` and re-marked as
+  /// changed only when its recipe actually changes (a `set_parameters` service
+  /// call). A late-joining GUI process does not rely on a re-broadcast window;
+  /// it pulls the current recipe on demand once its component type is
+  /// registered.
   ///
   /// SDF is parsed in `ParseSdf`: `<update_rate>` at plugin level and a
   /// `<wave>` block of parameters (backed by `waves::WaveParameters` in
@@ -77,7 +77,9 @@ namespace gz::sim::systems
     /// \brief On reset, rewind the update throttle so the wave field advances
     /// from t = 0 again. Sim time rewinds on a reset but the cached timestamps
     /// would not, which keeps the throttle false until time catches back up —
-    /// freezing the field (and anything riding it).
+    /// freezing the field (and anything riding it). Reset rewinds *time* only:
+    /// any parameters changed at runtime via `set_parameters` are intentionally
+    /// retained (a reset does not restore the original SDF recipe).
     public: void Reset(
       const UpdateInfo &_info,
       EntityComponentManager &_ecm) override;

--- a/gz_waves/include/gz/sim/systems/WavesSystemBase.hh
+++ b/gz_waves/include/gz/sim/systems/WavesSystemBase.hh
@@ -33,10 +33,17 @@ namespace gz::sim::systems
   /// concrete subclass.
   ///
   /// A subclass is a complete loadable System: it inherits the Configure /
-  /// PreUpdate behaviour and supplies just two things — the engine's token (for
-  /// the GUI to reconstruct the matching backend) and a factory that builds and
-  /// configures that backend. Because the subclass links its engine directly,
+  /// PreUpdate behaviour and supplies just two things: the engine's token (for
+  /// the GUI to reconstruct the matching engine) and a factory that builds and
+  /// configures that engine. Because the subclass links its engine directly,
   /// no runtime plugin loader is involved on the server side.
+  ///
+  /// Each engine token names a *whole synthesis technique* (a fixed bundle of
+  /// inverse transform, kinematics, and statistics), not a single design axis:
+  /// `gerstner` is the analytic, direct summation, deterministic engine and
+  /// `fft` is the FFT synthesized, random spectrum engine. The names are
+  /// conventional shorthand, not a transform versus kinematics contrast (the
+  /// `fft` engine also applies Gerstner-style displacement).
   ///
   /// The `Wavefield` component is written once in `Configure` and re-marked as
   /// changed only when its recipe actually changes (a `set_parameters` service

--- a/gz_waves/include/gz/sim/waves/Eval.hh
+++ b/gz_waves/include/gz/sim/waves/Eval.hh
@@ -11,7 +11,7 @@
 #ifndef GZ_SIM_WAVES_EVAL_HH_
 #define GZ_SIM_WAVES_EVAL_HH_
 
-#include <Eigen/Core>
+#include <gz/math/Vector3.hh>
 
 #include "gz/sim/waves/Wavefield.hh"
 
@@ -48,7 +48,7 @@ double SurfaceElevation(const WavefieldData &_wf,
 /// \param[in] _y  World-frame y coordinate [m].
 /// \param[in] _t  Simulation time [s].
 /// \return Particle velocity [m/s]; zero if `_wf` holds no engine.
-Eigen::Vector3d ParticleVelocity(const WavefieldData &_wf,
+gz::math::Vector3d ParticleVelocity(const WavefieldData &_wf,
                                  double _x, double _y, double _t);
 
 /// \brief Outward-pointing unit surface normal at (x, y, t).
@@ -57,7 +57,7 @@ Eigen::Vector3d ParticleVelocity(const WavefieldData &_wf,
 /// \param[in] _y  World-frame y coordinate [m].
 /// \param[in] _t  Simulation time [s].
 /// \return Unit surface normal; +Z if `_wf` holds no engine.
-Eigen::Vector3d Normal(const WavefieldData &_wf,
+gz::math::Vector3d Normal(const WavefieldData &_wf,
                        double _x, double _y, double _t);
 
 /// \brief Jacobian determinant of the horizontal displacement field.

--- a/gz_waves/include/gz/sim/waves/Eval.hh
+++ b/gz_waves/include/gz/sim/waves/Eval.hh
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Honu Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef GZ_SIM_WAVES_EVAL_HH_
+#define GZ_SIM_WAVES_EVAL_HH_
+
+#include <Eigen/Core>
+
+#include "gz/sim/waves/Wavefield.hh"
+
+namespace gz::sim::waves
+{
+
+// The wave field is queried only through these free functions: they take the
+// `Wavefield` component's data and forward to the polymorphic engine it holds.
+// Keeping them out-of-line (defined in Eval.cc) lets a consumer use the
+// component without seeing the full `IWaveField` interface — `Wavefield.hh`
+// only forward-declares it. Each is null-safe: with no engine the field reads
+// as still water.
+
+/// \brief Advance the wave field held by `_wf` to time `_t` [s] (no-op when no
+/// engine is present). Consumers call this instead of touching the engine
+/// directly, keeping `IWaveField` opaque to them.
+/// \param[in,out] _wf Wave-field state whose engine is advanced.
+/// \param[in]     _t  Simulation time [s] to advance to.
+void Advance(WavefieldData &_wf, double _t);
+
+/// \brief Surface elevation η(x, y, t) [m] above the still water level.
+/// \param[in] _wf Wave-field state to query.
+/// \param[in] _x  World-frame x coordinate [m].
+/// \param[in] _y  World-frame y coordinate [m].
+/// \param[in] _t  Simulation time [s].
+/// \return Elevation above the still water level [m]; 0 if `_wf` holds no
+/// engine.
+double SurfaceElevation(const WavefieldData &_wf,
+                        double _x, double _y, double _t);
+
+/// \brief Water particle velocity at the surface point (x, y) [m/s].
+/// \param[in] _wf Wave-field state to query.
+/// \param[in] _x  World-frame x coordinate [m].
+/// \param[in] _y  World-frame y coordinate [m].
+/// \param[in] _t  Simulation time [s].
+/// \return Particle velocity [m/s]; zero if `_wf` holds no engine.
+Eigen::Vector3d ParticleVelocity(const WavefieldData &_wf,
+                                 double _x, double _y, double _t);
+
+/// \brief Outward-pointing unit surface normal at (x, y, t).
+/// \param[in] _wf Wave-field state to query.
+/// \param[in] _x  World-frame x coordinate [m].
+/// \param[in] _y  World-frame y coordinate [m].
+/// \param[in] _t  Simulation time [s].
+/// \return Unit surface normal; +Z if `_wf` holds no engine.
+Eigen::Vector3d Normal(const WavefieldData &_wf,
+                       double _x, double _y, double _t);
+
+/// \brief Jacobian determinant of the horizontal displacement field.
+/// \param[in] _wf Wave-field state to query.
+/// \param[in] _x  World-frame x coordinate [m].
+/// \param[in] _y  World-frame y coordinate [m].
+/// \param[in] _t  Simulation time [s].
+/// \return Jacobian determinant; 1 if `_wf` holds no engine.
+double Jacobian(const WavefieldData &_wf, double _x, double _y, double _t);
+
+/// \brief Foam intensity in [0, 1] derived from the Jacobian (Tessendorf 2004).
+/// \param[in] _wf        Wave-field state to query.
+/// \param[in] _x         World-frame x coordinate [m].
+/// \param[in] _y         World-frame y coordinate [m].
+/// \param[in] _t         Simulation time [s].
+/// \param[in] _threshold Jacobian value at/above which foam is zero.
+/// \return Foam intensity in [0, 1] (0 = no foam).
+double FoamMask(const WavefieldData &_wf, double _x, double _y, double _t,
+                double _threshold = 0.6);
+
+}  // namespace gz::sim::waves
+
+#endif  // GZ_SIM_WAVES_EVAL_HH_

--- a/gz_waves/include/gz/sim/waves/WaveSimulation.hh
+++ b/gz_waves/include/gz/sim/waves/WaveSimulation.hh
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2026 Honu Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef GZ_SIM_WAVES_WAVESIMULATION_HH_
+#define GZ_SIM_WAVES_WAVESIMULATION_HH_
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include <Eigen/Core>
+
+namespace gz::sim::waves
+{
+
+struct WaveParameters;
+
+/// \brief Spatial extent of a wave field. Returned by `IWaveField::Bounds`.
+struct TileSize
+{
+  /// \brief Tile extent along x in metres.
+  double x{0.0};
+
+  /// \brief Tile extent along y in metres. The tile is centred at the world
+  /// origin; samples outside (-x/2, +x/2) × (-y/2, +y/2) are interpreted modulo
+  /// the tile size.
+  double y{0.0};
+};
+
+/// \brief A wave field sampled on a regular N×N grid over one tile — the
+/// uniform rendering contract every backend exposes via `IWaveField::Field`.
+/// Grid backends fill it from their IFFT output; analytic backends sample
+/// themselves into it. The renderer uploads it to a displacement texture and
+/// draws one backend-agnostic surface, so it never needs to know which backend
+/// is active.
+///
+/// All arrays are column-major N×N — element (i, j) is at index `i + j*N`,
+/// matching Eigen's default storage — and periodic over the tile. The pointers
+/// are owned by the wave-field implementation and remain valid until the next
+/// `SetParameters`; the values they reference are refreshed by `Update`.
+struct WaveField2D
+{
+  /// \brief Grid resolution per axis (N).
+  std::size_t n{0};
+
+  /// \brief Tile extent [m]; cell spacing is tile/N.
+  double tile{0.0};
+
+  /// \brief Vertical displacement η [m] (required).
+  const double *dz{nullptr};
+
+  /// \brief Horizontal chop x [m]; null ⇒ treat as 0.
+  const double *dx{nullptr};
+
+  /// \brief Horizontal chop y [m]; null ⇒ treat as 0.
+  const double *dy{nullptr};
+
+  /// \brief Folding metric: 1 = flat, < 1 → folding (whitecaps); null ⇒ the
+  /// backend has no foam.
+  const double *foam{nullptr};
+};
+
+/// \brief Polymorphic backend for a wave field. Concrete implementations (an
+/// analytic, closed-form engine; a grid-based, stochastic one; …) live in their
+/// own packages and are reached by token via the registry below. Consumers use
+/// `Eval::*` free functions which delegate to the implementation; they don't
+/// need to know which one is active. The renderer consumes the field uniformly
+/// through `Field`.
+class IWaveField
+{
+  /// \brief Virtual destructor.
+  public: virtual ~IWaveField() = default;
+
+  // ---- Point queries (mandatory) ------------------------------------------
+
+  /// \brief Surface elevation η(x, y, t) [m] above the still water level.
+  /// \param[in] _x World-frame x coordinate [m].
+  /// \param[in] _y World-frame y coordinate [m].
+  /// \param[in] _t Simulation time [s].
+  /// \return Surface elevation above the still water level [m].
+  public: virtual double Elevation(double _x, double _y, double _t) const = 0;
+
+  /// \brief Water particle velocity at the surface point (x, y) [m/s].
+  /// Used by drag terms for relative-velocity hydrodynamics.
+  /// \param[in] _x World-frame x coordinate [m].
+  /// \param[in] _y World-frame y coordinate [m].
+  /// \param[in] _t Simulation time [s].
+  /// \return Water particle velocity at the surface point [m/s].
+  public: virtual Eigen::Vector3d ParticleVelocity(
+    double _x, double _y, double _t) const = 0;
+
+  /// \brief Outward-pointing unit surface normal at (x, y, t).
+  /// \param[in] _x World-frame x coordinate [m].
+  /// \param[in] _y World-frame y coordinate [m].
+  /// \param[in] _t Simulation time [s].
+  /// \return Outward-pointing unit surface normal (dimensionless).
+  public: virtual Eigen::Vector3d Normal(
+    double _x, double _y, double _t) const = 0;
+
+  /// \brief Jacobian determinant of the horizontal displacement field at
+  /// (x, y, t). Values below ~0.6 indicate wave folding / whitecap formation
+  /// (Tessendorf 2004).
+  /// \param[in] _x World-frame x coordinate [m].
+  /// \param[in] _y World-frame y coordinate [m].
+  /// \param[in] _t Simulation time [s].
+  /// \return Jacobian determinant (dimensionless; 1 = unfolded).
+  public: virtual double Jacobian(double _x, double _y, double _t) const = 0;
+
+  // ---- Configuration ------------------------------------------------------
+
+  /// \brief (Re)configure the wave field from `_params`. The engine factory
+  /// default-constructs an implementation and then calls this to set it up; it
+  /// may also be invoked later to retune parameters at runtime. Implementations
+  /// fully (re)build their internal state from `_params`.
+  /// \param[in] _params Wave parameters to (re)build the field from.
+  public: virtual void SetParameters(const WaveParameters &_params) = 0;
+
+  // ---- Lifecycle ----------------------------------------------------------
+
+  /// \brief Advance any backend-internal time-dependent state. Analytic
+  /// backends are stateless and override this as a no-op; grid-based backends
+  /// regenerate the height grid here.
+  /// \param[in] _simTime Simulation time [s] to advance the field to.
+  public: virtual void Update(double /*_simTime*/) {}
+
+  // ---- Backend identity / capabilities ------------------------------------
+
+  /// \brief Short name identifying the backend (e.g. "gerstner", "fft"). Used
+  /// by the visual plugin to dispatch to the right shader path.
+  /// \return The backend's registration token.
+  public: virtual std::string_view Kind() const = 0;
+
+  /// \brief Spatial extent of the wave field. Grid backends return their tile
+  /// size; consumers must wrap queries outside the tile.
+  /// \return The tile extent, or `nullopt` for a field defined everywhere
+  /// (analytic backends).
+  public: virtual std::optional<TileSize> Bounds() const
+  {
+    return std::nullopt;
+  }
+
+  // ---- Rendering ----------------------------------------------------------
+
+  /// \brief A view of the current wave field sampled on a grid, for the
+  /// renderer to upload as a displacement texture (see `WaveField2D`). The
+  /// returned pointer references implementation-owned storage refreshed by
+  /// `Update`; it stays valid until the next `SetParameters`.
+  /// \return The renderable grid, or `nullptr` if the backend exposes none.
+  public: virtual const WaveField2D *Field() const { return nullptr; }
+};
+
+/// \brief Builds a default-constructed wave-field engine for a token. The
+/// returned engine has NOT yet had `SetParameters` called on it — that is the
+/// caller's job (see `CreateWaveSimulation`, which does both). Returning a bare
+/// engine keeps the factory free of the `WaveParameters` definition.
+using WaveEngineFactory =
+  std::function<std::shared_ptr<IWaveField>()>;
+
+/// \brief Register `_factory` under `_token` (e.g. "gerstner", "fft") in the
+/// process-wide engine registry that `CreateWaveSimulation` consults.
+///
+/// This is how a concrete engine library is made reachable by token without
+/// the core linking it (which would be a dependency cycle): the package that
+/// links an engine — a system plugin on the server, the water visual on the
+/// GUI — registers it here. Re-registering a token replaces the prior factory.
+/// Thread-safe.
+/// \param[in] _token   Engine identifier (matches `IWaveField::Kind`).
+/// \param[in] _factory Factory that builds a default-constructed engine.
+void RegisterWaveEngineFactory(const std::string &_token,
+                               WaveEngineFactory _factory);
+
+/// \brief Construct and configure the wave-field engine named by `_algorithm`
+/// (e.g. "gerstner", "fft"): look the token up in the registry populated by
+/// `RegisterWaveEngineFactory`, build an engine, and apply `_params` via
+/// `SetParameters`.
+/// \param[in] _algorithm Engine token to construct.
+/// \param[in] _params    Parameters to configure the new engine with.
+/// \return The configured engine, or `nullptr` for an unregistered token.
+std::shared_ptr<IWaveField> CreateWaveSimulation(
+  const std::string &_algorithm,
+  const WaveParameters &_params);
+
+}  // namespace gz::sim::waves
+
+#endif  // GZ_SIM_WAVES_WAVESIMULATION_HH_

--- a/gz_waves/include/gz/sim/waves/WaveSimulation.hh
+++ b/gz_waves/include/gz/sim/waves/WaveSimulation.hh
@@ -18,7 +18,7 @@
 #include <string>
 #include <string_view>
 
-#include <Eigen/Core>
+#include <gz/math/Vector3.hh>
 
 namespace gz::sim::waves
 {
@@ -44,10 +44,10 @@ struct TileSize
 /// draws one backend-agnostic surface, so it never needs to know which backend
 /// is active.
 ///
-/// All arrays are column-major N×N — element (i, j) is at index `i + j*N`,
-/// matching Eigen's default storage — and periodic over the tile. The pointers
-/// are owned by the wave-field implementation and remain valid until the next
-/// `SetParameters`; the values they reference are refreshed by `Update`.
+/// All arrays are column-major N×N — element (i, j) is at index `i + j*N` —
+/// and periodic over the tile. The pointers are owned by the wave-field
+/// implementation and remain valid until the next `SetParameters`; the values
+/// they reference are refreshed by `Update`.
 struct WaveField2D
 {
   /// \brief Grid resolution per axis (N).
@@ -96,7 +96,7 @@ class IWaveField
   /// \param[in] _y World-frame y coordinate [m].
   /// \param[in] _t Simulation time [s].
   /// \return Water particle velocity at the surface point [m/s].
-  public: virtual Eigen::Vector3d ParticleVelocity(
+  public: virtual gz::math::Vector3d ParticleVelocity(
     double _x, double _y, double _t) const = 0;
 
   /// \brief Outward-pointing unit surface normal at (x, y, t).
@@ -104,7 +104,7 @@ class IWaveField
   /// \param[in] _y World-frame y coordinate [m].
   /// \param[in] _t Simulation time [s].
   /// \return Outward-pointing unit surface normal (dimensionless).
-  public: virtual Eigen::Vector3d Normal(
+  public: virtual gz::math::Vector3d Normal(
     double _x, double _y, double _t) const = 0;
 
   /// \brief Jacobian determinant of the horizontal displacement field at

--- a/gz_waves/include/gz/sim/waves/Wavefield.hh
+++ b/gz_waves/include/gz/sim/waves/Wavefield.hh
@@ -1,0 +1,351 @@
+/*
+ * Copyright (C) 2026 Honu Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef GZ_SIM_WAVES_WAVEFIELD_HH_
+#define GZ_SIM_WAVES_WAVEFIELD_HH_
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <istream>
+#include <memory>
+#include <ostream>
+#include <string>
+
+namespace gz::sim::waves
+{
+
+/// \brief The polymorphic wave-field engine, forward-declared. Consumers reach
+/// it only through the `Wavefield` component (which holds a `shared_ptr`) and
+/// the `Eval.hh` free functions, so they never need the full interface — an
+/// incomplete type suffices for the `shared_ptr` member in `WavefieldData`.
+/// Producers and the `Eval` implementations include `WaveSimulation.hh` for
+/// the full definition.
+class IWaveField;
+
+/// \brief Human-facing wave parameters parsed from SDF or set programmatically.
+struct WaveParameters
+{
+  /// \brief Spectrum / sampling model: "PMS" or "CWR".
+  std::string model{"PMS"};
+
+  /// \brief Number of component waves (for Gerstner) or grid samples (for
+  /// future FFT layouts).
+  std::size_t number{3};
+
+  /// \brief Mean wave period [s].
+  double period{5.0};
+
+  /// \brief Mean wave amplitude [m] (CWR model only).
+  double amplitude{0.0};
+
+  /// \brief Mean wave direction [rad] from +X.
+  double direction{0.0};
+
+  /// \brief Angle between mean direction and largest/smallest component [rad].
+  double angle{0.4};
+
+  /// \brief Scale between mean and largest/smallest component waves.
+  double scale{1.1};
+
+  /// \brief Wave steepness in [0, 1].
+  double steepness{0.0};
+
+  /// \brief Phase [rad] (common to all components).
+  double phase{0.0};
+
+  /// \brief Time constant for the startup ramp `(1 - exp(-t/tau))` [s].
+  double tau{2.0};
+
+  /// \brief PMS amplitude multiplier (unitless).
+  double gain{1.0};
+
+  // ---- FFT-only parameters (ignored by the Gerstner backend) -------------
+
+  /// \brief Physical tile extent [m] along each axis for the periodic
+  /// FFT wave field.
+  double tileSize{200.0};
+
+  /// \brief Number of grid samples per axis for the FFT. Must be a power of
+  /// two (FFT/IFFT requirement). 64/128/256 typical.
+  std::size_t gridSize{128};
+
+  /// \brief RNG seed used to generate the stochastic spectral amplitudes.
+  /// Same seed → bit-for-bit identical wave field.
+  std::uint32_t seed{0};
+
+  /// \brief Tessendorf "choppiness" multiplier applied to the horizontal
+  /// displacement field in the visual shader. Negative values bunch
+  /// particles toward wave crests (the canonical choice). Typical range
+  /// [-2, 0]; 0 disables choppy displacement.
+  double choppiness{-1.0};
+
+  /// \brief FFT spectrum model (EncinoWaves): "pms", "jonswap", or "tma".
+  std::string spectrum{"tma"};
+
+  /// \brief FFT directional spreading (EncinoWaves): "poscos2", "mitsuyasu",
+  /// "hasselmann", or "donelanbanner".
+  std::string spreading{"hasselmann"};
+
+  /// \brief FFT dispersion relation (EncinoWaves): "deep", "finite", or
+  /// "capillary".
+  std::string dispersion{"capillary"};
+
+  /// \brief FFT water depth [m] (EncinoWaves dispersion input).
+  double depth{100.0};
+
+  /// \brief FFT wind fetch [km] (EncinoWaves spectrum input).
+  double fetch{300.0};
+
+  /// \brief FFT swell elongation (EncinoWaves directional spreading); 0 = none.
+  double swell{0.0};
+
+  /// \brief FFT breaking-wave trough damping in [0, 1] (EncinoWaves); 0 = none.
+  double troughDamping{0.0};
+
+  /// \brief FFT band-pass filter lower edge [m]. > 0 enables the band-pass,
+  /// keeping wavelengths within [filterMinWavelength, filterMaxWavelength].
+  double filterMinWavelength{0.0};
+
+  /// \brief FFT band-pass filter upper edge [m] (0 = no upper bound).
+  double filterMaxWavelength{0.0};
+
+  /// \brief FFT band-pass transition width [m] (0 = auto from the lower edge).
+  double filterSoftWidth{0.0};
+
+  /// \brief FFT band-pass suppression floor in [0, 1] (0 = full cut outside).
+  double filterMin{0.0};
+
+  /// \brief FFT band-pass invert: band-stop (notch) instead of band-pass.
+  bool filterInvert{false};
+
+  /// \brief WMO sea state code (0-9). A convenience that, when set, makes the
+  /// engine reproduce that sea state's significant wave height and peak period
+  /// (see WithSeaState / SeaStateFromCode). -1 (default) means "unset": use the
+  /// explicit period/gain above instead.
+  int seaState{-1};
+
+  /// \brief Gravitational acceleration magnitude [m/s²] driving the wave
+  /// physics (dispersion, spectrum, sea-state period). Populated from the
+  /// world's `<gravity>` in `WavesSystemBase::Configure` so the waves stay
+  /// consistent with buoyancy and rigid-body dynamics; defaults to gz-sim's
+  /// world default (9.8) when no world gravity is available.
+  double gravity{9.8};
+};
+
+/// \brief Canonical sea-state descriptor: significant wave height, peak period,
+/// and the fully-developed wind speed that produces them.
+struct SeaStateSpec
+{
+  /// \brief Significant wave height Hs [m].
+  double significantWaveHeight{0.0};
+
+  /// \brief Peak period Tp [s].
+  double peakPeriod{0.0};
+
+  /// \brief Fully-developed 19.5 m wind speed [m/s].
+  double windSpeed{0.0};
+};
+
+/// \brief Map a WMO Sea State code (0-9) to representative wave parameters.
+///
+/// The code's defining quantity is the significant-wave-height band; we take
+/// the band midpoint as the representative Hs, then derive the wind speed and
+/// peak period for a fully-developed Pierson-Moskowitz sea:
+///   Hs = 0.21 * V19.5^2 / g,  omega_p = 0.879 * g / V19.5,  Tp = 2*pi/omega_p
+///
+/// Canonical source: WMO Sea State code (code table 3700), WMO Manual on Codes
+/// (WMO-No. 306). Accessible table: https://en.wikipedia.org/wiki/Sea_state
+///
+/// \param[in]  _code WMO sea state code (0-9).
+/// \param[out] _out  Filled with the representative spec on success.
+/// \param[in]  _g    Gravity magnitude [m/s²] used in the PM relations above.
+/// \return true on success; false (leaving _out untouched) for an out-of-range
+/// code.
+inline bool SeaStateFromCode(int _code, SeaStateSpec &_out, double _g = 9.8)
+{
+  // Representative Hs [m] per WMO code: 0 calm/glassy, 1 calm/rippled,
+  // 2 smooth, 3 slight, 4 moderate, 5 rough, 6 very rough, 7 high,
+  // 8 very high, 9 phenomenal (band midpoints; 9 is open-ended).
+  static constexpr double kHs[10] =
+      {0.0, 0.05, 0.3, 0.875, 1.875, 3.25, 5.0, 7.5, 11.5, 16.0};
+  if (_code < 0 || _code > 9)
+    return false;
+  const double g = _g;
+  const double hs = kHs[_code];
+  const double v  = std::sqrt(hs * g / 0.21);
+  const double tp = (v > 0.0) ? (2.0 * M_PI * v / (0.879 * g)) : 0.0;
+  _out = SeaStateSpec{hs, tp, v};
+  return true;
+}
+
+/// \brief Return a copy of _p with the sea state (if set) applied: the peak
+/// period drives <period>, <gain> is normalised to 1 so the field shows the
+/// physical significant wave height (code 0 -> gain 0, i.e. flat), and for the
+/// CWR model the regular-wave <amplitude> is set to Hs/2. An unset (-1) or
+/// out-of-range seaState returns _p unchanged. Each provider calls this at the
+/// top of SetParameters, so <sea_state> works for every backend.
+/// \param[in] _p Wave parameters to derive from.
+/// \return A copy of _p with the sea state applied (or _p unchanged if unset).
+inline WaveParameters WithSeaState(const WaveParameters &_p)
+{
+  WaveParameters p = _p;
+  SeaStateSpec s;
+  if (p.seaState < 0 || !SeaStateFromCode(p.seaState, s, p.gravity))
+    return p;
+  if (s.significantWaveHeight <= 0.0)
+  {
+    p.gain = 0.0;            // sea state 0: calm / glassy -> flat
+    return p;
+  }
+  p.period = s.peakPeriod;
+  p.gain   = 1.0;            // physical Hs (no artistic boost)
+  if (p.model == "CWR")
+    p.amplitude = 0.5 * s.significantWaveHeight;
+  return p;
+}
+
+/// \brief Soft-start ramp factor `1 - exp(-t/tau)` in [0, 1] (`tau <= 0`
+/// disables it, returning 1). Shared by the wave engines so the startup
+/// transient is identical across backends.
+/// \param[in] _t   Elapsed simulation time [s].
+/// \param[in] _tau Ramp time constant [s] (`<= 0` disables the ramp).
+/// \return Ramp factor in [0, 1].
+inline double StartupRamp(double _t, double _tau)
+{
+  if (_tau <= 0.0)
+    return 1.0;
+  return 1.0 - std::exp(-_t / _tau);
+}
+
+/// \brief State held by the `Wavefield` ECM component. Wraps a polymorphic
+/// `IWaveField`. Consumers use the free functions in `Eval.hh` to query the
+/// wave field; they don't see the backend directly.
+struct WavefieldData
+{
+  /// \brief Backend identifier — "gerstner" or "fft". Serialized so the GUI
+  /// process can reconstruct the right backend on deserialization.
+  std::string algorithm{"gerstner"};
+
+  /// \brief Inputs to the backend.
+  WaveParameters params;
+
+  /// \brief The polymorphic wave-field implementation. Constructed by the wave
+  /// source system from `algorithm` + `params`. Consumers query via
+  /// `Eval::*` free functions.
+  std::shared_ptr<IWaveField> simulation;
+
+  /// \brief Monotonically increasing counter, bumped whenever the data is
+  /// rewritten. Consumers (visual upload, etc.) compare against their last
+  /// seen value to cheaply detect changes.
+  std::uint64_t generation{0};
+
+  /// \brief Server-side wave Update rate [Hz]. Mirrored from
+  /// `<update_rate>` so the GUI visual can throttle its own per-frame
+  /// Update to match the server's cadence — keeping them in step lets
+  /// the user retune a single SDF knob without the visual silently
+  /// drifting ahead.
+  double updateRate{30.0};
+};
+
+/// \brief Stream-out for ECM serialization. Writes the algorithm + the
+/// parameter struct. The simulation pointer is not serialized — it's
+/// reconstructed on the receiving side via the factory in WaveSimulation.hh.
+/// \param[in,out] _os Output stream to write to.
+/// \param[in]     _d  Wave-field state to serialize.
+/// \return The output stream `_os`.
+inline std::ostream &operator<<(std::ostream &_os, const WavefieldData &_d)
+{
+  _os << _d.algorithm << ' '
+      << _d.generation << ' '
+      << _d.params.model << ' '
+      << _d.params.number << ' '
+      << _d.params.period << ' '
+      << _d.params.amplitude << ' '
+      << _d.params.direction << ' '
+      << _d.params.angle << ' '
+      << _d.params.scale << ' '
+      << _d.params.steepness << ' '
+      << _d.params.phase << ' '
+      << _d.params.tau << ' '
+      << _d.params.gain << ' '
+      << _d.params.tileSize << ' '
+      << _d.params.gridSize << ' '
+      << _d.params.seed << ' '
+      << _d.params.choppiness << ' '
+      << _d.params.spectrum << ' '
+      << _d.params.spreading << ' '
+      << _d.params.dispersion << ' '
+      << _d.params.depth << ' '
+      << _d.params.fetch << ' '
+      << _d.params.swell << ' '
+      << _d.params.troughDamping << ' '
+      << _d.params.filterMinWavelength << ' '
+      << _d.params.filterMaxWavelength << ' '
+      << _d.params.filterSoftWidth << ' '
+      << _d.params.filterMin << ' '
+      << _d.params.filterInvert << ' '
+      << _d.params.seaState << ' '
+      << _d.params.gravity << ' '
+      << _d.updateRate << ' ';
+  return _os;
+}
+
+/// \brief Stream-in for ECM deserialization. Reads the *recipe* (algorithm +
+/// parameters) only; `simulation` is left null. Consumers that need a live wave
+/// field build their own engine from the deserialized params via
+/// `CreateWaveSimulation` (e.g. WaterVisual) — so each consumer owns a private
+/// instance and there is no shared, process-global engine.
+/// \param[in,out] _is Input stream to read from.
+/// \param[out]    _d  Wave-field state to populate (recipe only; engine null).
+/// \return The input stream `_is`.
+inline std::istream &operator>>(std::istream &_is, WavefieldData &_d)
+{
+  _is >> _d.algorithm
+      >> _d.generation
+      >> _d.params.model
+      >> _d.params.number
+      >> _d.params.period
+      >> _d.params.amplitude
+      >> _d.params.direction
+      >> _d.params.angle
+      >> _d.params.scale
+      >> _d.params.steepness
+      >> _d.params.phase
+      >> _d.params.tau
+      >> _d.params.gain
+      >> _d.params.tileSize
+      >> _d.params.gridSize
+      >> _d.params.seed
+      >> _d.params.choppiness
+      >> _d.params.spectrum
+      >> _d.params.spreading
+      >> _d.params.dispersion
+      >> _d.params.depth
+      >> _d.params.fetch
+      >> _d.params.swell
+      >> _d.params.troughDamping
+      >> _d.params.filterMinWavelength
+      >> _d.params.filterMaxWavelength
+      >> _d.params.filterSoftWidth
+      >> _d.params.filterMin
+      >> _d.params.filterInvert
+      >> _d.params.seaState
+      >> _d.params.gravity
+      >> _d.updateRate;
+  // The recipe is restored; build no engine. `simulation` stays null so no two
+  // consumers ever share a process-global instance.
+  _d.simulation.reset();
+  return _is;
+}
+
+}  // namespace gz::sim::waves
+
+#endif  // GZ_SIM_WAVES_WAVEFIELD_HH_

--- a/gz_waves/include/gz/sim/waves/Wavefield.hh
+++ b/gz_waves/include/gz/sim/waves/Wavefield.hh
@@ -14,10 +14,14 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <iomanip>
 #include <istream>
+#include <limits>
 #include <memory>
 #include <ostream>
 #include <string>
+
+#include <gz/math/Helpers.hh>  // GZ_PI
 
 namespace gz::sim::waves
 {
@@ -133,10 +137,11 @@ struct WaveParameters
   int seaState{-1};
 
   /// \brief Gravitational acceleration magnitude [m/s²] driving the wave
-  /// physics (dispersion, spectrum, sea-state period). Populated from the
-  /// world's `<gravity>` in `WavesSystemBase::Configure` so the waves stay
-  /// consistent with buoyancy and rigid-body dynamics; defaults to gz-sim's
-  /// world default (9.8) when no world gravity is available.
+  /// physics (dispersion, spectrum, sea-state period). Read from the world via
+  /// the `gz::sim::World::Gravity` API in `WavesSystemBase::Configure` (not
+  /// parsed from the plugin SDF) so the waves stay consistent with buoyancy and
+  /// rigid-body dynamics; defaults to gz-sim's world default (9.8) when the
+  /// world exposes no gravity.
   double gravity{9.8};
 };
 
@@ -181,7 +186,7 @@ inline bool SeaStateFromCode(int _code, SeaStateSpec &_out, double _g = 9.8)
   const double g = _g;
   const double hs = kHs[_code];
   const double v  = std::sqrt(hs * g / 0.21);
-  const double tp = (v > 0.0) ? (2.0 * M_PI * v / (0.879 * g)) : 0.0;
+  const double tp = (v > 0.0) ? (2.0 * GZ_PI * v / (0.879 * g)) : 0.0;
   _out = SeaStateSpec{hs, tp, v};
   return true;
 }
@@ -263,9 +268,17 @@ struct WavefieldData
 /// \return The output stream `_os`.
 inline std::ostream &operator<<(std::ostream &_os, const WavefieldData &_d)
 {
-  _os << _d.algorithm << ' '
+  // Emit doubles at full round-trip precision so the replicated copy rebuilds a
+  // bit-for-bit identical engine (the seed-reproducibility contract relies on
+  // this). Restore the caller's precision afterwards.
+  const auto oldPrecision =
+    _os.precision(std::numeric_limits<double>::max_digits10);
+  // Strings go through std::quoted so an empty value or one containing spaces
+  // (e.g. set via the runtime service) can't desync the positional field
+  // stream on read-back.
+  _os << std::quoted(_d.algorithm) << ' '
       << _d.generation << ' '
-      << _d.params.model << ' '
+      << std::quoted(_d.params.model) << ' '
       << _d.params.number << ' '
       << _d.params.period << ' '
       << _d.params.amplitude << ' '
@@ -280,9 +293,9 @@ inline std::ostream &operator<<(std::ostream &_os, const WavefieldData &_d)
       << _d.params.gridSize << ' '
       << _d.params.seed << ' '
       << _d.params.choppiness << ' '
-      << _d.params.spectrum << ' '
-      << _d.params.spreading << ' '
-      << _d.params.dispersion << ' '
+      << std::quoted(_d.params.spectrum) << ' '
+      << std::quoted(_d.params.spreading) << ' '
+      << std::quoted(_d.params.dispersion) << ' '
       << _d.params.depth << ' '
       << _d.params.fetch << ' '
       << _d.params.swell << ' '
@@ -295,6 +308,7 @@ inline std::ostream &operator<<(std::ostream &_os, const WavefieldData &_d)
       << _d.params.seaState << ' '
       << _d.params.gravity << ' '
       << _d.updateRate << ' ';
+  _os.precision(oldPrecision);
   return _os;
 }
 
@@ -308,9 +322,9 @@ inline std::ostream &operator<<(std::ostream &_os, const WavefieldData &_d)
 /// \return The input stream `_is`.
 inline std::istream &operator>>(std::istream &_is, WavefieldData &_d)
 {
-  _is >> _d.algorithm
+  _is >> std::quoted(_d.algorithm)
       >> _d.generation
-      >> _d.params.model
+      >> std::quoted(_d.params.model)
       >> _d.params.number
       >> _d.params.period
       >> _d.params.amplitude
@@ -325,9 +339,9 @@ inline std::istream &operator>>(std::istream &_is, WavefieldData &_d)
       >> _d.params.gridSize
       >> _d.params.seed
       >> _d.params.choppiness
-      >> _d.params.spectrum
-      >> _d.params.spreading
-      >> _d.params.dispersion
+      >> std::quoted(_d.params.spectrum)
+      >> std::quoted(_d.params.spreading)
+      >> std::quoted(_d.params.dispersion)
       >> _d.params.depth
       >> _d.params.fetch
       >> _d.params.swell

--- a/gz_waves/include/gz/sim/waves/Wavefield.hh
+++ b/gz_waves/include/gz/sim/waves/Wavefield.hh
@@ -145,6 +145,45 @@ struct WaveParameters
   double gravity{9.8};
 };
 
+/// \brief Single source of truth for the `WaveParameters` fields shared by
+/// serialization, SDF parsing (`<wave>` tags), and the `set_parameters`
+/// service. Each row is `X(member, "name", KIND)` where KIND is one of:
+///   DBL  → double          SIZE → std::size_t     U32 → std::uint32_t
+///   INT  → int             STR  → std::string     BOOL → bool
+/// Listed in struct-declaration order so `operator<<` / `operator>>` stream the
+/// fields in this exact order. `gravity` is intentionally absent: it is sourced
+/// from the world (not SDF or the service) and is streamed explicitly by the
+/// operators. Add a parameter once here and it is picked up by all four sites.
+#define GZ_WAVES_PARAM_TABLE(X)                  \
+  X(model,               "model",          STR)  \
+  X(number,              "number",         SIZE) \
+  X(period,              "period",         DBL)  \
+  X(amplitude,           "amplitude",      DBL)  \
+  X(direction,           "direction",      DBL)  \
+  X(angle,               "angle",          DBL)  \
+  X(scale,               "scale",          DBL)  \
+  X(steepness,           "steepness",      DBL)  \
+  X(phase,               "phase",          DBL)  \
+  X(tau,                 "tau",            DBL)  \
+  X(gain,                "gain",           DBL)  \
+  X(tileSize,            "tile_size",      DBL)  \
+  X(gridSize,            "grid_size",      SIZE) \
+  X(seed,                "seed",           U32)  \
+  X(choppiness,          "choppiness",     DBL)  \
+  X(spectrum,            "spectrum",       STR)  \
+  X(spreading,           "spreading",      STR)  \
+  X(dispersion,          "dispersion",     STR)  \
+  X(depth,               "depth",          DBL)  \
+  X(fetch,               "fetch",          DBL)  \
+  X(swell,               "swell",          DBL)  \
+  X(troughDamping,       "trough_damping", DBL)  \
+  X(filterMinWavelength, "filter_min_wl",  DBL)  \
+  X(filterMaxWavelength, "filter_max_wl",  DBL)  \
+  X(filterSoftWidth,     "filter_soft",    DBL)  \
+  X(filterMin,           "filter_min",     DBL)  \
+  X(filterInvert,        "filter_invert",  BOOL) \
+  X(seaState,            "sea_state",      INT)
+
 /// \brief Canonical sea-state descriptor: significant wave height, peak period,
 /// and the fully-developed wind speed that produces them.
 struct SeaStateSpec
@@ -275,39 +314,24 @@ inline std::ostream &operator<<(std::ostream &_os, const WavefieldData &_d)
     _os.precision(std::numeric_limits<double>::max_digits10);
   // Strings go through std::quoted so an empty value or one containing spaces
   // (e.g. set via the runtime service) can't desync the positional field
-  // stream on read-back.
-  _os << std::quoted(_d.algorithm) << ' '
-      << _d.generation << ' '
-      << std::quoted(_d.params.model) << ' '
-      << _d.params.number << ' '
-      << _d.params.period << ' '
-      << _d.params.amplitude << ' '
-      << _d.params.direction << ' '
-      << _d.params.angle << ' '
-      << _d.params.scale << ' '
-      << _d.params.steepness << ' '
-      << _d.params.phase << ' '
-      << _d.params.tau << ' '
-      << _d.params.gain << ' '
-      << _d.params.tileSize << ' '
-      << _d.params.gridSize << ' '
-      << _d.params.seed << ' '
-      << _d.params.choppiness << ' '
-      << std::quoted(_d.params.spectrum) << ' '
-      << std::quoted(_d.params.spreading) << ' '
-      << std::quoted(_d.params.dispersion) << ' '
-      << _d.params.depth << ' '
-      << _d.params.fetch << ' '
-      << _d.params.swell << ' '
-      << _d.params.troughDamping << ' '
-      << _d.params.filterMinWavelength << ' '
-      << _d.params.filterMaxWavelength << ' '
-      << _d.params.filterSoftWidth << ' '
-      << _d.params.filterMin << ' '
-      << _d.params.filterInvert << ' '
-      << _d.params.seaState << ' '
-      << _d.params.gravity << ' '
-      << _d.updateRate << ' ';
+  // stream on read-back. Field order/coverage comes from GZ_WAVES_PARAM_TABLE.
+#define GZ_WAVES_WR_STR(m)  _os << std::quoted(_d.params.m) << ' ';
+#define GZ_WAVES_WR_DBL(m)  _os << _d.params.m << ' ';
+#define GZ_WAVES_WR_SIZE(m) _os << _d.params.m << ' ';
+#define GZ_WAVES_WR_U32(m)  _os << _d.params.m << ' ';
+#define GZ_WAVES_WR_INT(m)  _os << _d.params.m << ' ';
+#define GZ_WAVES_WR_BOOL(m) _os << _d.params.m << ' ';
+#define GZ_WAVES_WR(member, name, kind) GZ_WAVES_WR_##kind(member)
+  _os << std::quoted(_d.algorithm) << ' ' << _d.generation << ' ';
+  GZ_WAVES_PARAM_TABLE(GZ_WAVES_WR)
+  _os << _d.params.gravity << ' ' << _d.updateRate << ' ';
+#undef GZ_WAVES_WR
+#undef GZ_WAVES_WR_STR
+#undef GZ_WAVES_WR_DBL
+#undef GZ_WAVES_WR_SIZE
+#undef GZ_WAVES_WR_U32
+#undef GZ_WAVES_WR_INT
+#undef GZ_WAVES_WR_BOOL
   _os.precision(oldPrecision);
   return _os;
 }
@@ -322,38 +346,24 @@ inline std::ostream &operator<<(std::ostream &_os, const WavefieldData &_d)
 /// \return The input stream `_is`.
 inline std::istream &operator>>(std::istream &_is, WavefieldData &_d)
 {
-  _is >> std::quoted(_d.algorithm)
-      >> _d.generation
-      >> std::quoted(_d.params.model)
-      >> _d.params.number
-      >> _d.params.period
-      >> _d.params.amplitude
-      >> _d.params.direction
-      >> _d.params.angle
-      >> _d.params.scale
-      >> _d.params.steepness
-      >> _d.params.phase
-      >> _d.params.tau
-      >> _d.params.gain
-      >> _d.params.tileSize
-      >> _d.params.gridSize
-      >> _d.params.seed
-      >> _d.params.choppiness
-      >> std::quoted(_d.params.spectrum)
-      >> std::quoted(_d.params.spreading)
-      >> std::quoted(_d.params.dispersion)
-      >> _d.params.depth
-      >> _d.params.fetch
-      >> _d.params.swell
-      >> _d.params.troughDamping
-      >> _d.params.filterMinWavelength
-      >> _d.params.filterMaxWavelength
-      >> _d.params.filterSoftWidth
-      >> _d.params.filterMin
-      >> _d.params.filterInvert
-      >> _d.params.seaState
-      >> _d.params.gravity
-      >> _d.updateRate;
+  // Field order/coverage mirrors operator<< via GZ_WAVES_PARAM_TABLE.
+#define GZ_WAVES_RD_STR(m)  _is >> std::quoted(_d.params.m);
+#define GZ_WAVES_RD_DBL(m)  _is >> _d.params.m;
+#define GZ_WAVES_RD_SIZE(m) _is >> _d.params.m;
+#define GZ_WAVES_RD_U32(m)  _is >> _d.params.m;
+#define GZ_WAVES_RD_INT(m)  _is >> _d.params.m;
+#define GZ_WAVES_RD_BOOL(m) _is >> _d.params.m;
+#define GZ_WAVES_RD(member, name, kind) GZ_WAVES_RD_##kind(member)
+  _is >> std::quoted(_d.algorithm) >> _d.generation;
+  GZ_WAVES_PARAM_TABLE(GZ_WAVES_RD)
+  _is >> _d.params.gravity >> _d.updateRate;
+#undef GZ_WAVES_RD
+#undef GZ_WAVES_RD_STR
+#undef GZ_WAVES_RD_DBL
+#undef GZ_WAVES_RD_SIZE
+#undef GZ_WAVES_RD_U32
+#undef GZ_WAVES_RD_INT
+#undef GZ_WAVES_RD_BOOL
   // The recipe is restored; build no engine. `simulation` stays null so no two
   // consumers ever share a process-global instance.
   _d.simulation.reset();

--- a/gz_waves/package.xml
+++ b/gz_waves/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>gz_waves</name>
+  <version>0.0.0</version>
+  <description>
+    Wave field component, evaluators, and spectrum sampling for Gazebo.
+    Designed to be upstreamed into gz-sim; lives in the VRX repository
+    during the bridging period.
+  </description>
+  <maintainer email="cen.aguero@gmail.com">Carlos Agüero</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>gz_sim_vendor</depend>
+  <depend>gz_math_vendor</depend>
+  <depend>gz_common_vendor</depend>
+  <depend>gz_plugin_vendor</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/gz_waves/src/Eval.cc
+++ b/gz_waves/src/Eval.cc
@@ -32,19 +32,19 @@ double SurfaceElevation(const WavefieldData &_wf,
 }
 
 //////////////////////////////////////////////////
-Eigen::Vector3d ParticleVelocity(const WavefieldData &_wf,
-                                 double _x, double _y, double _t)
+gz::math::Vector3d ParticleVelocity(const WavefieldData &_wf,
+                                    double _x, double _y, double _t)
 {
   return _wf.simulation ? _wf.simulation->ParticleVelocity(_x, _y, _t)
-                        : Eigen::Vector3d::Zero();
+                        : gz::math::Vector3d::Zero;
 }
 
 //////////////////////////////////////////////////
-Eigen::Vector3d Normal(const WavefieldData &_wf,
-                       double _x, double _y, double _t)
+gz::math::Vector3d Normal(const WavefieldData &_wf,
+                          double _x, double _y, double _t)
 {
   return _wf.simulation ? _wf.simulation->Normal(_x, _y, _t)
-                        : Eigen::Vector3d::UnitZ();
+                        : gz::math::Vector3d::UnitZ;
 }
 
 //////////////////////////////////////////////////

--- a/gz_waves/src/Eval.cc
+++ b/gz_waves/src/Eval.cc
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Honu Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "gz/sim/waves/Eval.hh"
+
+#include <algorithm>
+
+#include "gz/sim/waves/WaveSimulation.hh"
+
+namespace gz::sim::waves
+{
+
+//////////////////////////////////////////////////
+void Advance(WavefieldData &_wf, double _t)
+{
+  if (_wf.simulation)
+    _wf.simulation->Update(_t);
+}
+
+//////////////////////////////////////////////////
+double SurfaceElevation(const WavefieldData &_wf,
+                        double _x, double _y, double _t)
+{
+  return _wf.simulation ? _wf.simulation->Elevation(_x, _y, _t) : 0.0;
+}
+
+//////////////////////////////////////////////////
+Eigen::Vector3d ParticleVelocity(const WavefieldData &_wf,
+                                 double _x, double _y, double _t)
+{
+  return _wf.simulation ? _wf.simulation->ParticleVelocity(_x, _y, _t)
+                        : Eigen::Vector3d::Zero();
+}
+
+//////////////////////////////////////////////////
+Eigen::Vector3d Normal(const WavefieldData &_wf,
+                       double _x, double _y, double _t)
+{
+  return _wf.simulation ? _wf.simulation->Normal(_x, _y, _t)
+                        : Eigen::Vector3d::UnitZ();
+}
+
+//////////////////////////////////////////////////
+double Jacobian(const WavefieldData &_wf, double _x, double _y, double _t)
+{
+  return _wf.simulation ? _wf.simulation->Jacobian(_x, _y, _t) : 1.0;
+}
+
+//////////////////////////////////////////////////
+double FoamMask(const WavefieldData &_wf, double _x, double _y, double _t,
+                double _threshold)
+{
+  const double j = Jacobian(_wf, _x, _y, _t);
+  if (j >= _threshold)
+    return 0.0;
+  return std::clamp(1.0 - j / _threshold, 0.0, 1.0);
+}
+
+}  // namespace gz::sim::waves

--- a/gz_waves/src/WaveSimulation.cc
+++ b/gz_waves/src/WaveSimulation.cc
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Honu Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "gz/sim/waves/WaveSimulation.hh"
+
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <string>
+#include <utility>
+
+#include "gz/sim/waves/Wavefield.hh"
+
+namespace gz::sim::waves
+{
+
+namespace
+{
+//////////////////////////////////////////////////
+/// \brief The process-wide token → engine-factory registry, plus its guard.
+/// Function-local statics so there's no static-init-order dependency between
+/// this translation unit and whoever calls RegisterWaveEngineFactory.
+std::map<std::string, WaveEngineFactory> &Registry()
+{
+  static std::map<std::string, WaveEngineFactory> registry;
+  return registry;
+}
+
+//////////////////////////////////////////////////
+std::mutex &RegistryMutex()
+{
+  static std::mutex m;
+  return m;
+}
+}  // namespace
+
+//////////////////////////////////////////////////
+void RegisterWaveEngineFactory(const std::string &_token,
+                               WaveEngineFactory _factory)
+{
+  const std::lock_guard<std::mutex> lock(RegistryMutex());
+  Registry()[_token] = std::move(_factory);
+}
+
+//////////////////////////////////////////////////
+std::shared_ptr<IWaveField> CreateWaveSimulation(
+  const std::string &_algorithm,
+  const WaveParameters &_params)
+{
+  // Copy the factory out under the lock, then build/configure unlocked so a
+  // factory can't deadlock against the registry (and a slow build doesn't
+  // serialize other registrations).
+  WaveEngineFactory factory;
+  {
+    const std::lock_guard<std::mutex> lock(RegistryMutex());
+    auto it = Registry().find(_algorithm);
+    if (it != Registry().end())
+      factory = it->second;
+  }
+
+  if (!factory)
+  {
+    std::cerr << "[CreateWaveSimulation] no engine registered for '"
+              << _algorithm << "'. A consumer that links the engine must call "
+              << "RegisterWaveEngineFactory first — the system plugins do this "
+              << "on the server, the water visual on the GUI." << '\n';
+    return nullptr;
+  }
+
+  auto field = factory();
+  if (!field)
+  {
+    std::cerr << "[CreateWaveSimulation] factory for '" << _algorithm
+              << "' returned null" << '\n';
+    return nullptr;
+  }
+  field->SetParameters(_params);
+  return field;
+}
+
+}  // namespace gz::sim::waves

--- a/gz_waves/src/WaveSimulation.cc
+++ b/gz_waves/src/WaveSimulation.cc
@@ -10,11 +10,12 @@
 
 #include "gz/sim/waves/WaveSimulation.hh"
 
-#include <iostream>
 #include <map>
 #include <mutex>
 #include <string>
 #include <utility>
+
+#include <gz/common/Console.hh>
 
 #include "gz/sim/waves/Wavefield.hh"
 
@@ -67,18 +68,18 @@ std::shared_ptr<IWaveField> CreateWaveSimulation(
 
   if (!factory)
   {
-    std::cerr << "[CreateWaveSimulation] no engine registered for '"
-              << _algorithm << "'. A consumer that links the engine must call "
-              << "RegisterWaveEngineFactory first — the system plugins do this "
-              << "on the server, the water visual on the GUI." << '\n';
+    gzerr << "[CreateWaveSimulation] no engine registered for '"
+          << _algorithm << "'. A consumer that links the engine must call "
+          << "RegisterWaveEngineFactory first — the system plugins do this "
+          << "on the server, the water visual on the GUI." << '\n';
     return nullptr;
   }
 
   auto field = factory();
   if (!field)
   {
-    std::cerr << "[CreateWaveSimulation] factory for '" << _algorithm
-              << "' returned null" << '\n';
+    gzerr << "[CreateWaveSimulation] factory for '" << _algorithm
+          << "' returned null" << '\n';
     return nullptr;
   }
   field->SetParameters(_params);

--- a/gz_waves/src/components.cc
+++ b/gz_waves/src/components.cc
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2026 Honu Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/// \file
+/// \brief Anchors the `GZ_SIM_REGISTER_COMPONENT` static initializer for
+/// `components::Wavefield` in the core `libwaves.so`. Every system plugin we
+/// build links against this library, so the registration runs as soon as any
+/// of the plugins is dlopen'd — including in the GUI process, where the
+/// component needs to be registered before SceneBroadcaster's serialized
+/// state arrives.
+
+#include "gz/sim/components/Wavefield.hh"

--- a/gz_waves/src/systems/WavesSystemBase.cc
+++ b/gz_waves/src/systems/WavesSystemBase.cc
@@ -14,7 +14,6 @@
 #include <mutex>
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 #include <gz/common/Console.hh>
 #include <gz/msgs/boolean.pb.h>
@@ -71,8 +70,9 @@ bool ReadInt(const gz::msgs::Any &_v, int &_out)
 
 //////////////////////////////////////////////////
 /// \brief Merge the recognised keys in `_req` onto a copy of `_p` (partial
-/// update: absent keys keep their current value). Keys mirror the <wave> SDF
-/// tags parsed in ParseSdf — keep the two lists in sync.
+/// update: absent keys keep their current value). The recognised keys and their
+/// types come from GZ_WAVES_PARAM_TABLE — the same source `operator<<`/`>>` and
+/// ParseSdf use — so there is no separate list to keep in sync.
 /// \param[in]  _p       The base parameters to merge the update onto.
 /// \param[in]  _req     The requested key → value updates.
 /// \param[out] _matched Set true if at least one wave parameter was recognised.
@@ -80,26 +80,6 @@ bool ReadInt(const gz::msgs::Any &_v, int &_out)
 waves::WaveParameters ApplyParam(waves::WaveParameters _p,
     const gz::msgs::Param &_req, bool &_matched)
 {
-  // Double-valued tags (key -> destination field in the copy `_p`).
-  const std::unordered_map<std::string, double *> doubles{
-    {"period", &_p.period},     {"amplitude", &_p.amplitude},
-    {"direction", &_p.direction}, {"angle", &_p.angle},
-    {"scale", &_p.scale},       {"steepness", &_p.steepness},
-    {"phase", &_p.phase},       {"tau", &_p.tau},
-    {"gain", &_p.gain},         {"tile_size", &_p.tileSize},
-    {"choppiness", &_p.choppiness},
-    {"depth", &_p.depth},       {"fetch", &_p.fetch},
-    {"swell", &_p.swell},       {"trough_damping", &_p.troughDamping},
-    {"filter_min_wl", &_p.filterMinWavelength},
-    {"filter_max_wl", &_p.filterMaxWavelength},
-    {"filter_soft", &_p.filterSoftWidth},
-    {"filter_min", &_p.filterMin}};
-
-  // String-valued tags (key -> destination field).
-  const std::unordered_map<std::string, std::string *> strings{
-    {"model", &_p.model},         {"spectrum", &_p.spectrum},
-    {"spreading", &_p.spreading}, {"dispersion", &_p.dispersion}};
-
   auto warnType = [](const std::string &_k)
   {
     gzwarn << "[Waves] set_parameters: key '" << _k
@@ -112,28 +92,34 @@ waves::WaveParameters ApplyParam(waves::WaveParameters _p,
     const gz::msgs::Any &v = kv.second;
     double d = 0.0;
     int i = 0;
-    if (auto it = doubles.find(k); it != doubles.end())
-    {
-      if (ReadDouble(v, d)) { *it->second = d; _matched = true; }
-      else warnType(k);
-    }
-    else if (auto sit = strings.find(k); sit != strings.end())
-    {
-      if (v.type() == gz::msgs::Any::STRING)
-      { *sit->second = v.string_value(); _matched = true; }
-      else warnType(k);
-    }
-    else if (k == "filter_invert")
-    { if (ReadDouble(v, d)) { _p.filterInvert = (d != 0.0); _matched = true; } else warnType(k); }
-    else if (k == "number")
-    { if (ReadInt(v, i)) { _p.number = static_cast<std::size_t>(i); _matched = true; } else warnType(k); }
-    else if (k == "grid_size")
-    { if (ReadInt(v, i)) { _p.gridSize = static_cast<std::size_t>(i); _matched = true; } else warnType(k); }
-    else if (k == "seed")
-    { if (ReadInt(v, i)) { _p.seed = static_cast<std::uint32_t>(i); _matched = true; } else warnType(k); }
-    else if (k == "sea_state")
-    { if (ReadInt(v, i)) { _p.seaState = i; _matched = true; } else warnType(k); }
-    else
+    bool handled = false;
+#define GZ_WAVES_AP_DBL(m) \
+    { if (ReadDouble(v, d)) { _p.m = d; _matched = true; } else warnType(k); }
+#define GZ_WAVES_AP_SIZE(m) \
+    { if (ReadInt(v, i)) { _p.m = static_cast<std::size_t>(i); _matched = true; }\
+      else warnType(k); }
+#define GZ_WAVES_AP_U32(m) \
+    { if (ReadInt(v, i)) { _p.m = static_cast<std::uint32_t>(i); _matched = true;}\
+      else warnType(k); }
+#define GZ_WAVES_AP_INT(m) \
+    { if (ReadInt(v, i)) { _p.m = i; _matched = true; } else warnType(k); }
+#define GZ_WAVES_AP_STR(m) \
+    { if (v.type() == gz::msgs::Any::STRING) { _p.m = v.string_value(); \
+        _matched = true; } else warnType(k); }
+#define GZ_WAVES_AP_BOOL(m) \
+    { if (ReadDouble(v, d)) { _p.m = (d != 0.0); _matched = true; } \
+      else warnType(k); }
+#define GZ_WAVES_AP(member, name, kind) \
+    if (!handled && k == name) { handled = true; GZ_WAVES_AP_##kind(member) }
+    GZ_WAVES_PARAM_TABLE(GZ_WAVES_AP)
+#undef GZ_WAVES_AP
+#undef GZ_WAVES_AP_DBL
+#undef GZ_WAVES_AP_SIZE
+#undef GZ_WAVES_AP_U32
+#undef GZ_WAVES_AP_INT
+#undef GZ_WAVES_AP_STR
+#undef GZ_WAVES_AP_BOOL
+    if (!handled)
     {
       gzwarn << "[Waves] set_parameters: unknown key '" << k << "' ignored"
              << '\n';
@@ -208,44 +194,27 @@ void WavesSystemBase::Implementation::ParseSdf(const sdf::ElementPtr &_sdf)
 
   const auto wave = _sdf->GetElement("wave");
   auto &p = this->data.params;
-  p.model     = wave->Get<std::string>("model",     p.model    ).first;
-  p.number    = wave->Get<unsigned int>("number",   p.number   ).first;
-  p.period    = wave->Get<double>("period",         p.period   ).first;
-  p.amplitude = wave->Get<double>("amplitude",      p.amplitude).first;
-  p.direction = wave->Get<double>("direction",      p.direction).first;
-  p.angle     = wave->Get<double>("angle",          p.angle    ).first;
-  p.scale     = wave->Get<double>("scale",          p.scale    ).first;
-  p.steepness = wave->Get<double>("steepness",      p.steepness).first;
-  p.phase     = wave->Get<double>("phase",          p.phase    ).first;
-  p.tau       = wave->Get<double>("tau",            p.tau      ).first;
-  p.gain      = wave->Get<double>("gain",           p.gain     ).first;
-
-  // FFT-only parameters; ignored by Gerstner. Kept in <wave> for locality.
-  p.tileSize   = wave->Get<double>("tile_size",       p.tileSize  ).first;
-  p.gridSize   = wave->Get<unsigned int>("grid_size", p.gridSize  ).first;
-  p.seed       = wave->Get<unsigned int>("seed",      p.seed      ).first;
-  p.choppiness = wave->Get<double>("choppiness",      p.choppiness).first;
-
-  // FFT spectrum selectors (EncinoWaves); ignored by the Gerstner engine.
-  p.spectrum   = wave->Get<std::string>("spectrum",   p.spectrum  ).first;
-  p.spreading  = wave->Get<std::string>("spreading",  p.spreading ).first;
-  p.dispersion = wave->Get<std::string>("dispersion", p.dispersion).first;
-  p.depth         = wave->Get<double>("depth",          p.depth        ).first;
-  p.fetch         = wave->Get<double>("fetch",          p.fetch        ).first;
-  p.swell         = wave->Get<double>("swell",          p.swell        ).first;
-  p.troughDamping = wave->Get<double>("trough_damping", p.troughDamping).first;
-  p.filterMinWavelength =
-    wave->Get<double>("filter_min_wl", p.filterMinWavelength).first;
-  p.filterMaxWavelength =
-    wave->Get<double>("filter_max_wl", p.filterMaxWavelength).first;
-  p.filterSoftWidth = wave->Get<double>("filter_soft", p.filterSoftWidth).first;
-  p.filterMin       = wave->Get<double>("filter_min",  p.filterMin).first;
-  p.filterInvert    = wave->Get<bool>("filter_invert", p.filterInvert).first;
-
-  // High-level convenience: a WMO sea state code (0-9) that each engine turns
-  // into a matching significant wave height + peak period (see WithSeaState).
-  // When set, it overrides <period> and <gain>.
-  p.seaState   = wave->Get<int>("sea_state",          p.seaState  ).first;
+  // Every <wave> tag and its type comes from GZ_WAVES_PARAM_TABLE — the same
+  // source serialization and the set_parameters service use. (Tags not relevant
+  // to a given engine — e.g. the FFT/EncinoWaves selectors for Gerstner — are
+  // simply ignored by that backend; parsing them here is harmless.)
+#define GZ_WAVES_SDF_DBL(m, name)  p.m = wave->Get<double>(name, p.m).first;
+#define GZ_WAVES_SDF_SIZE(m, name) \
+    p.m = wave->Get<unsigned int>(name, static_cast<unsigned int>(p.m)).first;
+#define GZ_WAVES_SDF_U32(m, name) \
+    p.m = wave->Get<unsigned int>(name, static_cast<unsigned int>(p.m)).first;
+#define GZ_WAVES_SDF_INT(m, name)  p.m = wave->Get<int>(name, p.m).first;
+#define GZ_WAVES_SDF_STR(m, name)  p.m = wave->Get<std::string>(name, p.m).first;
+#define GZ_WAVES_SDF_BOOL(m, name) p.m = wave->Get<bool>(name, p.m).first;
+#define GZ_WAVES_SDF(member, name, kind) GZ_WAVES_SDF_##kind(member, name)
+  GZ_WAVES_PARAM_TABLE(GZ_WAVES_SDF)
+#undef GZ_WAVES_SDF
+#undef GZ_WAVES_SDF_DBL
+#undef GZ_WAVES_SDF_SIZE
+#undef GZ_WAVES_SDF_U32
+#undef GZ_WAVES_SDF_INT
+#undef GZ_WAVES_SDF_STR
+#undef GZ_WAVES_SDF_BOOL
 }
 
 //////////////////////////////////////////////////

--- a/gz_waves/src/systems/WavesSystemBase.cc
+++ b/gz_waves/src/systems/WavesSystemBase.cc
@@ -1,0 +1,438 @@
+/*
+ * Copyright (C) 2026 Honu Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "gz/sim/systems/WavesSystemBase.hh"
+
+#include <chrono>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include <gz/common/Console.hh>
+#include <gz/msgs/boolean.pb.h>
+#include <gz/msgs/param.pb.h>
+#include <gz/sim/Util.hh>
+#include <gz/sim/World.hh>
+#include <gz/transport/Node.hh>
+
+#include <sdf/Element.hh>
+
+#include "gz/sim/components/Name.hh"
+#include "gz/sim/components/Wavefield.hh"
+#include "gz/sim/waves/Wavefield.hh"
+#include "gz/sim/waves/WaveSimulation.hh"  // drives the engine (producer side)
+
+namespace gz::sim::systems
+{
+
+namespace
+{
+//////////////////////////////////////////////////
+// --- set_parameters service: gz.msgs.Any -> scalar -------------------------
+/// \brief Read a numeric Any (DOUBLE / INT32 / BOOLEAN) as a double.
+/// \param[in]  _v   The value to read.
+/// \param[out] _out Set to the numeric value on success.
+/// \return true on a numeric value; false on a non-numeric one (so the caller
+/// can warn and skip rather than corrupt a field).
+bool ReadDouble(const gz::msgs::Any &_v, double &_out)
+{
+  switch (_v.type())
+  {
+    case gz::msgs::Any::DOUBLE:  _out = _v.double_value();           return true;
+    case gz::msgs::Any::INT32:   _out = _v.int_value();              return true;
+    case gz::msgs::Any::BOOLEAN: _out = _v.bool_value() ? 1.0 : 0.0; return true;
+    default: return false;
+  }
+}
+
+//////////////////////////////////////////////////
+/// \brief Read an integer Any (INT32, or a DOUBLE truncated) as an int.
+/// \param[in]  _v   The value to read.
+/// \param[out] _out Set to the integer value on success.
+/// \return true on a numeric value; false otherwise.
+bool ReadInt(const gz::msgs::Any &_v, int &_out)
+{
+  switch (_v.type())
+  {
+    case gz::msgs::Any::INT32:  _out = _v.int_value();                      return true;
+    case gz::msgs::Any::DOUBLE: _out = static_cast<int>(_v.double_value()); return true;
+    default: return false;
+  }
+}
+
+//////////////////////////////////////////////////
+/// \brief Merge the recognised keys in `_req` onto a copy of `_p` (partial
+/// update: absent keys keep their current value). Keys mirror the <wave> SDF
+/// tags parsed in ParseSdf — keep the two lists in sync.
+/// \param[in]  _p       The base parameters to merge the update onto.
+/// \param[in]  _req     The requested key → value updates.
+/// \param[out] _matched Set true if at least one wave parameter was recognised.
+/// \return The merged parameters.
+waves::WaveParameters ApplyParam(waves::WaveParameters _p,
+    const gz::msgs::Param &_req, bool &_matched)
+{
+  // Double-valued tags (key -> destination field in the copy `_p`).
+  const std::unordered_map<std::string, double *> doubles{
+    {"period", &_p.period},     {"amplitude", &_p.amplitude},
+    {"direction", &_p.direction}, {"angle", &_p.angle},
+    {"scale", &_p.scale},       {"steepness", &_p.steepness},
+    {"phase", &_p.phase},       {"tau", &_p.tau},
+    {"gain", &_p.gain},         {"tile_size", &_p.tileSize},
+    {"choppiness", &_p.choppiness},
+    {"depth", &_p.depth},       {"fetch", &_p.fetch},
+    {"swell", &_p.swell},       {"trough_damping", &_p.troughDamping},
+    {"filter_min_wl", &_p.filterMinWavelength},
+    {"filter_max_wl", &_p.filterMaxWavelength},
+    {"filter_soft", &_p.filterSoftWidth},
+    {"filter_min", &_p.filterMin}};
+
+  // String-valued tags (key -> destination field).
+  const std::unordered_map<std::string, std::string *> strings{
+    {"model", &_p.model},         {"spectrum", &_p.spectrum},
+    {"spreading", &_p.spreading}, {"dispersion", &_p.dispersion}};
+
+  auto warnType = [](const std::string &_k)
+  {
+    gzwarn << "[Waves] set_parameters: key '" << _k
+           << "' has a non-numeric value; ignored" << '\n';
+  };
+
+  for (const auto &kv : _req.params())
+  {
+    const std::string &k = kv.first;
+    const gz::msgs::Any &v = kv.second;
+    double d = 0.0;
+    int i = 0;
+    if (auto it = doubles.find(k); it != doubles.end())
+    {
+      if (ReadDouble(v, d)) { *it->second = d; _matched = true; }
+      else warnType(k);
+    }
+    else if (auto sit = strings.find(k); sit != strings.end())
+    {
+      if (v.type() == gz::msgs::Any::STRING)
+      { *sit->second = v.string_value(); _matched = true; }
+      else warnType(k);
+    }
+    else if (k == "filter_invert")
+    { if (ReadDouble(v, d)) { _p.filterInvert = (d != 0.0); _matched = true; } else warnType(k); }
+    else if (k == "number")
+    { if (ReadInt(v, i)) { _p.number = static_cast<std::size_t>(i); _matched = true; } else warnType(k); }
+    else if (k == "grid_size")
+    { if (ReadInt(v, i)) { _p.gridSize = static_cast<std::size_t>(i); _matched = true; } else warnType(k); }
+    else if (k == "seed")
+    { if (ReadInt(v, i)) { _p.seed = static_cast<std::uint32_t>(i); _matched = true; } else warnType(k); }
+    else if (k == "sea_state")
+    { if (ReadInt(v, i)) { _p.seaState = i; _matched = true; } else warnType(k); }
+    else
+    {
+      gzwarn << "[Waves] set_parameters: unknown key '" << k << "' ignored"
+             << '\n';
+    }
+  }
+  return _p;
+}
+}
+
+class WavesSystemBase::Implementation
+{
+  /// \brief Parse `<update_rate>` (plugin level) and the `<wave>` parameter
+  /// block from the plugin SDF into `data.params`; missing tags keep defaults.
+  /// \param[in] _sdf The plugin's SDF element.
+  public: void ParseSdf(const sdf::ElementPtr &_sdf);
+
+  /// \brief The wave-field recipe and live engine written to the component.
+  public: waves::WavefieldData data;
+  /// \brief The world entity the Wavefield component is attached to.
+  public: Entity worldEnt{kNullEntity};
+  /// \brief Cached Wavefield component type id (for SetChanged on update).
+  public: ComponentTypeId componentType{0};
+
+  /// \brief Throttle backend updates to at most this rate [Hz]. Default 30 Hz
+  /// matches asv_wave_sim; cheap for analytic Gerstner, sets a sensible
+  /// ceiling on FFT IFFT cost.
+  public: double updateRate{30.0};
+
+  /// \brief Last sim time at which `simulation->Update` was called.
+  public: double lastUpdateTime{-1.0};
+
+  /// \brief Drain a queued runtime parameter update (from the set_parameters
+  /// service) on the ECM thread: reconfigure the engine, bump the generation,
+  /// and re-broadcast the Wavefield component. No-op when nothing is queued.
+  /// \param[in] _ecm The entity-component manager holding the component.
+  public: void ApplyPendingParams(EntityComponentManager &_ecm);
+
+  /// \brief set_parameters service handler. Runs on a gz-transport thread, so
+  /// it only validates + queues the new parameters; PreUpdate applies them.
+  /// \param[in]  _req The requested parameter updates (gz.msgs.Param map).
+  /// \param[out] _rep Set to true if at least one key was recognised.
+  /// \return true (the service call always completes; `_rep` carries the
+  /// recognised/ignored result).
+  public: bool OnSetParameters(
+    const gz::msgs::Param &_req, gz::msgs::Boolean &_rep);
+
+  /// \brief Transport node owning the set_parameters service.
+  public: gz::transport::Node node;
+  /// \brief Guards `currentParams` + `pendingParams` across the transport and
+  /// ECM threads.
+  public: std::mutex paramMutex;
+  /// \brief Latest applied wave parameters — the base a partial service update
+  /// is merged onto. Mutex-protected (the transport thread reads it).
+  public: waves::WaveParameters currentParams;
+  /// \brief Parameters queued by the service, applied in the next PreUpdate.
+  public: std::optional<waves::WaveParameters> pendingParams;
+};
+
+//////////////////////////////////////////////////
+void WavesSystemBase::Implementation::ParseSdf(const sdf::ElementPtr &_sdf)
+{
+  // Note: the engine is fixed by the concrete system (its plugin identity), so
+  // there is no <algorithm> tag to parse here.
+  this->updateRate =
+    _sdf->Get<double>("update_rate", this->updateRate).first;
+
+  if (!_sdf->HasElement("wave"))
+  {
+    gzwarn << "[Waves] no <wave> element found; using defaults" << '\n';
+    return;
+  }
+
+  const auto wave = _sdf->GetElement("wave");
+  auto &p = this->data.params;
+  p.model     = wave->Get<std::string>("model",     p.model    ).first;
+  p.number    = wave->Get<unsigned int>("number",   p.number   ).first;
+  p.period    = wave->Get<double>("period",         p.period   ).first;
+  p.amplitude = wave->Get<double>("amplitude",      p.amplitude).first;
+  p.direction = wave->Get<double>("direction",      p.direction).first;
+  p.angle     = wave->Get<double>("angle",          p.angle    ).first;
+  p.scale     = wave->Get<double>("scale",          p.scale    ).first;
+  p.steepness = wave->Get<double>("steepness",      p.steepness).first;
+  p.phase     = wave->Get<double>("phase",          p.phase    ).first;
+  p.tau       = wave->Get<double>("tau",            p.tau      ).first;
+  p.gain      = wave->Get<double>("gain",           p.gain     ).first;
+
+  // FFT-only parameters; ignored by Gerstner. Kept in <wave> for locality.
+  p.tileSize   = wave->Get<double>("tile_size",       p.tileSize  ).first;
+  p.gridSize   = wave->Get<unsigned int>("grid_size", p.gridSize  ).first;
+  p.seed       = wave->Get<unsigned int>("seed",      p.seed      ).first;
+  p.choppiness = wave->Get<double>("choppiness",      p.choppiness).first;
+
+  // FFT spectrum selectors (EncinoWaves); ignored by the Gerstner engine.
+  p.spectrum   = wave->Get<std::string>("spectrum",   p.spectrum  ).first;
+  p.spreading  = wave->Get<std::string>("spreading",  p.spreading ).first;
+  p.dispersion = wave->Get<std::string>("dispersion", p.dispersion).first;
+  p.depth         = wave->Get<double>("depth",          p.depth        ).first;
+  p.fetch         = wave->Get<double>("fetch",          p.fetch        ).first;
+  p.swell         = wave->Get<double>("swell",          p.swell        ).first;
+  p.troughDamping = wave->Get<double>("trough_damping", p.troughDamping).first;
+  p.filterMinWavelength =
+    wave->Get<double>("filter_min_wl", p.filterMinWavelength).first;
+  p.filterMaxWavelength =
+    wave->Get<double>("filter_max_wl", p.filterMaxWavelength).first;
+  p.filterSoftWidth = wave->Get<double>("filter_soft", p.filterSoftWidth).first;
+  p.filterMin       = wave->Get<double>("filter_min",  p.filterMin).first;
+  p.filterInvert    = wave->Get<bool>("filter_invert", p.filterInvert).first;
+
+  // High-level convenience: a WMO sea state code (0-9) that each engine turns
+  // into a matching significant wave height + peak period (see WithSeaState).
+  // When set, it overrides <period> and <gain>.
+  p.seaState   = wave->Get<int>("sea_state",          p.seaState  ).first;
+}
+
+//////////////////////////////////////////////////
+WavesSystemBase::WavesSystemBase()
+  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
+{
+}
+
+WavesSystemBase::~WavesSystemBase() = default;
+
+//////////////////////////////////////////////////
+void WavesSystemBase::Configure(
+  const Entity &/*_entity*/,
+  const std::shared_ptr<const sdf::Element> &_sdf,
+  EntityComponentManager &_ecm,
+  EventManager &/*_eventMgr*/)
+{
+  this->dataPtr->ParseSdf(
+    std::const_pointer_cast<sdf::Element>(_sdf));
+
+  this->dataPtr->worldEnt = worldEntity(_ecm);
+  if (this->dataPtr->worldEnt == kNullEntity)
+  {
+    gzerr << "[Waves] no world entity found; aborting" << '\n';
+    return;
+  }
+
+  // Drive the wave physics with the world's configured gravity so dispersion,
+  // spectrum and sea-state period stay consistent with buoyancy and dynamics.
+  if (auto gravOpt = World(this->dataPtr->worldEnt).Gravity(_ecm); gravOpt)
+    this->dataPtr->data.params.gravity = gravOpt->Length();
+
+  // The engine is determined by this concrete system, not by SDF.
+  this->dataPtr->data.algorithm = this->EngineToken();
+  this->dataPtr->data.simulation = this->MakeEngine(this->dataPtr->data.params);
+  if (!this->dataPtr->data.simulation)
+  {
+    gzerr << "[Waves] failed to create '" << this->dataPtr->data.algorithm
+          << "' engine; aborting" << '\n';
+    return;
+  }
+  this->dataPtr->data.generation = 1;
+  this->dataPtr->data.updateRate = this->dataPtr->updateRate;
+  this->dataPtr->currentParams = this->dataPtr->data.params;
+
+  _ecm.CreateComponent(this->dataPtr->worldEnt,
+    components::Wavefield(this->dataPtr->data));
+  this->dataPtr->componentType = components::Wavefield::typeId;
+
+  // Advertise a runtime parameter-update service. Callers send a gz.msgs.Param
+  // map of <wave> tag names -> values (partial: omitted keys keep their current
+  // value) and get a gz.msgs.Boolean ack. The change is queued here and applied
+  // on the ECM thread in PreUpdate.
+  std::string worldName;
+  if (auto *nameComp =
+        _ecm.Component<components::Name>(this->dataPtr->worldEnt))
+    worldName = nameComp->Data();
+  const std::string service =
+    "/world/" + worldName + "/wave/set_parameters";
+  if (this->dataPtr->node.Advertise(service,
+        &Implementation::OnSetParameters, this->dataPtr.get()))
+  {
+    gzmsg << "[Waves] runtime parameter service: " << service
+          << " (gz.msgs.Param -> gz.msgs.Boolean)" << '\n';
+  }
+  else
+  {
+    gzwarn << "[Waves] failed to advertise '" << service << "'" << '\n';
+  }
+
+  gzmsg << "[Waves] wavefield component created on world entity "
+        << this->dataPtr->worldEnt
+        << " (algorithm=" << this->dataPtr->data.algorithm
+        << ", model=" << this->dataPtr->data.params.model
+        << ", seaState=" << this->dataPtr->data.params.seaState
+        << ", generation=" << this->dataPtr->data.generation << ")"
+        << '\n';
+}
+
+//////////////////////////////////////////////////
+void WavesSystemBase::PreUpdate(
+  const UpdateInfo &_info,
+  EntityComponentManager &_ecm)
+{
+  if (!this->dataPtr->data.simulation)
+    return;
+
+  // Drain any runtime parameter update queued by the set_parameters service.
+  this->dataPtr->ApplyPendingParams(_ecm);
+
+  const double simTime = std::chrono::duration<double>(
+    _info.simTime).count();
+
+  // The Wavefield component serializes recipe-only, so any ECM deserialize —
+  // a reset's state restore or a SceneBroadcaster replication round-trip —
+  // clears the component's live engine pointer (operator>>). Server-side
+  // consumers (e.g. WaveBuoyancy) read the engine straight out of the
+  // component, so re-point it at our authoritative, always-advanced instance
+  // whenever the ECM has cleared it. Without this the buoy samples flat water
+  // and stops responding to the waves after a reset. (World systems run before
+  // model systems, so the buoy sees the restored pointer the same tick.)
+  if (auto *comp =
+        _ecm.Component<components::Wavefield>(this->dataPtr->worldEnt);
+      comp && !comp->Data().simulation)
+  {
+    comp->Data().simulation = this->dataPtr->data.simulation;
+  }
+
+  // Throttle backend updates. Analytic Gerstner has a no-op Update(); FFT
+  // regenerates the height grid each call (~ms at 128²). Skip entirely while
+  // paused — the field is frozen, so there's nothing to advance, and consumers
+  // (e.g. WaveBuoyancy) advance the field themselves, so correctness no longer
+  // depends on this call landing in any particular tick.
+  const double updatePeriod =
+    this->dataPtr->updateRate > 0.0 ? 1.0 / this->dataPtr->updateRate : 0.0;
+  if (!_info.paused &&
+      simTime - this->dataPtr->lastUpdateTime >= updatePeriod)
+  {
+    this->dataPtr->data.simulation->Update(simTime);
+    this->dataPtr->lastUpdateTime = simTime;
+  }
+}
+
+//////////////////////////////////////////////////
+void WavesSystemBase::Reset(
+  const UpdateInfo & /*_info*/, EntityComponentManager & /*_ecm*/)
+{
+  // A reset rewinds sim time to 0. PreUpdate's throttle gates on
+  // (simTime - lastUpdateTime >= period); with a stale lastUpdateTime it stays
+  // false until sim time catches back up, so the engine never advances and the
+  // field freezes. Rewind the throttle so the field advances from t = 0 again.
+  this->dataPtr->lastUpdateTime = -1.0;
+  gzmsg << "[Waves] reset: re-advancing the wave field from t=0" << '\n';
+}
+
+//////////////////////////////////////////////////
+void WavesSystemBase::Implementation::ApplyPendingParams(
+  EntityComponentManager &_ecm)
+{
+  waves::WaveParameters params;
+  {
+    const std::lock_guard<std::mutex> lock(this->paramMutex);
+    if (!this->pendingParams)
+      return;
+    params = *this->pendingParams;
+    this->pendingParams.reset();
+    this->currentParams = params;
+  }
+
+  // Reconfigure the server-side engine in place. WaveBuoyancy reads this same
+  // instance out of the component each tick, so it picks up the change with no
+  // extra signalling; WaterVisual (GUI) rebuilds its own engine off the bumped
+  // generation below. `data` is touched only on this (ECM) thread.
+  this->data.params = params;
+  this->data.simulation->SetParameters(params);
+  this->data.generation += 1;
+  this->lastUpdateTime = -1.0;  // advance the field next tick, unthrottled
+
+  if (auto *comp = _ecm.Component<components::Wavefield>(this->worldEnt))
+  {
+    comp->Data() = this->data;
+    _ecm.SetChanged(this->worldEnt, this->componentType,
+                    ComponentState::OneTimeChange);
+  }
+
+  gzmsg << "[Waves] runtime parameters applied (generation="
+        << this->data.generation << ", model=" << params.model
+        << ", seaState=" << params.seaState << ")" << '\n';
+}
+
+//////////////////////////////////////////////////
+bool WavesSystemBase::Implementation::OnSetParameters(
+  const gz::msgs::Param &_req, gz::msgs::Boolean &_rep)
+{
+  bool matched = false;
+  {
+    const std::lock_guard<std::mutex> lock(this->paramMutex);
+    const waves::WaveParameters base =
+      this->pendingParams ? *this->pendingParams : this->currentParams;
+    const waves::WaveParameters updated = ApplyParam(base, _req, matched);
+    if (matched)
+      this->pendingParams = updated;
+  }
+  if (!matched)
+    gzwarn << "[Waves] set_parameters: no recognised wave parameter keys"
+           << '\n';
+  _rep.set_data(matched);
+  return true;
+}
+
+}  // namespace gz::sim::systems

--- a/gz_waves/src/systems/WavesSystemBase.cc
+++ b/gz_waves/src/systems/WavesSystemBase.cc
@@ -27,6 +27,7 @@
 
 #include "gz/sim/components/Name.hh"
 #include "gz/sim/components/Wavefield.hh"
+#include "gz/sim/waves/Eval.hh"  // Advance(): the field-query facade
 #include "gz/sim/waves/Wavefield.hh"
 #include "gz/sim/waves/WaveSimulation.hh"  // drives the engine (producer side)
 
@@ -262,6 +263,8 @@ void WavesSystemBase::Configure(
   EntityComponentManager &_ecm,
   EventManager &/*_eventMgr*/)
 {
+  // ParseSdf only reads _sdf; the const_cast is solely to satisfy
+  // sdf::Element::Get/GetElement, whose signatures are non-const.
   this->dataPtr->ParseSdf(
     std::const_pointer_cast<sdf::Element>(_sdf));
 
@@ -363,7 +366,7 @@ void WavesSystemBase::PreUpdate(
   if (!_info.paused &&
       simTime - this->dataPtr->lastUpdateTime >= updatePeriod)
   {
-    this->dataPtr->data.simulation->Update(simTime);
+    waves::Advance(this->dataPtr->data, simTime);
     this->dataPtr->lastUpdateTime = simTime;
   }
 }

--- a/gz_waves/test/wave_core_test.cc
+++ b/gz_waves/test/wave_core_test.cc
@@ -221,19 +221,45 @@ TEST(Registry, NullFactoryReturnsNull)
 // Wavefield serialization — operator<< / operator>> (Wavefield.hh)
 // ===========================================================================
 //////////////////////////////////////////////////
-TEST(Serialization, RoundTripsRecipeAndDropsEngine)
+TEST(Serialization, RoundTripsEveryFieldAndDropsEngine)
 {
+  // Set every field to a distinct non-default value, with doubles chosen to
+  // need full precision, so a field forgotten in operator<< / operator>> (or a
+  // precision-losing serializer) is caught. Keep this in sync with the struct.
   gsw::WavefieldData in;
   in.algorithm = "stub";
   in.generation = 9;
-  in.params.model = "CWR";
-  in.params.period = 3.5;
-  in.params.gain = 0.8;
-  in.params.spectrum = "jonswap";
-  in.params.dispersion = "finite";
-  in.params.gridSize = 256;
-  in.params.seaState = 4;
-  in.params.filterInvert = true;
+  in.updateRate = 17.5;
+  auto &p = in.params;
+  p.model = "CWR";
+  p.number = 7;
+  p.period = 3.141592653589793;
+  p.amplitude = 0.123456789012345;
+  p.direction = 1.234567890123456;
+  p.angle = 0.456789012345678;
+  p.scale = 1.098765432109876;
+  p.steepness = 0.246802468024680;
+  p.phase = 2.718281828459045;
+  p.tau = 1.414213562373095;
+  p.gain = 0.876543210987654;
+  p.tileSize = 222.222222222222;
+  p.gridSize = 256;
+  p.seed = 4242424242u;
+  p.choppiness = -1.732050807568877;
+  p.spectrum = "jonswap";
+  p.spreading = "mitsuyasu";
+  p.dispersion = "finite";
+  p.depth = 88.8888888888888;
+  p.fetch = 321.987654321098;
+  p.swell = 0.314159265358979;
+  p.troughDamping = 0.271828182845904;
+  p.filterMinWavelength = 12.3456789012345;
+  p.filterMaxWavelength = 98.7654321098765;
+  p.filterSoftWidth = 3.33333333333333;
+  p.filterMin = 0.135792468013579;
+  p.filterInvert = true;
+  p.seaState = 6;
+  p.gravity = 9.806649999999999;
   in.simulation = std::make_shared<StubWaveField>();  // must NOT serialize
 
   std::stringstream ss;
@@ -241,17 +267,69 @@ TEST(Serialization, RoundTripsRecipeAndDropsEngine)
   gsw::WavefieldData out;
   ss >> out;
 
-  EXPECT_EQ(out.algorithm, "stub");
-  EXPECT_EQ(out.generation, 9u);
-  EXPECT_EQ(out.params.model, "CWR");
-  EXPECT_DOUBLE_EQ(out.params.period, 3.5);
-  EXPECT_DOUBLE_EQ(out.params.gain, 0.8);
-  EXPECT_EQ(out.params.spectrum, "jonswap");
-  EXPECT_EQ(out.params.dispersion, "finite");
-  EXPECT_EQ(out.params.gridSize, 256u);
-  EXPECT_EQ(out.params.seaState, 4);
-  EXPECT_TRUE(out.params.filterInvert);
+  EXPECT_EQ(out.algorithm, in.algorithm);
+  EXPECT_EQ(out.generation, in.generation);
+  EXPECT_DOUBLE_EQ(out.updateRate, in.updateRate);
+  const auto &q = out.params;
+  EXPECT_EQ(q.model, p.model);
+  EXPECT_EQ(q.number, p.number);
+  EXPECT_DOUBLE_EQ(q.period, p.period);
+  EXPECT_DOUBLE_EQ(q.amplitude, p.amplitude);
+  EXPECT_DOUBLE_EQ(q.direction, p.direction);
+  EXPECT_DOUBLE_EQ(q.angle, p.angle);
+  EXPECT_DOUBLE_EQ(q.scale, p.scale);
+  EXPECT_DOUBLE_EQ(q.steepness, p.steepness);
+  EXPECT_DOUBLE_EQ(q.phase, p.phase);
+  EXPECT_DOUBLE_EQ(q.tau, p.tau);
+  EXPECT_DOUBLE_EQ(q.gain, p.gain);
+  EXPECT_DOUBLE_EQ(q.tileSize, p.tileSize);
+  EXPECT_EQ(q.gridSize, p.gridSize);
+  EXPECT_EQ(q.seed, p.seed);
+  EXPECT_DOUBLE_EQ(q.choppiness, p.choppiness);
+  EXPECT_EQ(q.spectrum, p.spectrum);
+  EXPECT_EQ(q.spreading, p.spreading);
+  EXPECT_EQ(q.dispersion, p.dispersion);
+  EXPECT_DOUBLE_EQ(q.depth, p.depth);
+  EXPECT_DOUBLE_EQ(q.fetch, p.fetch);
+  EXPECT_DOUBLE_EQ(q.swell, p.swell);
+  EXPECT_DOUBLE_EQ(q.troughDamping, p.troughDamping);
+  EXPECT_DOUBLE_EQ(q.filterMinWavelength, p.filterMinWavelength);
+  EXPECT_DOUBLE_EQ(q.filterMaxWavelength, p.filterMaxWavelength);
+  EXPECT_DOUBLE_EQ(q.filterSoftWidth, p.filterSoftWidth);
+  EXPECT_DOUBLE_EQ(q.filterMin, p.filterMin);
+  EXPECT_TRUE(q.filterInvert);
+  EXPECT_EQ(q.seaState, p.seaState);
+  EXPECT_DOUBLE_EQ(q.gravity, p.gravity);
   EXPECT_EQ(out.simulation, nullptr);  // recipe-only: engine is rebuilt later
+}
+
+//////////////////////////////////////////////////
+// String fields go through std::quoted, so an empty value or one containing a
+// space (both reachable via the set_parameters service) round-trips without
+// desyncing the positional field stream and corrupting later fields.
+TEST(Serialization, QuotedStringsSurviveSpacesAndEmpty)
+{
+  gsw::WavefieldData in;
+  in.algorithm = "stub";
+  in.params.model = "";                 // empty
+  in.params.spectrum = "two words";     // embedded space
+  in.params.spreading = "";             // empty
+  in.params.dispersion = "a b c";       // embedded spaces
+  in.params.seaState = 5;               // a field *after* the strings
+  in.params.gravity = 9.81;
+
+  std::stringstream ss;
+  ss << in;
+  gsw::WavefieldData out;
+  ss >> out;
+
+  EXPECT_EQ(out.params.model, "");
+  EXPECT_EQ(out.params.spectrum, "two words");
+  EXPECT_EQ(out.params.spreading, "");
+  EXPECT_EQ(out.params.dispersion, "a b c");
+  // The trailing fields are still aligned despite the awkward strings.
+  EXPECT_EQ(out.params.seaState, 5);
+  EXPECT_DOUBLE_EQ(out.params.gravity, 9.81);
 }
 
 // ===========================================================================

--- a/gz_waves/test/wave_core_test.cc
+++ b/gz_waves/test/wave_core_test.cc
@@ -58,16 +58,16 @@ class StubWaveField : public gsw::IWaveField
     return _x + _y + _t;
   }
   /// \brief Particle velocity = (x, y, t).
-  public: Eigen::Vector3d ParticleVelocity(
+  public: gz::math::Vector3d ParticleVelocity(
     double _x, double _y, double _t) const override
   {
     return {_x, _y, _t};
   }
   /// \brief A fixed +Z unit normal.
-  public: Eigen::Vector3d Normal(
+  public: gz::math::Vector3d Normal(
     double /*_x*/, double /*_y*/, double /*_t*/) const override
   {
-    return Eigen::Vector3d(0.0, 0.0, 2.0).normalized();
+    return gz::math::Vector3d(0.0, 0.0, 2.0).Normalized();
   }
   /// \brief Returns the settable `jac` test value.
   public: double Jacobian(
@@ -141,10 +141,10 @@ TEST(Eval, ForwardsToEngine)
 
   EXPECT_DOUBLE_EQ(gsw::SurfaceElevation(wf, 1.0, 2.0, 3.0), 6.0);
   const auto v = gsw::ParticleVelocity(wf, 1.0, 2.0, 3.0);
-  EXPECT_DOUBLE_EQ(v.x(), 1.0);
-  EXPECT_DOUBLE_EQ(v.z(), 3.0);
+  EXPECT_DOUBLE_EQ(v.X(), 1.0);
+  EXPECT_DOUBLE_EQ(v.Z(), 3.0);
   const auto n = gsw::Normal(wf, 0.0, 0.0, 0.0);
-  EXPECT_NEAR(n.norm(), 1.0, 1e-12);
+  EXPECT_NEAR(n.Length(), 1.0, 1e-12);
   EXPECT_DOUBLE_EQ(gsw::Jacobian(wf, 0.0, 0.0, 0.0), 1.0);
 
   gsw::Advance(wf, 7.5);
@@ -161,8 +161,8 @@ TEST(Eval, NullEngineFallsBackToStillWater)
   ASSERT_EQ(wf.simulation, nullptr);
 
   EXPECT_DOUBLE_EQ(gsw::SurfaceElevation(wf, 1.0, 2.0, 3.0), 0.0);
-  EXPECT_EQ(gsw::ParticleVelocity(wf, 1.0, 2.0, 3.0), Eigen::Vector3d::Zero());
-  EXPECT_EQ(gsw::Normal(wf, 1.0, 2.0, 3.0), Eigen::Vector3d::UnitZ());
+  EXPECT_EQ(gsw::ParticleVelocity(wf, 1.0, 2.0, 3.0), gz::math::Vector3d::Zero);
+  EXPECT_EQ(gsw::Normal(wf, 1.0, 2.0, 3.0), gz::math::Vector3d::UnitZ);
   EXPECT_DOUBLE_EQ(gsw::Jacobian(wf, 1.0, 2.0, 3.0), 1.0);
   EXPECT_DOUBLE_EQ(gsw::FoamMask(wf, 1.0, 2.0, 3.0), 0.0);
   gsw::Advance(wf, 1.0);  // no-op, must not crash

--- a/gz_waves/test/wave_core_test.cc
+++ b/gz_waves/test/wave_core_test.cc
@@ -1,0 +1,614 @@
+/*
+ * Copyright (C) 2026 Honu Robotics
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Unit tests for the gz_waves *core* — the engine-agnostic contract. The core
+// can't link a real engine (that would be a dependency cycle), so these tests
+// supply a tiny stub IWaveField and a stub WavesSystemBase subclass and drive
+// everything — Eval, the factory registry, Wavefield serialization, the
+// sea-state helpers, and the source-system plumbing (Configure / PreUpdate /
+// Reset / the set_parameters service) — through a real EntityComponentManager.
+
+#include <chrono>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <gz/math/Vector3.hh>
+#include <gz/msgs/boolean.pb.h>
+#include <gz/msgs/param.pb.h>
+#include <gz/transport/Node.hh>
+#include <sdf/Element.hh>
+#include <sdf/Root.hh>
+
+#include "gz/sim/EntityComponentManager.hh"
+#include "gz/sim/EventManager.hh"
+#include "gz/sim/Util.hh"
+#include "gz/sim/World.hh"
+#include "gz/sim/components/Gravity.hh"
+#include "gz/sim/components/Name.hh"
+#include "gz/sim/components/Wavefield.hh"
+#include "gz/sim/components/World.hh"
+#include "gz/sim/systems/WavesSystemBase.hh"
+#include "gz/sim/waves/Eval.hh"
+#include "gz/sim/waves/WaveSimulation.hh"
+#include "gz/sim/waves/Wavefield.hh"
+
+namespace gsw = gz::sim::waves;
+
+namespace
+{
+/// \brief A minimal `IWaveField` stub: deterministic and instrumented. Returns
+/// values built from its arguments so tests can confirm `Eval` forwards
+/// (x, y, t) faithfully, and counts `Update`/`SetParameters` calls.
+class StubWaveField : public gsw::IWaveField
+{
+  /// \brief Elevation = x + y + t, so callers can verify Eval forwards args.
+  public: double Elevation(double _x, double _y, double _t) const override
+  {
+    return _x + _y + _t;
+  }
+  /// \brief Particle velocity = (x, y, t).
+  public: Eigen::Vector3d ParticleVelocity(
+    double _x, double _y, double _t) const override
+  {
+    return {_x, _y, _t};
+  }
+  /// \brief A fixed +Z unit normal.
+  public: Eigen::Vector3d Normal(
+    double /*_x*/, double /*_y*/, double /*_t*/) const override
+  {
+    return Eigen::Vector3d(0.0, 0.0, 2.0).normalized();
+  }
+  /// \brief Returns the settable `jac` test value.
+  public: double Jacobian(
+    double /*_x*/, double /*_y*/, double /*_t*/) const override
+  {
+    return this->jac;
+  }
+  /// \brief Record the params and count the call.
+  public: void SetParameters(const gsw::WaveParameters &_p) override
+  {
+    this->lastParams = _p;
+    ++this->setParamsCount;
+  }
+  /// \brief Record the time and count the call.
+  public: void Update(double _t) override
+  {
+    this->lastUpdate = _t;
+    ++this->updateCount;
+  }
+  /// \brief Backend token.
+  public: std::string_view Kind() const override { return "stub"; }
+
+  /// \brief Value returned by Jacobian() (drives FoamMask in the tests).
+  public: double jac{1.0};
+  /// \brief Params seen by the last SetParameters() call.
+  public: gsw::WaveParameters lastParams;
+  /// \brief Number of SetParameters() calls.
+  public: int setParamsCount{0};
+  /// \brief Time seen by the last Update() call.
+  public: double lastUpdate{-1.0};
+  /// \brief Number of Update() calls.
+  public: int updateCount{0};
+};
+
+/// \brief A stub source system: selects the "stub" engine and builds one.
+class StubWavesSystem : public gz::sim::systems::WavesSystemBase
+{
+  /// \brief The engine token recorded in the component.
+  protected: std::string EngineToken() const override { return "stub"; }
+  /// \brief Build and configure a StubWaveField from `_p`.
+  protected: std::shared_ptr<gsw::IWaveField> MakeEngine(
+    const gsw::WaveParameters &_p) const override
+  {
+    auto engine = std::make_shared<StubWaveField>();
+    engine->SetParameters(_p);
+    return engine;
+  }
+};
+
+// Register factories used by the registry tests (one good, one that returns
+// null). Done once at static init.
+const bool kRegistered = []
+{
+  gsw::RegisterWaveEngineFactory("stub",
+    [] { return std::static_pointer_cast<gsw::IWaveField>(
+           std::make_shared<StubWaveField>()); });
+  gsw::RegisterWaveEngineFactory("null-factory",
+    [] { return std::shared_ptr<gsw::IWaveField>(nullptr); });
+  return true;
+}();
+}  // namespace
+
+// ===========================================================================
+// Eval — the consumer query facade (Eval.cc)
+// ===========================================================================
+//////////////////////////////////////////////////
+TEST(Eval, ForwardsToEngine)
+{
+  gsw::WavefieldData wf;
+  wf.simulation = std::make_shared<StubWaveField>();
+
+  EXPECT_DOUBLE_EQ(gsw::SurfaceElevation(wf, 1.0, 2.0, 3.0), 6.0);
+  const auto v = gsw::ParticleVelocity(wf, 1.0, 2.0, 3.0);
+  EXPECT_DOUBLE_EQ(v.x(), 1.0);
+  EXPECT_DOUBLE_EQ(v.z(), 3.0);
+  const auto n = gsw::Normal(wf, 0.0, 0.0, 0.0);
+  EXPECT_NEAR(n.norm(), 1.0, 1e-12);
+  EXPECT_DOUBLE_EQ(gsw::Jacobian(wf, 0.0, 0.0, 0.0), 1.0);
+
+  gsw::Advance(wf, 7.5);
+  EXPECT_EQ(
+    static_cast<StubWaveField *>(wf.simulation.get())->updateCount, 1);
+  EXPECT_DOUBLE_EQ(
+    static_cast<StubWaveField *>(wf.simulation.get())->lastUpdate, 7.5);
+}
+
+//////////////////////////////////////////////////
+TEST(Eval, NullEngineFallsBackToStillWater)
+{
+  gsw::WavefieldData wf;  // no simulation
+  ASSERT_EQ(wf.simulation, nullptr);
+
+  EXPECT_DOUBLE_EQ(gsw::SurfaceElevation(wf, 1.0, 2.0, 3.0), 0.0);
+  EXPECT_EQ(gsw::ParticleVelocity(wf, 1.0, 2.0, 3.0), Eigen::Vector3d::Zero());
+  EXPECT_EQ(gsw::Normal(wf, 1.0, 2.0, 3.0), Eigen::Vector3d::UnitZ());
+  EXPECT_DOUBLE_EQ(gsw::Jacobian(wf, 1.0, 2.0, 3.0), 1.0);
+  EXPECT_DOUBLE_EQ(gsw::FoamMask(wf, 1.0, 2.0, 3.0), 0.0);
+  gsw::Advance(wf, 1.0);  // no-op, must not crash
+}
+
+//////////////////////////////////////////////////
+TEST(Eval, FoamMaskFromJacobian)
+{
+  gsw::WavefieldData wf;
+  auto stub = std::make_shared<StubWaveField>();
+  wf.simulation = stub;
+
+  stub->jac = 1.0;  // unfolded -> no foam
+  EXPECT_DOUBLE_EQ(gsw::FoamMask(wf, 0, 0, 0, 0.6), 0.0);
+  stub->jac = 0.6;  // exactly at threshold -> no foam
+  EXPECT_DOUBLE_EQ(gsw::FoamMask(wf, 0, 0, 0, 0.6), 0.0);
+  stub->jac = 0.3;  // half-folded
+  EXPECT_NEAR(gsw::FoamMask(wf, 0, 0, 0, 0.6), 0.5, 1e-12);
+  stub->jac = 0.0;  // fully folded
+  EXPECT_DOUBLE_EQ(gsw::FoamMask(wf, 0, 0, 0, 0.6), 1.0);
+  stub->jac = -1.0;  // beyond folded -> clamped to 1
+  EXPECT_DOUBLE_EQ(gsw::FoamMask(wf, 0, 0, 0, 0.6), 1.0);
+}
+
+// ===========================================================================
+// Registry — RegisterWaveEngineFactory / CreateWaveSimulation (WaveSimulation.cc)
+// ===========================================================================
+//////////////////////////////////////////////////
+TEST(Registry, BuildsAndConfigures)
+{
+  gsw::WaveParameters p;
+  p.period = 4.2;
+  auto sim = gsw::CreateWaveSimulation("stub", p);
+  ASSERT_NE(sim, nullptr);
+  EXPECT_EQ(sim->Kind(), "stub");
+  // CreateWaveSimulation must call SetParameters with our params.
+  EXPECT_DOUBLE_EQ(
+    static_cast<StubWaveField *>(sim.get())->lastParams.period, 4.2);
+  EXPECT_EQ(static_cast<StubWaveField *>(sim.get())->setParamsCount, 1);
+}
+
+//////////////////////////////////////////////////
+TEST(Registry, UnknownTokenReturnsNull)
+{
+  EXPECT_EQ(gsw::CreateWaveSimulation("nope", gsw::WaveParameters{}), nullptr);
+}
+
+//////////////////////////////////////////////////
+TEST(Registry, NullFactoryReturnsNull)
+{
+  EXPECT_EQ(gsw::CreateWaveSimulation("null-factory", gsw::WaveParameters{}),
+            nullptr);
+}
+
+// ===========================================================================
+// Wavefield serialization — operator<< / operator>> (Wavefield.hh)
+// ===========================================================================
+//////////////////////////////////////////////////
+TEST(Serialization, RoundTripsRecipeAndDropsEngine)
+{
+  gsw::WavefieldData in;
+  in.algorithm = "stub";
+  in.generation = 9;
+  in.params.model = "CWR";
+  in.params.period = 3.5;
+  in.params.gain = 0.8;
+  in.params.spectrum = "jonswap";
+  in.params.dispersion = "finite";
+  in.params.gridSize = 256;
+  in.params.seaState = 4;
+  in.params.filterInvert = true;
+  in.simulation = std::make_shared<StubWaveField>();  // must NOT serialize
+
+  std::stringstream ss;
+  ss << in;
+  gsw::WavefieldData out;
+  ss >> out;
+
+  EXPECT_EQ(out.algorithm, "stub");
+  EXPECT_EQ(out.generation, 9u);
+  EXPECT_EQ(out.params.model, "CWR");
+  EXPECT_DOUBLE_EQ(out.params.period, 3.5);
+  EXPECT_DOUBLE_EQ(out.params.gain, 0.8);
+  EXPECT_EQ(out.params.spectrum, "jonswap");
+  EXPECT_EQ(out.params.dispersion, "finite");
+  EXPECT_EQ(out.params.gridSize, 256u);
+  EXPECT_EQ(out.params.seaState, 4);
+  EXPECT_TRUE(out.params.filterInvert);
+  EXPECT_EQ(out.simulation, nullptr);  // recipe-only: engine is rebuilt later
+}
+
+// ===========================================================================
+// Helpers — StartupRamp / SeaStateFromCode / WithSeaState (Wavefield.hh)
+// ===========================================================================
+//////////////////////////////////////////////////
+TEST(Helpers, StartupRamp)
+{
+  EXPECT_DOUBLE_EQ(gsw::StartupRamp(5.0, 0.0), 1.0);   // disabled
+  EXPECT_DOUBLE_EQ(gsw::StartupRamp(5.0, -1.0), 1.0);  // disabled
+  EXPECT_DOUBLE_EQ(gsw::StartupRamp(0.0, 2.0), 0.0);   // t=0
+  EXPECT_NEAR(gsw::StartupRamp(2.0, 2.0), 1.0 - std::exp(-1.0), 1e-12);
+  EXPECT_GT(gsw::StartupRamp(4.0, 2.0), gsw::StartupRamp(2.0, 2.0));
+}
+
+//////////////////////////////////////////////////
+TEST(Helpers, SeaStateFromCode)
+{
+  gsw::SeaStateSpec s;
+  EXPECT_TRUE(gsw::SeaStateFromCode(0, s));
+  EXPECT_DOUBLE_EQ(s.significantWaveHeight, 0.0);
+  EXPECT_TRUE(gsw::SeaStateFromCode(5, s));
+  EXPECT_GT(s.significantWaveHeight, 0.0);
+  EXPECT_GT(s.peakPeriod, 0.0);
+  EXPECT_GT(s.windSpeed, 0.0);
+
+  gsw::SeaStateSpec untouched;
+  EXPECT_FALSE(gsw::SeaStateFromCode(-1, untouched));
+  EXPECT_FALSE(gsw::SeaStateFromCode(10, untouched));
+  EXPECT_DOUBLE_EQ(untouched.significantWaveHeight, 0.0);
+}
+
+//////////////////////////////////////////////////
+TEST(Helpers, WithSeaState)
+{
+  gsw::WaveParameters unset;  // seaState defaults to -1
+  unset.period = 7.0;
+  EXPECT_DOUBLE_EQ(gsw::WithSeaState(unset).period, 7.0);  // unchanged
+
+  gsw::WaveParameters calm;
+  calm.seaState = 0;
+  EXPECT_DOUBLE_EQ(gsw::WithSeaState(calm).gain, 0.0);  // glassy
+
+  gsw::WaveParameters rough;
+  rough.seaState = 5;
+  rough.model = "CWR";
+  const auto applied = gsw::WithSeaState(rough);
+  EXPECT_DOUBLE_EQ(applied.gain, 1.0);
+  EXPECT_GT(applied.period, 0.0);
+  EXPECT_GT(applied.amplitude, 0.0);  // CWR sets amplitude = Hs/2
+
+  gsw::WaveParameters bad;
+  bad.seaState = 99;  // out of range -> unchanged
+  bad.period = 6.0;
+  EXPECT_DOUBLE_EQ(gsw::WithSeaState(bad).period, 6.0);
+}
+
+// ===========================================================================
+// WavesSystemBase — the source-system plumbing, driven through a real ECM
+// ===========================================================================
+/// \brief Fixture for the `WavesSystemBase` tests: a world entity carrying the
+/// components `Configure` needs (World/Name/Gravity), plus helpers to build the
+/// plugin SDF element and `UpdateInfo` values.
+class WavesSystemTest : public ::testing::Test
+{
+  /// \brief Create the world entity with the World/Name/Gravity components
+  /// Configure reads.
+  protected: void SetUp() override
+  {
+    this->world = this->ecm.CreateEntity();
+    this->ecm.CreateComponent(this->world, gz::sim::components::World());
+    this->ecm.CreateComponent(this->world,
+      gz::sim::components::Name("test_world"));
+    this->ecm.CreateComponent(this->world,
+      gz::sim::components::Gravity(gz::math::Vector3d(0.0, 0.0, -9.8)));
+  }
+
+  /// \brief Build the plugin's SDF element (kept alive for the test via
+  /// `roots`).
+  /// \param[in] _inner The XML inside the `<plugin>` element.
+  /// \return The parsed `<plugin>` element.
+  protected: sdf::ElementPtr Plugin(const std::string &_inner)
+  {
+    auto root = std::make_shared<sdf::Root>();
+    const std::string xml =
+      "<sdf version='1.9'><world name='test_world'>"
+      "<plugin name='waves' filename='libstub.so'>" + _inner +
+      "</plugin></world></sdf>";
+    const auto errs = root->LoadSdfString(xml);
+    EXPECT_TRUE(errs.empty());
+    this->roots.push_back(root);
+    return root->WorldByIndex(0)->Element()->GetElement("plugin");
+  }
+
+  /// \brief Build an UpdateInfo at sim time `_t` [s], optionally paused.
+  /// \param[in] _t      Simulation time [s].
+  /// \param[in] _paused Whether the update is paused.
+  /// \return The populated UpdateInfo.
+  protected: static gz::sim::UpdateInfo Info(double _t, bool _paused = false)
+  {
+    gz::sim::UpdateInfo info;
+    info.simTime =
+      std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+        std::chrono::duration<double>(_t));
+    info.paused = _paused;
+    return info;
+  }
+
+  /// \brief The Wavefield component on the world entity, or null if absent.
+  protected: const gz::sim::components::Wavefield *Comp()
+  {
+    return this->ecm.Component<gz::sim::components::Wavefield>(this->world);
+  }
+
+  /// \brief The entity-component manager under test.
+  protected: gz::sim::EntityComponentManager ecm;
+  /// \brief Event manager passed to Configure.
+  protected: gz::sim::EventManager evm;
+  /// \brief The world entity carrying the Wavefield component.
+  protected: gz::sim::Entity world{gz::sim::kNullEntity};
+  /// \brief Keeps parsed SDF roots alive for the duration of a test.
+  protected: std::vector<std::shared_ptr<sdf::Root>> roots;
+};
+
+//////////////////////////////////////////////////
+TEST_F(WavesSystemTest, ConfigureParsesSdfAndWritesComponent)
+{
+  StubWavesSystem sys;
+  sys.Configure(this->world, this->Plugin(
+    "<update_rate>40</update_rate>"
+    "<wave><model>CWR</model><period>3.0</period><gain>0.7</gain>"
+    "<grid_size>64</grid_size><spectrum>pms</spectrum>"
+    "<sea_state>2</sea_state><filter_invert>true</filter_invert></wave>"),
+    this->ecm, this->evm);
+
+  const auto *comp = this->Comp();
+  ASSERT_NE(comp, nullptr);
+  EXPECT_EQ(comp->Data().algorithm, "stub");
+  EXPECT_EQ(comp->Data().generation, 1u);
+  EXPECT_DOUBLE_EQ(comp->Data().updateRate, 40.0);
+  EXPECT_EQ(comp->Data().params.model, "CWR");
+  EXPECT_DOUBLE_EQ(comp->Data().params.period, 3.0);
+  EXPECT_EQ(comp->Data().params.gridSize, 64u);
+  EXPECT_EQ(comp->Data().params.spectrum, "pms");
+  EXPECT_EQ(comp->Data().params.seaState, 2);
+  EXPECT_TRUE(comp->Data().params.filterInvert);
+  // Gravity taken from the world's Gravity component.
+  EXPECT_DOUBLE_EQ(comp->Data().params.gravity, 9.8);
+  // The engine was built and configured with the parsed params.
+  auto *engine = dynamic_cast<StubWaveField *>(comp->Data().simulation.get());
+  ASSERT_NE(engine, nullptr);
+  EXPECT_DOUBLE_EQ(engine->lastParams.period, 3.0);
+}
+
+//////////////////////////////////////////////////
+TEST_F(WavesSystemTest, ConfigureWithoutWaveUsesDefaults)
+{
+  StubWavesSystem sys;
+  sys.Configure(this->world, this->Plugin("<update_rate>15</update_rate>"),
+    this->ecm, this->evm);
+
+  const auto *comp = this->Comp();
+  ASSERT_NE(comp, nullptr);
+  EXPECT_DOUBLE_EQ(comp->Data().updateRate, 15.0);
+  EXPECT_EQ(comp->Data().params.model, gsw::WaveParameters{}.model);
+  EXPECT_DOUBLE_EQ(comp->Data().params.period, gsw::WaveParameters{}.period);
+}
+
+//////////////////////////////////////////////////
+TEST_F(WavesSystemTest, PreUpdateAdvancesEngineWithThrottle)
+{
+  StubWavesSystem sys;
+  sys.Configure(this->world,
+    this->Plugin("<update_rate>40</update_rate>"), this->ecm, this->evm);
+  auto *engine = dynamic_cast<StubWaveField *>(this->Comp()->Data().simulation.get());
+  ASSERT_NE(engine, nullptr);
+
+  sys.PreUpdate(this->Info(1.000), this->ecm);   // advances
+  EXPECT_EQ(engine->updateCount, 1);
+  EXPECT_DOUBLE_EQ(engine->lastUpdate, 1.0);
+  sys.PreUpdate(this->Info(1.010), this->ecm);   // < 1/40 s later -> throttled
+  EXPECT_EQ(engine->updateCount, 1);
+  sys.PreUpdate(this->Info(1.050), this->ecm);   // enough elapsed -> advances
+  EXPECT_EQ(engine->updateCount, 2);
+  sys.PreUpdate(this->Info(2.0, /*paused=*/true), this->ecm);  // paused -> skip
+  EXPECT_EQ(engine->updateCount, 2);
+}
+
+//////////////////////////////////////////////////
+TEST_F(WavesSystemTest, PreUpdateRepointsClearedEngine)
+{
+  StubWavesSystem sys;
+  sys.Configure(this->world,
+    this->Plugin("<update_rate>40</update_rate>"), this->ecm, this->evm);
+
+  // Simulate an ECM deserialize (operator>> nulls the engine pointer).
+  this->ecm.Component<gz::sim::components::Wavefield>(this->world)
+    ->Data().simulation.reset();
+  sys.PreUpdate(this->Info(1.0), this->ecm);
+  EXPECT_NE(this->Comp()->Data().simulation, nullptr);  // re-pointed
+}
+
+//////////////////////////////////////////////////
+TEST_F(WavesSystemTest, ResetRewindsThrottle)
+{
+  StubWavesSystem sys;
+  sys.Configure(this->world,
+    this->Plugin("<update_rate>40</update_rate>"), this->ecm, this->evm);
+  auto *engine = dynamic_cast<StubWaveField *>(this->Comp()->Data().simulation.get());
+  ASSERT_NE(engine, nullptr);
+
+  sys.PreUpdate(this->Info(5.0), this->ecm);
+  EXPECT_EQ(engine->updateCount, 1);
+  sys.Reset(this->Info(0.0), this->ecm);          // rewind throttle
+  sys.PreUpdate(this->Info(0.001), this->ecm);    // small t, but advances again
+  EXPECT_EQ(engine->updateCount, 2);
+}
+
+//////////////////////////////////////////////////
+TEST_F(WavesSystemTest, SetParametersServiceAppliesUpdate)
+{
+  StubWavesSystem sys;
+  sys.Configure(this->world,
+    this->Plugin("<update_rate>40</update_rate><wave><gain>0.1</gain></wave>"),
+    this->ecm, this->evm);
+
+  gz::transport::Node node;
+  gz::msgs::Param req;
+  auto &m = *req.mutable_params();
+  auto anyD = [](double v) { gz::msgs::Any a; a.set_type(gz::msgs::Any::DOUBLE);
+                             a.set_double_value(v); return a; };
+  auto anyS = [](const std::string &v) { gz::msgs::Any a;
+                 a.set_type(gz::msgs::Any::STRING); a.set_string_value(v);
+                 return a; };
+  auto anyI = [](int v) { gz::msgs::Any a; a.set_type(gz::msgs::Any::INT32);
+                          a.set_int_value(v); return a; };
+  m["gain"] = anyD(0.7);
+  m["spectrum"] = anyS("pms");
+  m["grid_size"] = anyI(64);
+  m["sea_state"] = anyI(3);
+  m["filter_invert"] = anyD(1.0);
+  m["number"] = anyI(5);
+  m["unknown_key"] = anyS("ignored");
+
+  gz::msgs::Boolean rep;
+  bool ok = false;
+  const bool got = node.Request(
+    "/world/test_world/wave/set_parameters", req, 5000, rep, ok);
+  ASSERT_TRUE(got);
+  ASSERT_TRUE(ok);
+  EXPECT_TRUE(rep.data());  // at least one key recognised
+
+  // Queued only — not applied until the ECM thread (PreUpdate) drains it.
+  EXPECT_EQ(this->Comp()->Data().generation, 1u);
+  sys.PreUpdate(this->Info(1.0), this->ecm);
+
+  const auto &d = this->Comp()->Data();
+  EXPECT_EQ(d.generation, 2u);
+  EXPECT_DOUBLE_EQ(d.params.gain, 0.7);
+  EXPECT_EQ(d.params.spectrum, "pms");
+  EXPECT_EQ(d.params.gridSize, 64u);
+  EXPECT_EQ(d.params.seaState, 3);
+  EXPECT_TRUE(d.params.filterInvert);
+}
+
+//////////////////////////////////////////////////
+TEST_F(WavesSystemTest, SetParametersServiceRejectsUnknownOnly)
+{
+  StubWavesSystem sys;
+  sys.Configure(this->world,
+    this->Plugin("<update_rate>40</update_rate>"), this->ecm, this->evm);
+
+  gz::transport::Node node;
+  gz::msgs::Param req;
+  gz::msgs::Any a;
+  a.set_type(gz::msgs::Any::STRING);
+  a.set_string_value("x");
+  (*req.mutable_params())["bogus"] = a;
+
+  gz::msgs::Boolean rep;
+  bool ok = false;
+  ASSERT_TRUE(node.Request(
+    "/world/test_world/wave/set_parameters", req, 5000, rep, ok));
+  EXPECT_TRUE(ok);            // the service call itself succeeded
+  EXPECT_FALSE(rep.data());   // but no recognised parameter keys
+}
+
+//////////////////////////////////////////////////
+TEST_F(WavesSystemTest, SetParametersServiceCoercesTypesAndWarns)
+{
+  StubWavesSystem sys;
+  sys.Configure(this->world,
+    this->Plugin("<update_rate>40</update_rate>"), this->ecm, this->evm);
+
+  gz::transport::Node node;
+  gz::msgs::Param req;
+  auto &m = *req.mutable_params();
+  auto any = [](gz::msgs::Any::ValueType _t) { gz::msgs::Any a; a.set_type(_t);
+                                               return a; };
+  { auto a = any(gz::msgs::Any::INT32);   a.set_int_value(7);
+    m["period"] = a; }         // double key fed an int  -> ReadDouble INT32
+  { auto a = any(gz::msgs::Any::BOOLEAN); a.set_bool_value(true);
+    m["filter_invert"] = a; }  // double key fed a bool  -> ReadDouble BOOLEAN
+  { auto a = any(gz::msgs::Any::DOUBLE);  a.set_double_value(128.0);
+    m["grid_size"] = a; }      // int key fed a double   -> ReadInt DOUBLE
+  { auto a = any(gz::msgs::Any::STRING);  a.set_string_value("x");
+    m["tau"] = a; }            // double key, non-numeric -> warn + skip
+  { auto a = any(gz::msgs::Any::STRING);  a.set_string_value("x");
+    m["seed"] = a; }           // int key, non-numeric    -> warn + skip
+  { auto a = any(gz::msgs::Any::DOUBLE);  a.set_double_value(1.0);
+    m["spectrum"] = a; }       // string key, non-string  -> warn + skip
+
+  gz::msgs::Boolean rep;
+  bool ok = false;
+  ASSERT_TRUE(node.Request(
+    "/world/test_world/wave/set_parameters", req, 5000, rep, ok));
+  EXPECT_TRUE(rep.data());  // period / filter_invert / grid_size were recognised
+  sys.PreUpdate(this->Info(1.0), this->ecm);
+
+  const auto &d = this->Comp()->Data().params;
+  EXPECT_DOUBLE_EQ(d.period, 7.0);     // int coerced to double
+  EXPECT_TRUE(d.filterInvert);         // bool coerced to double != 0
+  EXPECT_EQ(d.gridSize, 128u);         // double truncated to int
+}
+
+//////////////////////////////////////////////////
+TEST_F(WavesSystemTest, ConfigureAbortsWithoutWorldEntity)
+{
+  gz::sim::EntityComponentManager bareEcm;  // no world entity
+  gz::sim::EventManager bareEvm;
+  StubWavesSystem sys;
+  // worldEntity() returns kNullEntity -> Configure logs and returns early.
+  sys.Configure(gz::sim::kNullEntity,
+    this->Plugin("<update_rate>40</update_rate>"), bareEcm, bareEvm);
+  SUCCEED();  // the contract is: no crash, nothing created
+}
+
+//////////////////////////////////////////////////
+TEST_F(WavesSystemTest, ConfigureAbortsWhenEngineCreationFails)
+{
+  /// \brief A source system whose engine factory fails (returns nullptr).
+  class NullEngineSystem : public gz::sim::systems::WavesSystemBase
+  {
+    protected: std::string EngineToken() const override { return "null"; }
+    protected: std::shared_ptr<gsw::IWaveField> MakeEngine(
+      const gsw::WaveParameters &) const override { return nullptr; }
+  };
+  NullEngineSystem sys;
+  sys.Configure(this->world,
+    this->Plugin("<update_rate>40</update_rate>"), this->ecm, this->evm);
+  EXPECT_EQ(this->Comp(), nullptr);  // engine null -> no component written
+}
+
+//////////////////////////////////////////////////
+TEST_F(WavesSystemTest, PreUpdateBeforeConfigureIsNoop)
+{
+  StubWavesSystem sys;  // never Configured -> no engine
+  sys.PreUpdate(this->Info(1.0), this->ecm);  // early return on null engine
+  EXPECT_EQ(this->Comp(), nullptr);
+}


### PR DESCRIPTION
First of a series of patches that splits the wave-simulation work. This PR lands the engine-agnostic core that every later layer builds on.

## Summary

- **`IWaveField`** — the abstract wave-field interface (`Elevation`, `Normal`,  `ParticleVelocity`, `Jacobian`, `Update`, `SetParameters`, `Kind`).
- **Engine registry** — an in-process token→factory map (`CreateWaveSimulation`,  `RegisterWaveEngineFactory`); concrete engines register themselves from their own packages, so the core depends on none of them.
- **`WaveParameters`** — the shared input recipe.
- **`Wavefield` ECM component** (+ serialization) — the channel on the world entity carrying the recipe and the live `shared_ptr<IWaveField>`. Only the recipe is serialized; a replicated copy reconstructs its engine via the
  factory.
- **`Eval.hh` / `Eval.cc`** — the null-safe free-function query facade consumers use (falls back to still water when no engine is present). Bodies are out-of-line so 
- **`IWaveField` stays opaque to consumers**; includes a new `Advance()` helper so a consumer never has to deref the engine directly.
- **`WavesSystemBase`** — base class for the per-engine source plugins.

The core ships **only the contract** — no consumers. Buoyancy and the water visual live in their own packages `gz_waves_buoyancy`, `gz_waves_rendering`), each a downstream consumer of the wave field. 

